### PR TITLE
Fixed squid language issues

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -288,6 +288,12 @@ Key procs
 								/datum/language/slime = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/slime = list(LANGUAGE_ATOM))
 
+/datum/language_holder/squid
+	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+								/datum/language/rylethian = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+							/datum/language/rylethian = list(LANGUAGE_ATOM))
+
 /datum/language_holder/swarmer
 	understood_languages = list(/datum/language/swarmer = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/swarmer = list(LANGUAGE_ATOM))

--- a/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
@@ -20,16 +20,14 @@
 	liked_food = VEGETABLES | MEAT
 	toxic_food = FRIED
 	mutanttongue = /obj/item/organ/tongue/squid
+	species_language_holder = /datum/language_holder/squid
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/squid
 	exotic_bloodtype = "S"
 	no_equip = list(ITEM_SLOT_FEET)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	loreblurb = "A race of squid-like amphibians with an odd appearance. \
 	They posses the ability to change their pigmentation at will, often leading to confusion. \
-	Nanotrasen ensures that the Yaggoli do not eat human grey matter, and such reports will be discarded."
-
-/datum/species/lizard/after_equip_job(datum/job/J, mob/living/carbon/human/H)
-	H.grant_language(/datum/language/rylethian)
+	Nanotrasen ensures that the squid people do not eat human grey matter, and such reports will be discarded."
 
 /datum/species/squid/random_name(gender,unique,lastname)
 	if(unique)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Squidpeople can now speak rylethian, as the old ones intended.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is how its supposed to work
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Squidpeople can now actually speak rylethian
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
