### PR TITLE
Shows bone fractures on medical scanners

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -301,9 +301,9 @@ GENE SCANNER
 		var/list/broken_stuff = list()
 		for(var/obj/item/bodypart/B in H.bodyparts)
 			if(B.bone_status == BONE_FLAG_BROKEN)
-				broken_stuff += B
+				broken_stuff += B.name
 		if(broken_stuff.len)
-			render_list += "\t<span class='alert'>Bone fractures detected. Advanced scanner required for location.</span>\n"
+			render_list += "\t<span class='alert'>Bone fractures detected. Subject's [english_list(broken_stuff)] [broken_stuff.len > 1 ? "require" : "requires"] surgical treatment!</span>\n"
 
 		// Species and body temperature
 		var/datum/species/S = H.dna.species


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Missing functionality that was supposed to be added with full-body scanners from oracle.

Partial Re-port of OracleStation/OracleStation#5

## Why It's Good For The Game
It's hard to remember what bones are broken sometimes, and people who weren't there for it breaking don't know at all.

## Changelog
:cl:
tweak: Medical Scanners now show broken bones.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
