### PR TITLE
riot shotguns on the cargo console

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -477,6 +477,24 @@
 					/obj/item/storage/belt/bandolier)
 	crate_name = "combat shotguns crate"
 
+/datum/supply_pack/security/armory/riot_shotgun_single
+	name = "Riot Shotgun Single-Pack"
+	desc = "When you simply just want Butch to step aside. Requires Armory level access to open."
+	cost =  2500
+	contains = list(/obj/item/gun/ballistic/shotgun/riot,
+					/obj/item/storage/belt/bandolier)
+
+/datum/supply_pack/security/armory/riot_shotgun
+	name = "Riot Shotguns Crate"
+	desc = "For when the greytide gets out of hand. Contains 3 pump shotguns and shotgun ammo bandoliers to go with. Requires Armory level access to open."
+	cost = 6000
+	contains = list(/obj/item/gun/ballistic/shotgun/riot,
+					/obj/item/gun/ballistic/shotgun/riot,
+					/obj/item/gun/ballistic/shotgun/riot,
+					/obj/item/storage/belt/bandolier,
+					/obj/item/storage/belt/bandolier,
+					/obj/item/storage/belt/bandolier)
+
 /datum/supply_pack/security/armory/dragnet
 	name = "DRAGnet Crate"
 	desc = "Contains three \"Dynamic Rapid-Apprehension of the Guilty\" netting devices, a recent breakthrough in law enforcement prisoner management technology. Requires armory access to open."


### PR DESCRIPTION
## About The Pull Request

read title

adds the ability for the pump action shotgun to be purchased from cargo

this is pretty self explanatory 

## Why It's Good For The Game

1. in the words of Oshibka, "... a cheaper and more practicable alternative [to the rather expensive] combat shotguns. Helps with the problem of running out of shotguns during war ops since only 3 or 4 [sic] spawn in the armory roundstart."

2. the sound that the TG code shotguns make when you rack the pump is pretty coom

3. you can't saw down the combat shotgun, but you can saw down the riot shotgun, which makes it easier to conceal for whatever purpose you'd need for a shotgun to be concealed

4. cargo always likes more guns on the menu to be able to purchase

5. a whole lot of other minuscule gameplay differences that I probably couldn't list here

6. this is also basically just a port from bee station that i tweaked a bit https://github.com/BeeStation/BeeStation-Hornet/pull/616

## Changelog
:cl:
adds: The riot shotgun single-pack and riot shotguns crate to the cargo console, contains 1 riot shotgun + 1 bandoleer and 3 riot shotguns + 3 bandoleers respectively
tweaks: makes the riot shotgun crate $6,000 as compared to bee station's $6,500
tweaks: bundles the three bandoleers that didn't come with when Oshibka coded this originally
/:cl: