### PR TITLE
Begone low pop brain traumas

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -2,6 +2,7 @@
 	name = "Spontaneous Brain Trauma"
 	typepath = /datum/round_event/brain_trauma
 	weight = 25
+	min_players = 10 // WaspStation Edit - Min pop Braintrauma event (because braintrauma event on lowpop when theres no one to fix it is terible)
 
 /datum/round_event/brain_trauma
 	fakeable = FALSE


### PR DESCRIPTION
i have gotten monophobia one to many times when there's no one to talk to

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds a minimum pop for the brain trauma event to 10
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Picture this: you are alone on the station. you suddenly get monophobia! its severe! now you will definetly die from a heart attack very soon as there is literally nothing you can do about it.

with this pr this will never happen again!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a minimum pop to random braintraumas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
