### PR TITLE
Reloading Eguns

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -213,7 +213,7 @@
 
 /obj/item/stock_parts/cell/secborg
 	name = "security borg rechargeable D battery"
-	maxcharge = 600	//600 max charge / 100 charge per shot = six shots
+	maxcharge = 6000	//6000 max charge / 1000 charge per shot = six shots
 	custom_materials = list(/datum/material/glass=40)
 
 /obj/item/stock_parts/cell/secborg/empty/Initialize()
@@ -223,16 +223,16 @@
 
 /obj/item/stock_parts/cell/pulse //200 pulse shots
 	name = "pulse rifle power cell"
-	maxcharge = 40000
+	maxcharge = 400000
 	chargerate = 1500
 
 /obj/item/stock_parts/cell/pulse/carbine //25 pulse shots
 	name = "pulse carbine power cell"
-	maxcharge = 5000
+	maxcharge = 50000
 
 /obj/item/stock_parts/cell/pulse/pistol //10 pulse shots
 	name = "pulse pistol power cell"
-	maxcharge = 2000
+	maxcharge = 20000
 
 /obj/item/stock_parts/cell/high
 	name = "high-capacity power cell"

--- a/code/modules/projectiles/ammunition/energy/_energy.dm
+++ b/code/modules/projectiles/ammunition/energy/_energy.dm
@@ -3,7 +3,7 @@
 	desc = "The part of the gun that makes the laser go pew."
 	caliber = "energy"
 	projectile_type = /obj/projectile/energy
-	var/e_cost = 100 //The amount of energy a cell needs to expend to create this shot.
+	var/e_cost = 1000 //The amount of energy a cell needs to expend to create this shot.
 	var/select_name = "energy"
 	fire_sound = 'sound/weapons/laser.ogg'
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -4,16 +4,16 @@
 
 /obj/item/ammo_casing/energy/lasergun
 	projectile_type = /obj/projectile/beam/laser
-	e_cost = 83
+	e_cost = 830
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/lasergun/old
 	projectile_type = /obj/projectile/beam/laser
-	e_cost = 200
+	e_cost = 2000
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/hos
-	e_cost = 120
+	e_cost = 1200
 
 /obj/item/ammo_casing/energy/laser/practice
 	projectile_type = /obj/projectile/beam/practice
@@ -39,7 +39,7 @@
 
 /obj/item/ammo_casing/energy/laser/pulse
 	projectile_type = /obj/projectile/beam/pulse
-	e_cost = 200
+	e_cost = 2000
 	select_name = "DESTROY"
 	fire_sound = 'sound/weapons/pulse.ogg'
 
@@ -61,7 +61,7 @@
 
 /obj/item/ammo_casing/energy/xray
 	projectile_type = /obj/projectile/beam/xray
-	e_cost = 50
+	e_cost = 500
 	fire_sound = 'sound/weapons/laser3.ogg'
 
 /obj/item/ammo_casing/energy/mindflayer

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -5,7 +5,7 @@
 
 /obj/item/ammo_casing/energy/ion/hos
 	projectile_type = /obj/projectile/ion/weak
-	e_cost = 300
+	e_cost = 3000
 
 /obj/item/ammo_casing/energy/declone
 	projectile_type = /obj/projectile/energy/declone
@@ -30,7 +30,7 @@
 /obj/item/ammo_casing/energy/temp
 	projectile_type = /obj/projectile/temp
 	select_name = "freeze"
-	e_cost = 250
+	e_cost = 2500
 	fire_sound = 'sound/weapons/pulse3.ogg'
 
 /obj/item/ammo_casing/energy/temp/hot
@@ -40,6 +40,7 @@
 /obj/item/ammo_casing/energy/meteor
 	projectile_type = /obj/projectile/meteor
 	select_name = "goddamn meteor"
+	e_cost = 100
 
 /obj/item/ammo_casing/energy/net
 	projectile_type = /obj/projectile/energy/net
@@ -66,11 +67,11 @@
 
 /obj/item/ammo_casing/energy/tesla_revolver
 	fire_sound = 'sound/magic/lightningbolt.ogg'
-	e_cost = 200
+	e_cost = 2000
 	select_name = "stun"
 	projectile_type = /obj/projectile/energy/tesla/revolver
 
 /obj/item/ammo_casing/energy/shrink
 	projectile_type = /obj/projectile/beam/shrink
 	select_name = "shrink ray"
-	e_cost = 200
+	e_cost = 2000

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -2,25 +2,25 @@
 	projectile_type = /obj/projectile/energy/electrode
 	select_name = "stun"
 	fire_sound = 'sound/weapons/taser.ogg'
-	e_cost = 200
+	e_cost = 2000
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/electrode/spec
-	e_cost = 100
+	e_cost = 1000
 
 /obj/item/ammo_casing/energy/electrode/gun
 	fire_sound = 'sound/weapons/gun/pistol/shot.ogg'
-	e_cost = 100
+	e_cost = 1000
 
 /obj/item/ammo_casing/energy/electrode/old
-	e_cost = 1000
+	e_cost = 10000
 
 /obj/item/ammo_casing/energy/disabler
 	projectile_type = /obj/projectile/beam/disabler
 	select_name  = "disable"
-	e_cost = 50
+	e_cost = 500
 	fire_sound = 'sound/weapons/taser2.ogg'
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/disabler/hos
-	e_cost = 60
+	e_cost = 600

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/guns/energy.dmi'
 
 	var/obj/item/stock_parts/cell/cell //What type of power cell this uses
-	var/cell_type = /obj/item/stock_parts/cell
+	var/cell_type = /obj/item/stock_parts/cell/high
 	var/modifystate = 0
 	var/list/ammo_type = list(/obj/item/ammo_casing/energy)
 	var/select = 1 //The state of the select fire switch. Determines from the ammo_type list what kind of shot is fired next.
@@ -20,6 +20,14 @@
 	var/charge_delay = 4
 	var/use_cyborg_cell = FALSE //whether the gun's cell drains the cyborg user's cell to recharge
 	var/dead_cell = FALSE //set to true so the gun is given an empty cell
+	var/internal_cell = FALSE //if the gun's cell cannot be replaced
+	var/small_gun = FALSE //if the gun is small and can only fit batteries that have less than a certain max charge
+	var/max_charge = 10000 //if the gun is small, this is the highest amount of charge can be in a battery for it
+
+	var/load_sound = 'sound/weapons/gun/general/magazine_insert_full.ogg' //Sound when inserting magazine. UPDATE PLEASE
+	var/eject_sound = 'sound/weapons/gun/general/magazine_remove_full.ogg' //Sound of ejecting a cell. UPDATE PLEASE
+	var/sound_volume = 40 //Volume of loading/unloading sounds
+	var/load_sound_vary = TRUE //Should the load/unload sounds vary?
 
 /obj/item/gun/energy/emp_act(severity)
 	. = ..()
@@ -83,6 +91,51 @@
 	if(ammo_type.len > 1)
 		select_fire(user)
 		update_icon()
+
+/obj/item/gun/energy/attackby(obj/item/A, mob/user, params)
+	. = ..()
+	if (.)
+		return
+	if (!internal_cell && istype(A, /obj/item/stock_parts/cell))
+		var/obj/item/stock_parts/cell/C = A
+		if (!cell)
+			insert_cell(user, C)
+		else
+			eject_cell(user, C)
+
+/obj/item/gun/energy/proc/insert_cell(mob/user, obj/item/stock_parts/cell/C)
+	if(small_gun && C.maxcharge > max_charge)
+		to_chat(user, "<span class='warning'>\The [C] doesn't seem to fit into \the [src]...</span>")
+		return FALSE
+	if(user.transferItemToLoc(C, src))
+		cell = C
+		to_chat(user, "<span class='notice'>You load the [C] into \the [src].</span>")
+		playsound(src, load_sound, sound_volume, load_sound_vary)
+		update_icon()
+		return TRUE
+	else
+		to_chat(user, "<span class='warning'>You cannot seem to get \the [src] out of your hands!</span>")
+		return FALSE
+
+/obj/item/gun/energy/proc/eject_cell(mob/user, obj/item/stock_parts/cell/tac_load = null)
+	playsound(src, load_sound, sound_volume, load_sound_vary)
+	cell.forceMove(drop_location())
+	var/obj/item/stock_parts/cell/old_cell = cell
+	if (insert_cell(user, tac_load))
+		to_chat(user, "<span class='notice'>You perform a tactical reload on \the [src].</span>")
+	else
+		to_chat(user, "<span class='warning'>You dropped the old cell, but the new one doesn't fit. How embarassing.</span>")
+		cell = null
+	user.put_in_hands(old_cell)
+	old_cell.update_icon()
+	to_chat(user, "<span class='notice'>You pull the cell out of \the [src].</span>")
+	update_icon()
+
+/obj/item/gun/energy/attack_hand(mob/user)
+	if(!internal_cell && loc == user && user.is_holding(src) && cell)
+		eject_cell(user)
+		return
+	return ..()
 
 /obj/item/gun/energy/can_shoot()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -17,7 +17,9 @@
 	icon_state = "mini"
 	item_state = "gun"
 	w_class = WEIGHT_CLASS_SMALL
-	cell_type = /obj/item/stock_parts/cell{charge = 600; maxcharge = 600}
+	cell_type = /obj/item/stock_parts/cell/high{charge = 6000; maxcharge = 6000}
+	small_gun = TRUE
+	max_charge = 6000
 	ammo_x_offset = 2
 	charge_sections = 3
 	can_flashlight = FALSE // Can't attach or detach the flashlight, and override it's icon update
@@ -52,7 +54,7 @@
 /obj/item/gun/energy/e_gun/hos
 	name = "\improper X-01 MultiPhase Energy Gun"
 	desc = "This is an expensive, modern recreation of an antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time."
-	cell_type = /obj/item/stock_parts/cell{charge = 1200; maxcharge = 1200}
+	cell_type = /obj/item/stock_parts/cell/high{charge = 12000; maxcharge = 12000}
 	icon_state = "hoslaser"
 	force = 10
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/ion/hos)
@@ -96,6 +98,7 @@
 	charge_delay = 5
 	pin = null
 	can_charge = FALSE
+	internal_cell = TRUE
 	ammo_x_offset = 1
 	ammo_type = list(/obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/disabler)
 	selfcharge = 1

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -15,6 +15,7 @@
 	can_bayonet = TRUE
 	knife_x_offset = 20
 	knife_y_offset = 12
+	internal_cell = TRUE //prevents you from giving it an OP cell
 	var/overheat_time = 16
 	var/holds_charge = FALSE
 	var/unique_frequency = FALSE // modified by KA modkits

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -133,6 +133,7 @@
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
 	tool_behaviour = TOOL_WELDER
 	toolspeed = 0.7 //plasmacutters can be used as welders, and are faster than standard welders
+	internal_cell = TRUE //so you don't cheese through the need for plasma
 	var/progress_flash_divisor = 10  //copypasta is best pasta
 	var/light_intensity = 1
 	var/charge_weld = 25 //amount of charge used up to start action (multiplied by amount) and per progress_flash_divisor ticks of welding


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the ability to switch out power cells in energy weapons, similar to ballistic weapons with  magazines. This code could be improved, but I'm satisfied with it as it is now.

## Why It's Good For The Game
No longer will you need to carry around 20 eguns, only to carry 19 batteries.

## Changelog
:cl:
add: ability to swap out cells in eguns
tweak: all projectile costs x100 and eguns now use highcap cells.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
