### PR TITLE
Job Titles on Radio Messages

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -70,7 +70,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	return ""
 
 /atom/movable/proc/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
-	return ""
+	var/speakerJob = speaker.GetJob()
+	return "[ speakerJob ? " (" +  speakerJob + ")" : ""]"
 
 /atom/movable/proc/say_mod(input, message_mode)
 	var/ending = copytext(input, length(input))

--- a/code/modules/mob/say_readme.md
+++ b/code/modules/mob/say_readme.md
@@ -92,7 +92,7 @@ global procs
 		Composes the href tags used by the AI for tracking. Returns "" for all mobs except AIs.
 
 	compose_job(message, atom/movable/speaker, message_langs, raw_message, radio_freq)
-		Composes the job and the end tag for tracking hrefs. Returns "" for all mobs except AIs.
+		Composes the job and the end tag for tracking hrefs. Returns the job title string.
 
 	hivecheck()
 		Returns 1 if the mob can hear and talk in the alien hivemind.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Radio messages now show the speaker's job after their name (Ex. `[Common] John Doe (Assistant) says, "Test."`) ~~Stolen~~ Ported from a closed PR on Oracle.

## Why It's Good For The Game
Allows you to see the jobs of who you're talking to over radio. I think it's a good addition.

## Changelog
:cl:
add: Radio messages now show the speaker's job after their name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
