### PR TITLE
Crew Transfer Vote

### DIFF
--- a/Waspstation/code/controllers/subsystem/autotransfer.dm
+++ b/Waspstation/code/controllers/subsystem/autotransfer.dm
@@ -9,6 +9,7 @@ SUBSYSTEM_DEF(autotransfer)
 /datum/controller/subsystem/autotransfer/Initialize(timeofday)
 	starttime = world.time
 	targettime = starttime + CONFIG_GET(number/vote_autotransfer_initial)
+	return ..()
 
 /datum/controller/subsystem/autotransfer/fire()
 	if (world.time > targettime)

--- a/Waspstation/code/controllers/subsystem/autotransfer.dm
+++ b/Waspstation/code/controllers/subsystem/autotransfer.dm
@@ -1,0 +1,16 @@
+SUBSYSTEM_DEF(autotransfer)
+	name = "Autotransfer Vote"
+	flags = SS_KEEP_TIMING | SS_BACKGROUND
+	wait = 1 MINUTES
+
+	var/starttime
+	var/targettime
+
+/datum/controller/subsystem/autotransfer/Initialize(timeofday)
+	starttime = world.time
+	targettime = starttime + CONFIG_GET(number/vote_autotransfer_initial)
+
+/datum/controller/subsystem/autotransfer/fire()
+	if (world.time > targettime)
+		SSvote.initiate_vote("transfer",null) //TODO figure out how to not use null as the user
+		targettime = targettime + CONFIG_GET(number/vote_autotransfer_interval)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -105,6 +105,20 @@
 	integer = FALSE
 	min_val = 0
 
+//Waspstation Begin - Autotranfer vote
+
+/datum/config_entry/number/vote_autotransfer_initial //length of time before the first autotransfer vote is called (deciseconds, default 2 hours)
+	config_entry_value = 72000
+	integer = FALSE
+	min_val = 0
+
+/datum/config_entry/number/vote_autotransfer_interval //length of time to wait before subsequent autotransfer votes (deciseconds, default 30 minutes)
+	config_entry_value = 18000
+	integer = FALSE
+	min_val = 0
+
+//Waspstation End
+
 /datum/config_entry/flag/default_no_vote	// vote does not default to nochange/norestart
 
 /datum/config_entry/flag/no_dead_vote	// dead people can't vote

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -185,7 +185,7 @@ SUBSYSTEM_DEF(shuttle)
 			Good luck.")
 		emergency = backup_shuttle
 	var/srd = CONFIG_GET(number/shuttle_refuel_delay)
-	if(world.time - SSticker.round_start_time < srd)
+	if(world.time - SSticker.round_start_time < srd && user != null)
 		to_chat(user, "<span class='alert'>The emergency shuttle is refueling. Please wait [DisplayTimeText(srd - (world.time - SSticker.round_start_time))] before trying again.</span>")
 		return
 

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -185,7 +185,7 @@ SUBSYSTEM_DEF(shuttle)
 			Good luck.")
 		emergency = backup_shuttle
 	var/srd = CONFIG_GET(number/shuttle_refuel_delay)
-	if(world.time - SSticker.round_start_time < srd && user != null)
+	if(world.time - SSticker.round_start_time < srd && user != null) //WaspStation Edit - Autotransfer
 		to_chat(user, "<span class='alert'>The emergency shuttle is refueling. Please wait [DisplayTimeText(srd - (world.time - SSticker.round_start_time))] before trying again.</span>")
 		return
 

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -71,6 +71,8 @@ SUBSYSTEM_DEF(vote)
 					choices[GLOB.master_mode] += non_voters.len
 					if(choices[GLOB.master_mode] >= greatest_votes)
 						greatest_votes = choices[GLOB.master_mode]
+						
+			//WaspStation Begin - Autotransfer
 			else if(mode == "transfer")
 				var/factor = 1
 				switch(world.time / (1 MINUTES ))
@@ -85,6 +87,8 @@ SUBSYSTEM_DEF(vote)
 					else
 						factor = 1.4
 				choices["Initiate Crew Transfer"] += round(non_voters.len * factor)
+			//WaspStation End	
+				
 			else if(mode == "map")
 				for (var/non_voter_ckey in non_voters)
 					var/client/C = non_voters[non_voter_ckey]

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -71,6 +71,20 @@ SUBSYSTEM_DEF(vote)
 					choices[GLOB.master_mode] += non_voters.len
 					if(choices[GLOB.master_mode] >= greatest_votes)
 						greatest_votes = choices[GLOB.master_mode]
+			else if(mode == "transfer")
+				var/factor = 1
+				switch(world.time / (1 MINUTES ))
+					if(0 to 60)
+						factor = 0.5
+					if(61 to 120)
+						factor = 0.8
+					if(121 to 240)
+						factor = 1
+					if(241 to 300)
+						factor = 1.2
+					else
+						factor = 1.4
+				choices["Initiate Crew Transfer"] += round(non_voters.len * factor)
 			else if(mode == "map")
 				for (var/non_voter_ckey in non_voters)
 					var/client/C = non_voters[non_voter_ckey]
@@ -136,6 +150,17 @@ SUBSYSTEM_DEF(vote)
 						restart = TRUE
 					else
 						GLOB.master_mode = .
+
+			//WS Begin - Autotransfer
+			if("transfer")
+				if(. == "Initiate Crew Transfer")
+					//TODO find a cleaner way to do this
+					SSshuttle.requestEvac(null,"Crew transfer requested.")
+					var/obj/machinery/computer/communications/C = locate() in GLOB.machines
+					if(C)
+						C.post_status("shuttle")
+			//WS End
+
 			if("map")
 				SSmapping.changemap(global.config.maplist[.])
 				SSmapping.map_voted = TRUE
@@ -185,12 +210,19 @@ SUBSYSTEM_DEF(vote)
 				to_chat(usr, "<span class='warning'>A vote was initiated recently, you must wait [DisplayTimeText(next_allowed_time-world.time)] before a new vote can be started!</span>")
 				return FALSE
 
+		SEND_SOUND(world, sound('sound/misc/notice2.ogg'))//WS Edit - Autotransfer
 		reset()
 		switch(vote_type)
 			if("restart")
 				choices.Add("Restart Round","Continue Playing")
 			if("gamemode")
 				choices.Add(config.votable_modes)
+
+			//WS Begin - Autotransfer
+			if("transfer")
+				choices.Add("Initiate Crew Transfer","Continue Playing")
+			//WS End
+
 			if("map")
 				if(!admin && SSmapping.map_voted)
 					to_chat(usr, "<span class='warning'>The next map has already been selected.</span>")
@@ -212,7 +244,7 @@ SUBSYSTEM_DEF(vote)
 			else
 				return FALSE
 		mode = vote_type
-		initiator = initiator_key
+		initiator = initiator_key ? initiator_key : "the Server" //WS Edit - Autotransfer
 		started_time = world.time
 		var/text = "[capitalize(mode)] vote started by [initiator]."
 		if(mode == "custom")

--- a/config/config.txt
+++ b/config/config.txt
@@ -185,6 +185,12 @@ VOTE_DELAY 6000
 ## time period (deciseconds) which voting session will last (default 1 minute)
 VOTE_PERIOD 600
 
+## autovote initial delay (deciseconds) before first automatic transfer vote call (default 120 minutes)
+VOTE_AUTOTRANSFER_INITIAL 72000
+
+##autovote delay (deciseconds) before sequential automatic transfer votes are called (default 30 minutes)
+VOTE_AUTOTRANSFER_INTERVAL 18000
+
 ## prevents dead players from voting or starting votes
 # NO_DEAD_VOTE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3026,6 +3026,7 @@
 #include "interface\skin.dmf"
 #include "waspstation\define_includes.dm"
 #include "waspstation\code\_globalvars\game_modes.dm"
+#include "waspstation\code\controllers\subsystem\autotransfer.dm"
 #include "waspstation\code\controllers\subsystem\job.dm"
 #include "waspstation\code\datums\brain_damage\brain_trauma.dm"
 #include "waspstation\code\datums\brain_damage\phobia.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Starts a vote after a config-specified time to call the shuttle and end the round. Simple enough.

## Why It's Good For The Game
Allows rounds to end IC instead of the sudden restart vote or the round just fizzling out.

## Changelog
:cl:
add: Crew transfer vote
server: Need to set desired crew transfer times
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
