### PR TITLE
Locker lock creation/removal

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -37,11 +37,15 @@
 	var/delivery_icon = "deliverycloset" //which icon to use when packagewrapped. null to be unwrappable.
 	var/anchorable = TRUE
 	var/icon_welded = "welded"
-
+	var/obj/item/electronics/airlock/lockerelectronics //Installed electronics
+	var/lock_in_use = FALSE //Someone is doing some stuff with the lock here, better not proceed further
 
 /obj/structure/closet/Initialize(mapload)
 	if(mapload && !opened)		// if closed, any item at the crate's loc is put in the contents
 		addtimer(CALLBACK(src, .proc/take_contents), 0)
+	if(secure)
+		lockerelectronics = new(src)
+		lockerelectronics.accesses = req_access
 	. = ..()
 	update_icon()
 	PopulateContents()
@@ -51,31 +55,32 @@
 	return
 
 /obj/structure/closet/Destroy()
-	dump_contents()
+	dump_contents(override = FALSE)
 	return ..()
 
 /obj/structure/closet/update_icon()
 	cut_overlays()
-	if(!opened)
-		layer = OBJ_LAYER
-		if(icon_door)
-			add_overlay("[icon_door]_door")
-		else
-			add_overlay("[icon_state]_door")
-		if(welded)
-			add_overlay(icon_welded)
-		if(secure && !broken)
-			if(locked)
-				add_overlay("locked")
-			else
-				add_overlay("unlocked")
-
+	if(opened & icon_door_override)
+		add_overlay("[icon_door]_open")
+		return
+	else if(opened)
+		add_overlay("[icon_state]_open")
+		return
+	if(icon_door)
+		add_overlay("[icon_door]_door")
 	else
-		layer = BELOW_OBJ_LAYER
-		if(icon_door_override)
-			add_overlay("[icon_door]_open")
-		else
-			add_overlay("[icon_state]_open")
+		add_overlay("[icon_state]_door")
+	if(welded)
+		add_overlay("welded")
+	if(!secure)
+		return
+	if(broken)
+		add_overlay("off")
+		add_overlay("sparking")
+	else if(locked)
+		add_overlay("locked")
+	else
+		add_overlay("unlocked")
 
 /obj/structure/closet/examine(mob/user)
 	. = ..()
@@ -85,6 +90,8 @@
 		. += "<span class='notice'>It is <b>bolted</b> to the ground.</span>"
 	if(opened)
 		. += "<span class='notice'>The parts are <b>welded</b> together.</span>"
+	else if(broken)
+		to_chat(user, "<span class='notice'>The lock is <b>screwed</b> in.</span>")
 	else if(secure && !opened)
 		. += "<span class='notice'>Alt-click to [locked ? "unlock" : "lock"].</span>"
 	if(isliving(user))
@@ -120,9 +127,26 @@
 			return FALSE
 	return TRUE
 
-/obj/structure/closet/dump_contents()
+/obj/structure/closet/proc/can_lock(mob/living/user, var/check_access = TRUE) //set check_access to FALSE if you only need to check if a locker has a functional lock rather than access
+	if(!secure)
+		return FALSE
+	if(broken)
+		to_chat(user, "<span class='notice'>[src] is broken!</span>")
+		return FALSE
+	if(QDELETED(lockerelectronics) && !locked) //We want to be able to unlock it regardless of electronics, but only lockable with electronics
+		to_chat(user, "<span class='notice'>[src] is missing locker electronics!</span>")
+		return FALSE
+	if(!check_access)
+		return TRUE
+	if(allowed(user))
+		return TRUE
+	to_chat(user, "<span class='notice'>Access denied.</span>")
+
+/obj/structure/closet/dump_contents(var/override = TRUE) //Override is for not revealing the locker electronics when you open the locker, for example
 	var/atom/L = drop_location()
 	for(var/atom/movable/AM in src)
+		if(AM == lockerelectronics && override)
+			continue
 		AM.forceMove(L)
 		if(throwing) // you keep some momentum when getting out of a thrown closet
 			step(AM, dir)
@@ -145,7 +169,7 @@
 	climb_time *= 0.5 //it's faster to climb onto an open thing
 	dump_contents()
 	update_icon()
-	return 1
+	return TRUE
 
 /obj/structure/closet/proc/insert(atom/movable/AM)
 	if(contents.len >= storage_capacity)
@@ -188,6 +212,8 @@
 
 	return TRUE
 
+	return TRUE
+
 /obj/structure/closet/proc/close(mob/living/user)
 	if(!opened || !can_close(user))
 		return FALSE
@@ -204,6 +230,72 @@
 		return close(user)
 	else
 		return open(user)
+
+/obj/structure/closet/proc/bust_open()
+	welded = FALSE //applies to all lockers
+	locked = FALSE //applies to critter crates and secure lockers only
+	broken = TRUE //applies to secure lockers only
+	open()
+
+/obj/structure/closet/proc/handle_lock_addition(mob/user, obj/item/electronics/airlock/E)
+	add_fingerprint(user)
+	if(lock_in_use)
+		to_chat(user, "<span class='notice'>Wait for work on [src] to be done first!</span>")
+		return
+	if(secure)
+		to_chat(user, "<span class='notice'>This locker already has a lock!</span>")
+		return
+	if(broken)
+		to_chat(user, "<span class='notice'><b>Unscrew</b> the broken lock first!</span>")
+		return
+	if(!istype(E))
+		return
+	user.visible_message("<span class='notice'>[user] begins installing a lock on [src]...</span>","<span class='notice'>You begin installing a lock on [src]...</span>")
+	lock_in_use = TRUE
+	playsound(loc, 'sound/items/screwdriver.ogg', 50, 1)
+	if(!do_after(user, 200, target = src))
+		lock_in_use = FALSE
+		return
+	lock_in_use = FALSE
+	to_chat(user, "<span class='notice'>You finish the lock on [src]!</span>")
+	E.forceMove(src)
+	lockerelectronics = E
+	req_access = E.accesses
+	secure = TRUE
+	update_icon()
+	return TRUE
+
+/obj/structure/closet/proc/handle_lock_removal(mob/user, obj/item/screwdriver/S)
+	if(lock_in_use)
+		to_chat(user, "<span class='notice'>Wait for work on [src] to be done first!</span>")
+		return
+	if(locked)
+		to_chat(user, "<span class='notice'>Unlock it first!</span>")
+		return
+	if(!secure)
+		to_chat(user, "<span class='notice'>[src] doesn't have a lock that you can remove!</span>")
+		return
+	if(!istype(S))
+		return
+	var/brokenword = broken ? "broken " : null
+	user.visible_message("<span class='notice'>You begin removing the [brokenword]lock on [src]...</span>", "<span class='notice'>[user] begins removing the [brokenword]lock on [src]...</span>")
+	playsound(loc, S.usesound, 50, 1)
+	lock_in_use = TRUE
+	if(!do_after(user, 100 * S.toolspeed, target = src))
+		lock_in_use = FALSE
+		return
+	to_chat(user, "<span class='notice'>You remove the [brokenword]lock from [src]!</span>")
+	if(!QDELETED(lockerelectronics))
+		lockerelectronics.add_fingerprint(user)
+		lockerelectronics.forceMove(user.loc)
+	lockerelectronics = null
+	req_access = null
+	secure = FALSE
+	broken = FALSE
+	locked = FALSE
+	lock_in_use = FALSE
+	update_icon()
+	return TRUE
 
 /obj/structure/closet/deconstruct(disassembled = TRUE)
 	if(ispath(material_drop) && material_drop_amount && !(flags_1 & NODECONSTRUCT_1))
@@ -246,6 +338,10 @@
 				return
 		if(user.transferItemToLoc(W, drop_location())) // so we put in unlit welder too
 			return
+	else if(istype(W, /obj/item/electronics/airlock))
+		handle_lock_addition(user, W)
+	else if(istype(W, /obj/item/screwdriver))
+		handle_lock_removal(user, W)
 	else if(W.tool_behaviour == TOOL_WELDER && can_weld_shut)
 		if(!W.tool_start_check(user, amount=0))
 			return
@@ -274,6 +370,7 @@
 			return FALSE
 		if(item_is_id || !toggle(user))
 			togglelock(user)
+		return TRUE
 	else
 		return FALSE
 
@@ -317,7 +414,7 @@
 			close()
 	else
 		O.forceMove(T)
-	return 1
+	return TRUE
 
 /obj/structure/closet/relaymove(mob/user)
 	if(user.stat || !isturf(loc) || !isliving(user))
@@ -369,8 +466,8 @@
 /obj/structure/closet/Exit(atom/movable/AM)
 	open()
 	if(AM.loc == src)
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /obj/structure/closet/container_resist(mob/living/user)
 	if(opened)
@@ -402,20 +499,11 @@
 		if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
 			to_chat(user, "<span class='warning'>You fail to break out of [src]!</span>")
 
-/obj/structure/closet/proc/bust_open()
-	welded = FALSE //applies to all lockers
-	locked = FALSE //applies to critter crates and secure lockers only
-	broken = TRUE //applies to secure lockers only
-	open()
-
 /obj/structure/closet/AltClick(mob/user)
 	..()
 	if(!user.canUseTopic(src, BE_CLOSE) || !isturf(loc))
 		return
-	if(opened || !secure)
-		return
-	else
-		togglelock(user)
+	togglelock(user)
 
 /obj/structure/closet/CtrlShiftClick(mob/living/user)
 	if(!HAS_TRAIT(user, TRAIT_SKITTISH))
@@ -447,6 +535,9 @@
 		playsound(src, "sparks", 50, TRUE)
 		broken = TRUE
 		locked = FALSE
+		if(!QDELETED(lockerelectronics))
+			qdel(lockerelectronics)
+		lockerelectronics = null
 		update_icon()
 
 /obj/structure/closet/get_remote_view_fullscreens(mob/user)

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -65,6 +65,12 @@
 		density = FALSE
 		mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 
+/obj/structure/closet/body_bag/handle_lock_addition()
+	return
+
+/obj/structure/closet/body_bag/handle_lock_removal()
+	return
+
 /obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
 	. = ..()
 	if(over_object == usr && Adjacent(usr) && (in_range(src, usr) || usr.contents.Find(src)))

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -55,6 +55,12 @@
 				L.do_alert_animation(L)
 		playsound(loc, 'sound/machines/chime.ogg', 50, FALSE, -5)
 
+/obj/structure/closet/cardboard/handle_lock_addition() //Whoever heard of a lockable cardboard box anyway
+	return
+
+/obj/structure/closet/cardboard/handle_lock_removal()
+	return
+
 /mob/living/proc/do_alert_animation(atom/A)
 	var/image/I = image('goon/icons/obj/closet.dmi', A, "cardboard_special", A.layer+1)
 	flick_overlay_view(I, A, 8)

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -111,6 +111,12 @@
 	new /obj/item/storage/fancy/candle_box(src)
 	return
 
+/obj/structure/closet/coffin/handle_lock_addition()
+	return
+
+/obj/structure/closet/coffin/handle_lock_removal()
+	return
+
 /obj/structure/closet/wardrobe/red
 	name = "security wardrobe"
 	icon_door = "red"

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -4,6 +4,18 @@
 	req_access = list(ACCESS_ALL_PERSONAL_LOCKERS)
 	var/registered_name = null
 
+/obj/structure/closet/secure_closet/personal/examine(mob/user)
+	..()
+	if(registered_name)
+		to_chat(user, "<span class='notice'>The display reads, \"Owned by [registered_name]\".</span>")
+
+/obj/structure/closet/secure_closet/personal/check_access(obj/item/card/id/I)
+	. = ..()
+	if(!I || !istype(I))
+		return
+	if(registered_name == I.registered_name)
+		return TRUE
+
 /obj/structure/closet/secure_closet/personal/PopulateContents()
 	..()
 	if(prob(40))
@@ -20,8 +32,8 @@
 	name = "patient's closet"
 
 /obj/structure/closet/secure_closet/personal/patient/PopulateContents()
-	new /obj/item/clothing/under/color/white( src )
-	new /obj/item/clothing/shoes/sneakers/white( src )
+	new /obj/item/clothing/under/color/white(src)
+	new /obj/item/clothing/shoes/sneakers/white(src)
 
 /obj/structure/closet/secure_closet/personal/cabinet
 	icon_state = "cabinet"
@@ -39,21 +51,21 @@
 
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/W, mob/user, params)
 	var/obj/item/card/id/I = W.GetID()
-	if(istype(I))
-		if(broken)
-			to_chat(user, "<span class='danger'>It appears to be broken.</span>")
-			return
-		if(!I || !I.registered_name)
-			return
-		if(allowed(user) || !registered_name || (istype(I) && (registered_name == I.registered_name)))
-			//they can open all lockers, or nobody owns this, or they own this locker
-			locked = !locked
-			update_icon()
-
-			if(!registered_name)
-				registered_name = I.registered_name
-				desc = "Owned by [I.registered_name]."
-		else
-			to_chat(user, "<span class='danger'>Access Denied.</span>")
-	else
+	if(!I || !istype(I))
 		return ..()
+	if(!can_lock(user, FALSE)) //Can't do anything if there isn't a lock!
+		return
+	if(I.registered_name && !registered_name)
+		to_chat(user, "<span class='notice'>You claim [src].</span>")
+		registered_name = I.registered_name
+	else
+		..()
+
+/obj/structure/closet/secure_closet/personal/handle_lock_addition() //If lock construction is successful we don't care what access the electronics had, so we override it
+	if(..())
+		req_access = list(ACCESS_ALL_PERSONAL_LOCKERS)
+		lockerelectronics.accesses = req_access
+
+/obj/structure/closet/secure_closet/personal/handle_lock_removal()
+	if(..())
+		registered_name = null

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -59,6 +59,12 @@
 		manifest = null
 		update_icon()
 
+/obj/structure/closet/crate/handle_lock_addition()
+	return
+
+/obj/structure/closet/crate/handle_lock_removal()
+	return
+
 /obj/structure/closet/crate/proc/tear_manifest(mob/user)
 	to_chat(user, "<span class='notice'>You tear the manifest off of [src].</span>")
 	playsound(src, 'sound/items/poster_ripped.ogg', 75, TRUE)
@@ -81,6 +87,13 @@
 	close_sound = 'sound/machines/wooden_closet_close.ogg'
 	open_sound_volume = 25
 	close_sound_volume = 50
+
+/obj/structure/closet/coffin/handle_lock_addition() 
+	return 
+ 
+/obj/structure/closet/coffin/handle_lock_removal() 
+	return 
+ 
 
 /obj/structure/closet/crate/internals
 	desc = "An internals crate."

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -785,6 +785,13 @@ Difficulty: Very Hard
 /obj/structure/closet/stasis/ex_act()
 	return
 
+
+/obj/structure/closet/stasis/handle_lock_addition()
+	return
+
+/obj/structure/closet/stasis/handle_lock_removal()
+	return
+
 /obj/effect/proc_holder/spell/targeted/exit_possession
 	name = "Exit Possession"
 	desc = "Exits the body you are possessing."

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -766,7 +766,7 @@ Difficulty: Very Hard
 		holder_animal.mind.AddSpell(P)
 		holder_animal.verbs -= /mob/living/verb/pulled
 
-/obj/structure/closet/stasis/dump_contents(var/kill = 1)
+/obj/structure/closet/stasis/dump_contents(TRUE, var/kill = 1)
 	STOP_PROCESSING(SSobj, src)
 	for(var/mob/living/L in src)
 		REMOVE_TRAIT(L, TRAIT_MUTE, STASIS_MUTE)
@@ -813,7 +813,7 @@ Difficulty: Very Hard
 	for(var/i in user)
 		if(istype(i, /obj/structure/closet/stasis))
 			var/obj/structure/closet/stasis/S = i
-			S.dump_contents(0)
+			S.dump_contents(TRUE, 0)
 			qdel(S)
 			break
 	user.gib()


### PR DESCRIPTION
## About The Pull Request
Near-direct port of OracleStation/OracleStation#994

This PR adds the ability to construct and deconstruct locker locks.

* Use an airlock electronics on a locker without a lock to add one. The locker will inherit the access from the electronics. You can't lock certain lockers such as cardboard boxes.
* Screwdriver a locker to remove its lock. This will give you back the electronics (emagging destroys the electronics). You can only do this to unlocked lockers.

To create a locker lock:

1.  Make sure your locker doesn't have a lock and is closed.
1.  Hit the locker with airlock electronics.
1.  Wait for construction to complete (20 seconds). The locker's access will be updated with the airlock electronics access.

To deconstruct a locker lock:

1.  The locker must be unlocked and closed, and must have either a functional or broken lock.
1.  Use a screwdriver on the locker.
1.  After 10 seconds (better screwdrivers will be faster), the lock will be removed and the airlock electronics (should they exist) will be dropped at your feet.

Emagged/broken locks now show a sparking effect, to differentiate between lockers with no lock and lockers with a broken lock that can be removed.

## Why It's Good For The Game
Allows you to create and remove locks to lockers, as well as replace broken ones.

## Changelog
:cl:
add: You can now use an airlock electronics on a locker to add a lock, and can screwdriver an unlocked locker to remove its lock.
add: You can now remove the locks on broken or emagged lockers.
tweak: Removing the lock from a personal locker now wipes that locker's ID details.
tweak: Broken lockers have had their appearance changed.
/:cl: