### PR TITLE
Makes Felinids speak normally instead of "meowing."

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -2,7 +2,9 @@
 /datum/species/human/felinid
 	name = "Felinid"
 	id = "felinid"
+	/* WaspStation Edit - Removes Sin
 	say_mod = "meows"
+	WaspStation End */
 	limbs_id = "human"
 
 	mutant_bodyparts = list("ears", "tail_human")


### PR DESCRIPTION

## Why It's Good For The Game
If you can't tell me why this is good for the game, I don't know what to tell you.

## Changelog
:cl:
del: felinid's speak prefix is normal instead of "meowing."
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
