### PR TITLE
ALL HAIL TREKCHEM

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -20,9 +20,9 @@
 	var/list/available_chems
 	var/controls_inside = FALSE
 	var/list/possible_chems = list(
-		list(/datum/reagent/medicine/epinephrine, /datum/reagent/medicine/morphine, /datum/reagent/medicine/perfluorodecalin, /datum/reagent/medicine/sanguiose, /datum/reagent/medicine/frogenite),
+		list(/datum/reagent/medicine/epinephrine, /datum/reagent/medicine/morphine, /datum/reagent/medicine/dexalin, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/antitoxin, /datum/reagent/medicine/bicaridine),
 		list(/datum/reagent/medicine/oculine,/datum/reagent/medicine/inacusiate),
-		list(/datum/reagent/medicine/ferveatium, /datum/reagent/medicine/mutadone, /datum/reagent/medicine/mannitol, /datum/reagent/medicine/salbutamol, /datum/reagent/medicine/pen_acid),
+		list(/datum/reagent/medicine/mutadone, /datum/reagent/medicine/mannitol, /datum/reagent/medicine/salbutamol, /datum/reagent/medicine/pen_acid),
 		list(/datum/reagent/medicine/omnizine)
 	)
 	var/list/chem_buttons	//Used when emagged to scramble which chem is used, eg: antitoxin -> morphine

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1017,6 +1017,23 @@
 	..()
 	. = 1
 
+/datum/reagent/medicine/dexalinp
+	name = "Dexalin Plus"
+	description = "Restores oxygen loss. Overdose causes it instead. It is highly effective."
+	reagent_state = LIQUID
+	color = "#0040FF"
+	overdose_threshold = 25
+
+/datum/reagent/medicine/dexalinp/on_mob_life(mob/living/carbon/M)
+	M.adjustOxyLoss(-4*REM, 0)
+	..()
+	. = 1
+
+/datum/reagent/medicine/dexalinp/overdose_process(mob/living/M)
+	M.adjustOxyLoss(8*REM, 0)
+	..()
+	. = 1
+
 /datum/reagent/medicine/kelotane
 	name = "Kelotane"
 	description = "Restores fire damage. Overdose causes it instead."
@@ -1552,101 +1569,6 @@
 
 #undef PERF_BASE_DAMAGE
 
-//Injectables!
-//These are shitty chems
-
-/datum/reagent/medicine/sanguiose
-	name = "Sanguiose"
-	description = "A chemical developed to aid in the butchering proccess, it causes a chemical reaction which consumes blood and oxygen while healing cuts, bruises, and other similar injuries,"
-	reagent_state = LIQUID
-	color = "#FF6464"
-	metabolization_rate = 0.5* REAGENTS_METABOLISM
-	overdose_threshold = 25
-	taste_description = "salty"
-
-/datum/reagent/medicine/sanguiose/on_mob_life(mob/living/carbon/M)
-	M.adjustBruteLoss(-1, 0)
-	M.adjustOxyLoss(0.25,0)
-	M.blood_volume -= 1 //Removes blood
-	..()
-	. = 1
-
-/datum/reagent/medicine/sanguiose/overdose_process(mob/living/M)
-	M.adjustOxyLoss(3,0)
-	M.blood_volume -= 2 //I hope you like blood.
-	..()
-	. = 1
-
-/datum/reagent/medicine/sanguiose/on_transfer(atom/A, method=TOUCH, volume) // Borrowed from whoever made charcoal injection or pill only and modified so it doesn't add a reagent.
-	if(method == INJECT || !iscarbon(A)) //the atom not the charcoal
-		return
-	A.reagents.remove_reagent(type, volume)
-	..()
-
-/datum/reagent/medicine/frogenite
-	name = "Frogenite"
-	description = "An industrial cryostorage chemical previously used for preservation and storage. It removes oxygen from the body and heals to prevent and heal burns. If too much is injected the reaction will speed up dramatically removing all oxygen quickly."
-	reagent_state = LIQUID
-	color = "#00FFFF"
-	metabolization_rate = 0.5* REAGENTS_METABOLISM
-	overdose_threshold = 25
-	taste_description = "Oil"
-
-/datum/reagent/medicine/frogenite/on_mob_life(mob/living/carbon/M) //Reuses code done by cobby in Perflu to convert burn damage to oxygen, Meant to simunlate a chemical reaction to remove oxygen from the body.
-	var/firecalc = 1*REM*current_cycle
-	M.adjustFireLoss(-1, 0)
-	if (firecalc <10)
-		M.adjustOxyLoss(firecalc*0.15, 0)
-	if (firecalc >= 10)
-		M.adjustOxyLoss(1.5,0)
-	..()
-	. = 1
-
-/datum/reagent/medicine/frogenite/overdose_process(mob/living/M)
-	M.adjustOxyLoss(3,0)
-	M.reagents.remove_reagent(type, metabolization_rate*2) // Reused code from syndicate nanites meant to purge the chem quickly.
-	to_chat(M, "<span class='notice'>You feel like you aren't getting any oxygen!</span>")
-	..()
-	. = 1
-
-/datum/reagent/medicine/frogenite/on_transfer(atom/A, method=TOUCH, volume) // Borrowed from whoever made charcoal injection or pill only and modified so it doesn't add a reagent.
-	if(method == INJECT || !iscarbon(A)) //the atom not the charcoal
-		return
-	A.reagents.remove_reagent(type, volume)
-	..()
-
-/datum/reagent/medicine/ferveatium
-	name = "Ferveatium"
-	description = "A chemical previously used to cook questionable meat, it has come to enjoy a new life as a treatment for many poisons."
-	reagent_state = LIQUID
-	color = "#00FFFF"
-	metabolization_rate = 0.5* REAGENTS_METABOLISM
-	overdose_threshold = 25
-	taste_description = "Fire"
-
-/datum/reagent/medicine/ferveatium/on_mob_life(mob/living/carbon/M) //Reuses code done by cobby in Perflu to convert burn damage to oxygen, Meant to simunlate a chemical reaction to remove oxygen from the body.
-	var/toxcalc = 1*REM*current_cycle
-	M.adjustToxLoss(-1, 0)
-	if (toxcalc <10)
-		M.adjustFireLoss(toxcalc/10, 0)
-	if (toxcalc >= 10)
-		M.adjustFireLoss(1,0)
-	..()
-	. = 1
-
-/datum/reagent/medicine/ferveatium/overdose_process(mob/living/M)
-	M.adjustFireLoss(3,0)
-	M.reagents.remove_reagent(type, metabolization_rate*2) // Reused code from syndicate nanites meant to purge the chem quickly.
-	to_chat(M, "<span class='notice'>You feel like you are melting!</span>")
-	..()
-	. = 1
-
-/datum/reagent/medicine/ferveatium/on_transfer(atom/A, method=TOUCH, volume) // Borrowed from whoever made charcoal injection or pill only and modified so it doesn't add a reagent.
-	if(method == INJECT || !iscarbon(A)) //the atom not the charcoal
-		return
-	A.reagents.remove_reagent(type, volume)
-	..()
-
 /datum/reagent/medicine/silibinin
 	name = "Silibinin"
 	description = "A thistle derrived hepatoprotective flavolignan mixture that help reverse damage to the liver."
@@ -1690,3 +1612,50 @@
 	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, 0.5)
 	..()
 	. = 1
+
+/datum/reagent/medicine/carthatoline
+	name = "Carthatoline"
+	description = "Carthatoline is strong evacuant used to treat severe poisoning."
+	reagent_state = LIQUID
+	color = "#225722"
+
+/datum/reagent/medicine/carthatoline/on_mob_life(mob/living/carbon/M)
+	M.adjustToxLoss(-5*REM, 0)
+	if(M.getToxLoss() && prob(10))
+		M.vomit(1)
+	for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
+		M.reagents.remove_reagent(R.type,1)
+	..()
+	. = 1
+
+/datum/reagent/medicine/carthatoline/overdose_process(mob/living/M)
+	M.adjustToxLoss(10*REM, 0) // End result is 5 toxin loss taken, because it heals 5 and then removes 10.
+	..()
+	. = 1
+
+/datum/reagent/medicine/hepanephrodaxon
+	name = "Hepanephrodaxon"
+	description = "Used to repair the common tissues involved in filtration."
+	taste_description = "glue"
+	reagent_state = LIQUID
+	color = "#D2691E"
+	metabolization_rate = REM * 1.5
+	overdose_threshold = 10
+
+/datum/reagent/medicine/hepanephrodaxon/on_mob_life(var/mob/living/carbon/M)
+	var/repair_strength = 1
+	var/obj/item/organ/liver/L = M.getorganslot(ORGAN_SLOT_LIVER)
+	if(L.damage > 0)
+		L.damage = max(L.damage - 4 * repair_strength, 0)
+		M.confused = (2)
+	M.adjustToxLoss(-12)
+	..()
+	. = 1
+
+/datum/reagent/medicine/hepanephrodaxon/overdose_process(mob/living/M)
+	var/obj/item/organ/liver/L = M.getorganslot(ORGAN_SLOT_LIVER)
+	L.damage = max(L.damage + 4, 0)
+	M.confused = (2)
+	..()
+	. = 1
+

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -235,6 +235,19 @@
 	results = list(/datum/reagent/medicine/antitoxin = 3)
 	required_reagents = list(/datum/reagent/nitrogen = 1, /datum/reagent/silicon = 1, /datum/reagent/potassium = 1)
 
+/datum/chemical_reaction/dexalin
+	name = "Dexalin"
+	id = "dexalin"
+	results = list(/datum/reagent/medicine/dexalin = 5)
+	required_reagents = list(/datum/reagent/oxygen = 5)
+	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
+
+/datum/chemical_reaction/dexalinp
+	name = "Dexalin Plus"
+	id = "dexalinp"
+	results = list(/datum/reagent/medicine/dexalinp = 3)
+	required_reagents = list(/datum/reagent/medicine/dexalin = 1, /datum/reagent/carbon = 1, /datum/reagent/iron = 1)
+
 /datum/chemical_reaction/tricordrazine
 	name = "Tricordrazine"
 	id = /datum/reagent/medicine/tricordrazine
@@ -293,21 +306,16 @@
 	results = list(/datum/reagent/medicine/thializid = 5)
 	required_reagents = list(/datum/reagent/sulfur = 1, /datum/reagent/fluorine = 1, /datum/reagent/toxin = 1, /datum/reagent/nitrous_oxide = 2)
 
-/datum/chemical_reaction/sanguiose
-	name = "Sanguiose"
-	id = /datum/reagent/medicine/sanguiose
-	results = list(/datum/reagent/medicine/sanguiose= 4)
-	required_reagents = list(/datum/reagent/phosphorus = 1, /datum/reagent/hydrogen = 1,/datum/reagent/phenol=1, /datum/reagent/acetone=1,)
+/datum/chemical_reaction/carthatoline
+	name = "Carthatoline"
+	id = "carthatoline"
+	results = list(/datum/reagent/medicine/carthatoline = 3)
+	required_reagents = list(/datum/reagent/medicine/antitoxin = 1, /datum/reagent/carbon = 2)
+	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
 
-/datum/chemical_reaction/frogenite
-	name = "Frogenite"
-	id = /datum/reagent/medicine/frogenite
-	results = list(/datum/reagent/medicine/frogenite = 4)
-	required_reagents = list( /datum/reagent/lye = 1, /datum/reagent/hydrogen = 1,/datum/reagent/phenol=1, /datum/reagent/bromine=1,)
-
-/datum/chemical_reaction/ferveatium
-	name = "Ferveatium"
-	id = /datum/reagent/medicine/ferveatium
-	results = list(/datum/reagent/medicine/ferveatium = 4)
-	required_reagents = list( /datum/reagent/ammonia = 1, /datum/reagent/hydrogen = 1,/datum/reagent/phenol=1, /datum/reagent/toxin/acid=1,)
-
+/datum/chemical_reaction/hepanephrodaxon
+	name = "Hepanephrodaxon"
+	id = "hepanephrodaxon"
+	results = list(/datum/reagent/medicine/hepanephrodaxon = 5)
+	required_reagents = list(/datum/reagent/medicine/carthatoline = 2, /datum/reagent/carbon = 2, /datum/reagent/lithium = 1)
+	required_catalysts = list(/datum/reagent/toxin/plasma = 5)


### PR DESCRIPTION

## About The Pull Request
Deletes the ~~shitty~~ replacements that were added by the PR that removed trekchems. It also readds dexalin and dexalin+, as well as changes what  the sleepers dispense back to trekchems.

## Why It's Good For The Game
Fuck cobby. 

## Changelog
:cl:
add: Dexalin and Dex+ are back!
tweak: Sleepers now use trekchems instead of proto-cobbychems
del: Shitty trek replacement chems
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
