### PR TITLE
Turns holsters into accessories as they should be.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -1179,7 +1179,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/structure/closet/crate/secure/gear,
 /obj/item/storage/belt/bandolier,
-/obj/item/storage/belt/holster,
+/obj/item/clothing/accessory/holster,
 /turf/open/floor/plasteel/airless/dark,
 /area/shuttle/caravan/freighter2)
 "jZ" = (

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -95,6 +95,30 @@
 	// if the component is reparented to a jumpsuit, the items still go in the protector
 	return original_parent
 
+/datum/component/storage/concrete/pockets/holster
+	max_items = 3
+	max_w_class = WEIGHT_CLASS_NORMAL
+	var/atom/original_parent
+
+/datum/component/storage/concrete/pockets/holster/Initialize()
+	original_parent = parent
+	. = ..()
+	can_hold = typecacheof(list(
+		/obj/item/gun/ballistic/automatic/pistol,
+		/obj/item/gun/ballistic/revolver,
+		/obj/item/ammo_box))
+
+/datum/component/storage/concrete/pockets/holster/real_location()
+	// if the component is reparented to a jumpsuit, the items still go in the protector
+	return original_parent
+
+/datum/component/storage/concrete/pockets/holster/detective/Initialize()
+	original_parent = parent
+	. = ..()
+	can_hold = typecacheof(list(
+		/obj/item/gun/ballistic/revolver/detective,
+		/obj/item/ammo_box/c38))
+
 /datum/component/storage/concrete/pockets/helmet
 	quickdraw = TRUE
 	max_combined_w_class = 6

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -549,31 +549,6 @@
 		/obj/item/ammo_casing/shotgun
 		))
 
-/obj/item/storage/belt/holster
-	name = "shoulder holster"
-	desc = "A holster to carry a handgun and ammo. WARNING: Badasses only."
-	icon_state = "holster"
-	item_state = "holster"
-	alternate_worn_layer = UNDER_SUIT_LAYER
-
-/obj/item/storage/belt/holster/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 3
-	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.set_holdable(list(
-		/obj/item/gun/ballistic/automatic/pistol,
-		/obj/item/gun/ballistic/revolver,
-		/obj/item/ammo_box,
-		/obj/item/gun/energy/e_gun/mini
-		))
-
-/obj/item/storage/belt/holster/full/PopulateContents()
-	var/static/items_inside = list(
-		/obj/item/gun/ballistic/revolver/detective = 1,
-		/obj/item/ammo_box/c38 = 2)
-	generate_items_inside(items_inside,src)
-
 /obj/item/storage/belt/fannypack
 	name = "fannypack"
 	desc = "A dorky fannypack for keeping small items in."

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -228,7 +228,7 @@
 	new /obj/item/holosign_creator/security(src)
 	new /obj/item/reagent_containers/spray/pepper(src)
 	new /obj/item/clothing/suit/armor/vest/det_suit(src)
-	new /obj/item/storage/belt/holster/full(src)
+	new /obj/item/clothing/accessory/holster/detective(src)
 	new /obj/item/pinpointer/crew(src)
 	new /obj/item/twohanded/binoculars(src)
 	new /obj/item/storage/box/rxglasses/spyglasskit(src)

--- a/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_items/misc.dm
@@ -14,7 +14,7 @@
 /datum/blackmarket_item/misc/shoulder_holster
 	name = "Shoulder holster"
 	desc = "Yeehaw, hardboiled friends! This holster is the first step in your dream of becoming a detective and being allowed to shoot real guns!"
-	item = /obj/item/storage/belt/holster
+	item = /obj/item/clothing/accessory/holster
 
 	price_min = 400
 	price_max = 800

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -181,7 +181,7 @@ BLIND     // can't see anything
 	female_clothing_icon 			= fcopy_rsc(female_clothing_icon)
 	GLOB.female_clothing_icons[index] = female_clothing_icon
 
-/obj/item/clothing/under/verb/toggle(
+/obj/item/clothing/under/verb/toggle()
 	set name = "Adjust Suit Sensors"
 	set category = "Object"
 	set src in usr

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -181,7 +181,7 @@ BLIND     // can't see anything
 	female_clothing_icon 			= fcopy_rsc(female_clothing_icon)
 	GLOB.female_clothing_icons[index] = female_clothing_icon
 
-/obj/item/clothing/under/verb/toggle()
+/obj/item/clothing/under/verb/toggle(
 	set name = "Adjust Suit Sensors"
 	set category = "Object"
 	set src in usr
@@ -222,8 +222,6 @@ BLIND     // can't see anything
 		var/mob/living/carbon/human/H = loc
 		if(H.w_uniform == src)
 			H.update_suit_sensors()
-
-	..()
 
 /obj/item/clothing/under/attack_hand(mob/user)
 	if(attached_accessory && ispath(attached_accessory.pocket_storage_component_path) && loc == user)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -38,7 +38,6 @@
 	var/dynamic_fhair_suffix = ""//mask > head for facial hair
 
 
-
 /obj/item/clothing/Initialize()
 	if(CHECK_BITFIELD(clothing_flags, VOICEBOX_TOGGLABLE))
 		actions_types += /datum/action/item_action/toggle_voice_box
@@ -223,6 +222,14 @@ BLIND     // can't see anything
 		var/mob/living/carbon/human/H = loc
 		if(H.w_uniform == src)
 			H.update_suit_sensors()
+
+	..()
+
+/obj/item/clothing/under/attack_hand(mob/user)
+	if(attached_accessory && ispath(attached_accessory.pocket_storage_component_path) && loc == user)
+		attached_accessory.attack_hand(user)
+		return
+	..()
 
 /obj/item/clothing/under/AltClick(mob/user)
 	if(..())

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -373,6 +373,23 @@
 	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 20, "bio" = 20, "rad" = 5, "fire" = 0, "acid" = 25)
 	attachment_slot = GROIN
 
+/obj/item/clothing/accessory/holster
+	name = "shoulder holster"
+	desc = "A holster to carry a handgun and ammo. WARNING: Badasses only."
+	icon_state = "holster"
+	item_state = "holster"
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/holster
+
+/obj/item/clothing/accessory/holster/detective
+	name = "detective's shoulder holster"
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/holster/detective
+
+/obj/item/clothing/accessory/holster/detective/Initialize()
+	. = ..()
+	new /obj/item/gun/ballistic/revolver/detective(src)
+	new /obj/item/ammo_box/c38(src)
+	new /obj/item/ammo_box/c38(src)
+
 /obj/item/clothing/accessory/skilt
 	name = "Sinew Skirt"
 	desc = "For the last time. IT'S A KILT not a skirt."

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -151,7 +151,7 @@
 	id = "s_holster"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 400)
-	build_path = /obj/item/storage/belt/holster
+	build_path = /obj/item/clothing/accessory/holster
 	category = list("initial","Organic Materials")
 
 /datum/design/rice_hat

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1609,7 +1609,6 @@
 #include "code\modules\client\preferences_savefile.dm"
 #include "code\modules\client\preferences_toggles.dm"
 #include "code\modules\client\verbs\etips.dm"
-#include "code\modules\client\verbs\looc.dm"
 #include "code\modules\client\verbs\ooc.dm"
 #include "code\modules\client\verbs\ping.dm"
 #include "code\modules\client\verbs\suicide.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Port of OracleStation/OracleStation#527.

## Why It's Good For The Game
Why are shoulder holsters called shoulder holsters? Well, obviously because they're worn around the shoulder. But then why are they equipped in the belt slot? No idea.

## Changelog
:cl:
tweak: Shoulder holsters are now an accessory, not a belt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
