### PR TITLE
Clown PDA slipstun

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -9,7 +9,7 @@
 
 /obj/item/pda/clown/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 120, NO_SLIP_WHEN_WALKING, CALLBACK(src, .proc/AfterSlip))
+	AddComponent(/datum/component/slippery, 7SECONDS, NO_SLIP_WHEN_WALKING, CALLBACK(src, .proc/AfterSlip), 7SECONDS)
 
 /obj/item/pda/clown/proc/AfterSlip(mob/living/carbon/human/M)
 	if (istype(M) && (M.real_name != owner))

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -9,7 +9,7 @@
 
 /obj/item/pda/clown/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 7SECONDS, NO_SLIP_WHEN_WALKING, CALLBACK(src, .proc/AfterSlip), 7SECONDS)
+	AddComponent(/datum/component/slippery, 5SECONDS, NO_SLIP_WHEN_WALKING, CALLBACK(src, .proc/AfterSlip), 5SECONDS)
 
 /obj/item/pda/clown/proc/AfterSlip(mob/living/carbon/human/M)
 	if (istype(M) && (M.real_name != owner))


### PR DESCRIPTION
## About The Pull Request

Adds 5 second clown PDA slipstun from bee.
Original from: [tgstation/tgstation#42491](https://github.com/tgstation/tgstation/pull/42491)
I've compiled and tested it myself, but this is my first pr, so you should probably test it too.

Edit: Now only stuns for 5 seconds

## Why It's Good For The Game

Gives clowns an opportunity to steal shoes/perform other clown shenanigans after slipping people with their PDA.

## Changelog
:cl:
tweak: Added 5 second clown PDA slipstun
/:cl: