### PR TITLE
Wikilink and Custom notice on joining

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -468,10 +468,15 @@ SUBSYSTEM_DEF(job)
 			else
 				handle_auto_deadmin_roles(M.client, rank)
 
+		to_chat(M, "<b>You are the [rank].</b>")
 		to_chat(M, "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
 		job.radio_help_message(M)
 		if(job.req_admin_notify)
 			to_chat(M, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")
+		if(job.special_notice)
+			to_chat(M, "<span class='userdanger'>[job.special_notice]</span>")
+		if(job.wiki_page)
+			to_chat(M, "<span class='notice'><a href=[CONFIG_GET(string/wikiurl)]/[job.wiki_page]>Wiki Page</a></span>")
 		if(CONFIG_GET(number/minimal_access_threshold))
 			to_chat(M, "<span class='notice'><B>As this station was initially staffed with a [CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B></span>")
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -49,6 +49,12 @@
 	var/exp_type = ""
 	var/exp_type_department = ""
 
+	//A special, very large and noticeable message for certain roles reminding them of something important. Ex: "Blueshields are not security"
+	var/special_notice = ""
+
+	// A link to the relevant wiki related to the job. Ex: "Space_law" would link to wiki.blah/Space_law
+	var/wiki_page = ""
+
 	//The amount of good boy points playing this role will earn you towards a higher chance to roll antagonist next round
 	//can be overridden by antag_rep.txt config
 	var/antag_rep = 10

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -15,6 +15,8 @@
 	exp_type_department = EXP_TYPE_SILICON
 	display_order = JOB_DISPLAY_ORDER_AI
 	var/do_special_check = TRUE
+	wiki_page = "AI"
+	special_notice = "Your laws take precedence over everything, including space law and past objectives. Do NOT break them."
 
 /datum/job/ai/equip(mob/living/carbon/human/H, visualsOnly, announce, latejoin, datum/outfit/outfit_override, client/preference_source = null)
 	if(visualsOnly)

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -17,6 +17,7 @@ Assistant
 	paycheck = PAYCHECK_ASSISTANT // Get a job. Job reassignment changes your paycheck now. Get over it.
 	paycheck_department = ACCOUNT_CIV
 	display_order = JOB_DISPLAY_ORDER_ASSISTANT
+	wiki_page = "Assistant"
 
 /datum/job/assistant/get_access()
 	if(CONFIG_GET(flag/assistants_have_maint_access) || !CONFIG_GET(flag/jobs_have_minimal_access)) //Config has assistant maint access set

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -10,6 +10,7 @@
 	selection_color = "#fff5cc"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
+	wiki_page = "Guide_to_Atmospherics"
 
 	outfit = /datum/outfit/job/atmos
 

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -9,6 +9,7 @@
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
 	exp_type_department = EXP_TYPE_SERVICE // This is so the jobs menu can work properly
+	wiki_page = "Drinks"
 
 	outfit = /datum/outfit/job/bartender
 

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -8,6 +8,7 @@
 	spawn_positions = 2
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
+	wiki_page = "Guide_to_Botany"
 
 	outfit = /datum/outfit/job/botanist
 

--- a/code/modules/jobs/job_types/brigphys.dm
+++ b/code/modules/jobs/job_types/brigphys.dm
@@ -11,6 +11,8 @@
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	wiki_page = "Guide_to_Medicine"
+	special_notice = "You are not a security officer, do not do their job for them. However, you can help them if they need immediate assistance. You are to tend to the medical needs of officers and prisoners."
 
 	outfit = /datum/outfit/job/brig_phys
 

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -10,10 +10,12 @@
 	supervisors = "Nanotrasen officials and Space law"
 	selection_color = "#ccccff"
 	req_admin_notify = 1
-	minimal_player_age = 14
+	minimal_player_age = 30
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_COMMAND
+	wiki_page = "Captain"
+	special_notice = "You may be the Captain of this station, but you are still beholden to The Corporation."
 
 	outfit = /datum/outfit/job/captain
 

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -8,6 +8,7 @@
 	spawn_positions = 2
 	supervisors = "the quartermaster and the head of personnel"
 	selection_color = "#dcba97"
+	wiki_page = "Cargo_technician"
 
 	outfit = /datum/outfit/job/cargo_tech
 

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -8,6 +8,7 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+	wiki_page = "Chaplain"
 
 	outfit = /datum/outfit/job/chaplain
 

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -10,6 +10,7 @@
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
+	wiki_page = "Guide_to_Chemistry"
 
 	outfit = /datum/outfit/job/chemist
 

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -15,6 +15,7 @@
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_ENGINEERING
+	wiki_page = "Chief_Engineer"
 
 	outfit = /datum/outfit/job/ce
 

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -15,6 +15,7 @@
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_MEDICAL
+	wiki_page = "Chief_Medical_Officer"
 
 	outfit = /datum/outfit/job/cmo
 

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -8,6 +8,8 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+	wiki_page = "Clown"
+	special_notice = "There is a difference between funny pranks and griefing. Know it."
 
 	outfit = /datum/outfit/job/clown
 
@@ -47,7 +49,7 @@
 	duffelbag = /obj/item/storage/backpack/duffelbag/clown //strangely has a duffel
 
 	box = /obj/item/storage/box/hug/survival
-	
+
 	chameleon_extras = /obj/item/stamp/clown
 
 /datum/outfit/job/clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -8,6 +8,7 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
+	wiki_page = "Food"
 	var/cooks = 0 //Counts cooks amount
 
 	outfit = /datum/outfit/job/cook

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -8,6 +8,7 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+	wiki_page = "Curator"
 
 	outfit = /datum/outfit/job/curator
 

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -11,6 +11,8 @@
 	minimal_player_age = 21
 	exp_requirements = 120
 	exp_type = EXP_TYPE_CREW
+	wiki_page = "Cyborg"
+	special_notice = "Your laws take precedence over everything, including space law and past objectives. Do NOT break them."
 
 	display_order = JOB_DISPLAY_ORDER_CYBORG
 

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -12,6 +12,8 @@
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	special_notice = "You are not a security officer, do not do their job for them. However, you can help them if they need immediate assistance."
+	wiki_page = "Space_Law"
 
 	outfit = /datum/outfit/job/detective
 

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -10,6 +10,7 @@
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
+	wiki_page = "Guide_to_Genetics"
 
 	outfit = /datum/outfit/job/geneticist
 

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -13,8 +13,10 @@
 	req_admin_notify = 1
 	minimal_player_age = 10
 	exp_requirements = 180
+	wiki_page = "Head_of_Personnel"
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SUPPLY
+	special_notice = "You are NOT security, and should NEVER UNDER ANY CIRCUMSTANCES act like them."
 
 	outfit = /datum/outfit/job/hop
 

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -13,6 +13,7 @@
 	req_admin_notify = 1
 	minimal_player_age = 14
 	exp_requirements = 300
+	wiki_page = "Head_of_Security"
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
 

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -8,6 +8,7 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
+	wiki_page = "Janitor"
 
 	outfit = /datum/outfit/job/janitor
 

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -8,6 +8,7 @@
 	spawn_positions = 2
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+	wiki_page = "Lawyer"
 	var/lawyers = 0 //Counts lawyer amount
 
 	outfit = /datum/outfit/job/lawyer

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -8,6 +8,7 @@
 	spawn_positions = 3
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
+	wiki_page = "Guide_to_Medicine"
 
 	outfit = /datum/outfit/job/doctor
 

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -8,6 +8,7 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+	wiki_page = "Mime"
 
 	outfit = /datum/outfit/job/mime
 

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -8,6 +8,7 @@
 	spawn_positions = 2
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
+	wiki_page = "Paramedic"
 
 	outfit = /datum/outfit/job/paramedic
 

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -8,6 +8,8 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#d7b088"
+	wiki_page = "Quartermaster"
+	special_notice = "You are not a head of staff. You answer to the Head of Personnel."
 
 	outfit = /datum/outfit/job/quartermaster
 

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -15,6 +15,7 @@
 	exp_type_department = EXP_TYPE_SCIENCE
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
+	wiki_page = "Research_Director"
 
 	outfit = /datum/outfit/job/rd
 

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -10,6 +10,7 @@
 	selection_color = "#ffeeff"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
+	wiki_page = "Guide_to_Robotics"
 
 	outfit = /datum/outfit/job/roboticist
 

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -10,7 +10,7 @@
 	selection_color = "#ffeeff"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
-
+	wiki_page = "Scientist"
 
 	outfit = /datum/outfit/job/scientist
 

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -12,6 +12,8 @@
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	wiki_page = "Space_Law"
+	special_notice = "Space law is THE law. Follow it."
 
 	outfit = /datum/outfit/job/security
 

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -8,6 +8,7 @@
 	spawn_positions = 3
 	supervisors = "the quartermaster and the head of personnel"
 	selection_color = "#dcba97"
+	wiki_page = "Shaft_Miner"
 
 	outfit = /datum/outfit/job/miner
 

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -10,6 +10,7 @@
 	selection_color = "#fff5cc"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
+	wiki_page = "Station_Engineer"
 
 	outfit = /datum/outfit/job/engineer
 

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -10,6 +10,8 @@
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
+	wiki_page = "Infections"
+	special_notice = "Don't release viruses, harmful or not, without the CMO's permission."
 
 	outfit = /datum/outfit/job/virologist
 

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -12,6 +12,8 @@
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	wiki_page = "Space_Law"
+	special_notice = "You're the Warden, not a Security Officer. Your job is in the brig processing criminals, not patrolling the station."
 
 	outfit = /datum/outfit/job/warden
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**Port from Oracle**

This PR adds a short but highly visible notice to the text seen when initially joining as an employee, as well as a link right below it to the relevant wiki page for said job.

![image](https://user-images.githubusercontent.com/29362068/74314172-9adf7880-4d3a-11ea-8013-56ec46cbe041.png)

## Why It's Good For The Game
Reminds people not to do the things they shouldn't, and allows beginners easy access to the wiki pages related to the job they're doing.

## Changelog
:cl:
add: Custom Notice shown to players upon joining, as well as a wikilink to the relevant wiki page.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
