### PR TITLE
allows normal seccies to force holopad calls, take 2

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -34,7 +34,7 @@ Possible to do for anyone motivated enough:
 	layer = LOW_OBJ_LAYER
 	plane = FLOOR_PLANE
 	flags_1 = HEAR_1
-	req_access = list(ACCESS_SEC_DOORS) //Used to allow for forced connecting to other (not secure) holopads. Anyone can make a call, though.
+	req_access = list(ACCESS_SEC_DOORS) //Used to allow for forced connecting to other (not secure) holopads. Anyone can make a call, though. WaspStation edit to seccie holopads.
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 5
 	active_power_usage = 100

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -34,7 +34,7 @@ Possible to do for anyone motivated enough:
 	layer = LOW_OBJ_LAYER
 	plane = FLOOR_PLANE
 	flags_1 = HEAR_1
-	req_access = list(ACCESS_KEYCARD_AUTH) //Used to allow for forced connecting to other (not secure) holopads. Anyone can make a call, though.
+	req_access = list(ACCESS_SEC_DOORS) //Used to allow for forced connecting to other (not secure) holopads. Anyone can make a call, though.
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 5
 	active_power_usage = 100


### PR DESCRIPTION
## About The Pull Request

there is a little known ability for high ranking staff to force a connection through holopads instead of having to wait for someone on the other end to pick up

this PR is to extend the access restriction to normal seccies, instead of just heads

## Why It's Good For The Game

allows seccies to keep tabs on employees a bit more than traditional camera weaving and radio use
https://imgur.com/NfUilVR

## Changelog
:cl:
tweak: allows seccies to force a connection with a holopad instead of having to wait for someone else to answer on the other end
/:cl: