### PR TITLE
Sleep Healing

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -52,16 +52,18 @@
 	needs_update_stat = TRUE
 	var/mob/living/carbon/carbon_owner
 	var/mob/living/carbon/human/human_owner
+	var/heal = FALSE		// WaspStation Edit
 
-/datum/status_effect/incapacitating/sleeping/on_creation(mob/living/new_owner, updating_canmove)
+/datum/status_effect/incapacitating/sleeping/on_creation(mob/living/new_owner, updating_canmove, healing)		// WaspStation Edit  Added healing
 	. = ..()
 	if(.)
 		if(iscarbon(owner)) //to avoid repeated istypes
 			carbon_owner = owner
 		if(ishuman(owner))
 			human_owner = owner
+		heal = healing		// WaspStation Edit
 
-/*		Wasp Station Edit		Moved to Waspstation folder
+/*		WaspStation Edit		Moved to WaspStation folder
 
 /datum/status_effect/incapacitating/sleeping/Destroy()
 	carbon_owner = null

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -61,6 +61,8 @@
 		if(ishuman(owner))
 			human_owner = owner
 
+/*		Wasp Station Edit		Moved to Waspstation folder
+
 /datum/status_effect/incapacitating/sleeping/Destroy()
 	carbon_owner = null
 	human_owner = null
@@ -91,6 +93,8 @@
 			carbon_owner.handle_dreams()
 		if(prob(10) && owner.health > owner.crit_threshold)
 			owner.emote("snore")
+
+		Wasp Station Edit End  */
 
 /obj/screen/alert/status_effect/asleep
 	name = "Asleep"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -433,7 +433,7 @@
 		return
 	else
 		if(alert(src, "You sure you want to sleep for a while?", "Sleep", "Yes", "No") == "Yes")
-			SetSleeping(400) //Short nap
+			SetSleeping(400, TRUE, FALSE, TRUE) //Short nap
 	update_mobility()
 
 /mob/proc/get_contents()

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -310,7 +310,7 @@
 			S = apply_status_effect(STATUS_EFFECT_SLEEPING, amount, updating)
 		return S
 
-/mob/living/proc/SetSleeping(amount, updating = TRUE, ignore_canstun = FALSE) //Sets remaining duration
+/mob/living/proc/SetSleeping(amount, updating = TRUE, ignore_canstun = FALSE, healing = FALSE) //Sets remaining duration waspstation edit
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_SLEEP, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if((!HAS_TRAIT(src, TRAIT_SLEEPIMMUNE)) || ignore_canstun)
@@ -321,7 +321,7 @@
 		else if(S)
 			S.duration = world.time + amount
 		else
-			S = apply_status_effect(STATUS_EFFECT_SLEEPING, amount, updating)
+			S = apply_status_effect(STATUS_EFFECT_SLEEPING, amount, updating, healing)
 		return S
 
 /mob/living/proc/AdjustSleeping(amount, updating = TRUE, ignore_canstun = FALSE) //Adds to remaining duration

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3039,6 +3039,7 @@
 #include "waspstation\code\datums\components\crafting\recipes.dm"
 #include "waspstation\code\datums\components\storage\concrete\pockets.dm"
 #include "waspstation\code\datums\diseases\coronavirus.dm"
+#include "waspstation\code\datums\status_effects\debuffs.dm"
 #include "waspstation\code\datums\traits\_quirk.dm"
 #include "waspstation\code\game\area\Space_Station_13_areas.dm"
 #include "waspstation\code\game\gamemodes\changeling\changeling.dm"

--- a/waspstation/code/datums/status_effects/debuffs.dm
+++ b/waspstation/code/datums/status_effects/debuffs.dm
@@ -1,0 +1,43 @@
+// Overall healing intentionally low to make omnizine/donk pockets preferred alternative
+/datum/status_effect/incapacitating/sleeping/Destroy()
+	if(owner.maxHealth)
+		var/health_ratio = owner.health / owner.maxHealth
+		var/healing = -5
+		if((locate(/obj/structure/bed) in owner.loc))
+			healing -= 4
+		else if((locate(/obj/structure/table) in owner.loc))
+			healing -= 2
+		for(var/obj/item/bedsheet/bedsheet in range(owner.loc,0))
+			if(bedsheet.loc != owner.loc)//bedsheets in your backpack/neck don't give you comfort
+				continue
+			healing -= 1
+			break //Only count the first bedsheet
+
+		var/datum/component/mood/mood = owner.GetComponent(/datum/component/mood)
+		if(mood.sanity >= SANITY_GREAT)
+			healing -= 2
+		else if(mood.sanity <= SANITY_DISTURBED)
+			healing += 1
+
+		if(owner.metabolism_efficiency == 1.25)     // Have been eating healthy
+			healing -= 3
+		else if (owner.metabolism_efficiency == 0.8)
+			healing += 2
+
+		if(health_ratio > 0)
+			owner.adjustBruteLoss(healing)
+			owner.adjustFireLoss(healing)
+			owner.adjustToxLoss(healing * 0.5, TRUE, TRUE)
+		owner.adjustStaminaLoss(healing)
+	carbon_owner = null
+	human_owner = null
+	return ..()
+
+/datum/status_effect/incapacitating/sleeping/tick()
+	if(human_owner && human_owner.drunkenness)
+		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
+	if(prob(20))
+		if(carbon_owner)
+			carbon_owner.handle_dreams()
+		if(prob(10) && owner.health > owner.crit_threshold)
+			owner.emote("snore")

--- a/waspstation/code/datums/status_effects/debuffs.dm
+++ b/waspstation/code/datums/status_effects/debuffs.dm
@@ -24,7 +24,7 @@
 		else if (owner.metabolism_efficiency == 0.8)
 			healing += 2
 
-		if(health_ratio > 0)
+		if(health_ratio > 0 && heal == TRUE)
 			owner.adjustBruteLoss(healing)
 			owner.adjustFireLoss(healing)
 			owner.adjustToxLoss(healing * 0.5, TRUE, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Sleeping through the IC tab Sleep verb will now heal you even when below 80 hp, with changes based on sleeping on a bed/table, blanket, mood, and metabolism.
Healing sleeping on a bed with sheets gives 10 hp, with up to 5 bonus from mood and metabolism.
The healing amount is intentionally low in order to encourage alternatives like meds, surgery, and donk pockets.
Base: 5hp
Bed: 4
Table: 2
Sheet: 1
Mood: +2, -1
Metabolism: +3, -2

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Could provide a source of passive healing as in the To-Do list. Would give players a reliable source of healing while hopefully not strong enough to eclipse methods that take resources/other players.

## Changelog
:cl:
tweak: Sleeping now always heals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
