### PR TITLE
Renames blackpowder to gunpowder

### DIFF
--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -136,7 +136,7 @@
 		/datum/reagent/medicine/diphenhydramine,\
 		/datum/reagent/drug/space_drugs,\
 		/datum/reagent/drug/crank,\
-		/datum/reagent/blackpowder,\
+		/datum/reagent/gunpowder,\
 		/datum/reagent/napalm,\
 		/datum/reagent/firefighting_foam,\
 		/datum/reagent/consumable/mayonnaise,\

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -182,7 +182,7 @@
 	trash = /obj/item/gun/ballistic/revolver
 	bitesize_mod = 2
 	foodtype = FRUIT
-	tastes = list("blackpowder" = 1)
+	tastes = list("gunpowder" = 1)
 	wine_power = 90 //It burns going down, too.
 
 //Cherry Bombs
@@ -194,7 +194,7 @@
 	plantname = "Cherry Bomb Tree"
 	product = /obj/item/reagent_containers/food/snacks/grown/cherry_bomb
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/sugar = 0.1, /datum/reagent/blackpowder = 0.7)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/sugar = 0.1, /datum/reagent/gunpowder = 0.7)
 	rarity = 60 //See above
 
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb
@@ -204,7 +204,7 @@
 	filling_color = rgb(20, 20, 20)
 	seed = /obj/item/seeds/cherry/bomb
 	bitesize_mod = 2
-	volume = 125 //Gives enough room for the blackpowder at max potency
+	volume = 125 //Gives enough room for the gunpowder at max potency
 	max_integrity = 40
 	wine_power = 80
 
@@ -225,6 +225,6 @@
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime()
 	icon_state = "cherry_bomb_lit"
 	playsound(src, 'sound/effects/fuse.ogg', seed.potency, FALSE)
-	reagents.chem_temp = 1000 //Sets off the blackpowder
+	reagents.chem_temp = 1000 //Sets off the gunpowder
 	reagents.handle_reactions()
 

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -87,15 +87,15 @@
 	color = "#210021"
 	taste_description = "compressed bitterness"
 
-/datum/reagent/blackpowder
-	name = "blackpowder"
+/datum/reagent/gunpowder
+	name = "Gunpowder"
 	description = "Explodes. Violently."
 	reagent_state = LIQUID
 	color = "#000000"
 	metabolization_rate = 0.05
 	taste_description = "salt"
 
-/datum/reagent/blackpowder/on_mob_life(mob/living/carbon/M)
+/datum/reagent/gunpowder/on_mob_life(mob/living/carbon/M)
 	. = TRUE
 	..()
 	if(!isplasmaman(M))
@@ -104,7 +104,7 @@
 	if(M.hallucination < volume)
 		M.hallucination += 5
 
-/datum/reagent/blackpowder/on_ex_act()
+/datum/reagent/gunpowder/on_ex_act()
 	var/location = get_turf(holder.my_atom)
 	var/datum/effect_system/reagents_explosion/e = new()
 	e.set_up(1 + round(volume/6, 1), location, 0, 0, message = 0)
@@ -124,7 +124,7 @@
 	reagent_state = SOLID
 	color = "#FFFFFF"
 	taste_description = "death"
-	
+
 /datum/reagent/flash_powder
 	name = "Flash Powder"
 	description = "Makes a very bright flash."

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -165,7 +165,7 @@
 
 WaspStation End*/
 
-/datum/chemical_reaction/reagent_explosion/blackpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/reagent_explosion/gunpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
 	sleep(rand(50,100))
 	..()
 
@@ -429,7 +429,7 @@ WaspStation End*/
 
 /datum/chemical_reaction/teslium
 	results = list(/datum/reagent/teslium = 3)
-	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/silver = 1, /datum/reagent/blackpowder = 1)
+	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/silver = 1, /datum/reagent/gunpowder = 1)
 	mix_message = "<span class='danger'>A jet of sparks flies from the mixture as it merges into a flickering slurry.</span>"
 	required_temp = 400
 

--- a/waspstation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/waspstation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -1,10 +1,10 @@
-/datum/chemical_reaction/blackpowder
-	results = list(/datum/reagent/blackpowder = 3)
+/datum/chemical_reaction/gunpowder
+	results = list(/datum/reagent/gunpowder = 3)
 	required_reagents = list(/datum/reagent/saltpetre = 1, /datum/reagent/medicine/charcoal = 1, /datum/reagent/sulfur = 1)
 
-/datum/chemical_reaction/reagent_explosion/blackpowder_explosion
-	required_reagents = list(/datum/reagent/blackpowder = 1)
+/datum/chemical_reaction/reagent_explosion/gunpowder_explosion
+	required_reagents = list(/datum/reagent/gunpowder = 1)
 	required_temp = 474
 	strengthdiv = 6
 	modifier = 1
-	mix_message = "<span class='boldannounce'>Sparks start flying around the blackpowder!</span>"
+	mix_message = "<span class='boldannounce'>Sparks start flying around the Gunpowder!</span>"

--- a/waspstation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/waspstation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -7,4 +7,4 @@
 	required_temp = 474
 	strengthdiv = 6
 	modifier = 1
-	mix_message = "<span class='boldannounce'>Sparks start flying around the Gunpowder!</span>"
+	mix_message = "<span class='boldannounce'>Sparks start flying around the gunpowder!</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Renames blackpowder to gunpowder
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When inputting blackpowder into plumbing machines it will instead input "black powder" the crayon powder, this fixes that problem and makes it easier to differentiate between each reagent.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: blackpowder renamed to gunpowder
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
