### PR TITLE
Ashwalker tendril can now be moved

### DIFF
--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -11,8 +11,8 @@
 	max_integrity = 250
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/tendril)
 
-	move_resist=INFINITY // just killing it tears a massive hole in the ground, let's not move it
-	anchored = TRUE
+	move_resist = 0 // "just killing it tears a massive hole in the ground, let's not move it" -a goddamn coward
+	anchored = FALSE
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
 
 	var/gps = null

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -11,8 +11,8 @@
 	max_integrity = 250
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/tendril)
 
-	move_resist = 0 // "just killing it tears a massive hole in the ground, let's not move it" -a goddamn coward
-	anchored = FALSE
+	move_resist = INFINITY // just killing it tears a massive hole in the ground, let's not move it
+	anchored = TRUE
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
 
 	var/gps = null
@@ -24,6 +24,7 @@
 
 /obj/structure/spawner/lavaland/legion
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril)
+
 
 GLOBAL_LIST_INIT(tendrils, list())
 /obj/structure/spawner/lavaland/Initialize()

--- a/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
@@ -6,8 +6,8 @@
 	icon = 'icons/mob/nest.dmi'
 	icon_state = "ash_walker_nest"
 
-	move_resist=INFINITY // just killing it tears a massive hole in the ground, let's not move it
-	anchored = TRUE
+	move_resist=1000 // can be pulled if you displace it from the lava pool and have 1000 pull force, can be pushed if you have 1000 push force, takes damage if you somehow have more
+	anchored = FALSE
 	density = TRUE
 
 	resistance_flags = FIRE_PROOF | LAVA_PROOF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Unanchors the ashwalker tendril and sets move_resist to 1000, which player races and thrown giblets of player races are on par with. This allows you to displace it with a gibbed sacrifice, allowing you to pull it away.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Ashwalker CTF was fun while it was in the game. Stealing the tendril and making them pay to have it back, or conversely sneaking it onto the station and staging an invasion from within. This should effectively bring it back, albeit without requiring a moving chair to buckle it to, since the tendril is no longer a mob.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: you can just pick up the tendril and leave now
tweak: sanitized a line of code in a dead end i found while looking for the ashwalker den
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
