### PR TITLE
SSD Sleeping

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -22,6 +22,9 @@
 	if(draining)
 		to_chat(src, "<span class='revenwarning'>You are already siphoning the essence of a soul!</span>")
 		return
+	if(target.isLivingSSD())
+		to_chat(src, "<span class='revennotice'>[target.p_their(TRUE)] soul is beyond your reach.</span>")
+		return
 	if(!target.stat)
 		to_chat(src, "<span class='revennotice'>[target.p_their(TRUE)] soul is too strong to harvest.</span>")
 		if(prob(10))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -311,8 +311,7 @@
 			if(!key)
 				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
 			else if(!client)
-				msg += "[t_He] [t_has] a blank, absent-minded stare and appears completely unresponsive to anything. [t_He] may snap out of it soon.\n"
-
+				msg += "<span class='warning'>[t_He] appears to be suffering from SSD - Space Sleep Disorder. [t_He] may snap out of it at any time! Or maybe never. It's best to leave [t_him] be.</span>\n"
 	if (length(msg))
 		. += "<span class='warning'>[msg.Join("")]</span>"
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -21,6 +21,10 @@
 		if(.) //not dead
 			handle_blood()
 
+		if(isLivingSSD())//if you're disconnected, you're going to sleep
+			if(AmountSleeping() < 20)
+				AdjustSleeping(20)//adjust every 10 seconds
+
 		if(stat != DEAD)
 			var/bprv = handle_bodyparts()
 			if(bprv & BODYPART_LIFE_UPDATE_HEALTH)
@@ -673,7 +677,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	// apply insulation to the amount of change
 	if(use_insulation)
 		amount *= (1 - get_insulation_protection(bodytemperature + amount))
-	
+
 	// Extra calculation for hardsuits to bleed off heat
 	if(hardsuit_fix)
 		amount += hardsuit_fix

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1397,6 +1397,10 @@
 		if("lighting_alpha")
 			sync_lighting_plane_alpha()
 
+/mob/living/proc/isLivingSSD()
+	if(player_logged && stat != DEAD)
+		return TRUE
+
 /mob/living/vv_get_header()
 	. = ..()
 	var/refid = REF(src)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -123,6 +123,8 @@
 	var/list/diseases = list() /// list of all diseases in a mob
 	var/list/disease_resistances = list()
 
+	var/player_logged = FALSE //keep track at login and logout; used for SSD
+
 	var/slowed_by_drag = TRUE ///Whether the mob is slowed down when dragging another prone mob
 
 	var/list/ownedSoullinks ///soullinks we are the owner of

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -27,3 +27,4 @@
 	var/datum/antagonist/changeling/changeling = mind.has_antag_datum(/datum/antagonist/changeling)
 	if(changeling)
 		changeling.regain_powers()
+	player_logged = FALSE

--- a/code/modules/mob/living/logout.dm
+++ b/code/modules/mob/living/logout.dm
@@ -1,5 +1,10 @@
 /mob/living/Logout()
 	update_z(null)
 	..()
+	if(mind && mind.active)
+		player_logged = TRUE
+	else
+		player_logged = FALSE
+
 	if(!key && mind)	//key and mind have become separated.
 		mind.active = 0	//This is to stop say, a mind.transfer_to call on a corpse causing a ghost to re-enter its body.


### PR DESCRIPTION
## About The Pull Request
Port of: SunsetStation/SunsetStation#1202

## Why It's Good For The Game
Easier to tell if people are SSD, and thanks to TG making sleep heal, while you're logged out you will passively heal due to it.

## Changelog
:cl:
add: People now fall asleep when they go SSD.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
