### PR TITLE
Adds tiny fans to Lavaland Seed vault

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -644,6 +644,13 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
+"nX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/seedvault)
 "oR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -657,6 +664,10 @@
 "qQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
+"rs" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
 /area/ruin/powered/seedvault)
 "sv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -797,7 +808,7 @@ as
 PH
 aQ
 av
-al
+rs
 aR
 ab
 ab
@@ -819,7 +830,7 @@ Bb
 qQ
 ah
 av
-am
+nX
 aR
 ab
 ab


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/6519623/79036578-79163c80-7b97-11ea-8461-8a0e9c481676.png)


## Why It's Good For The Game

Fixes #139 

## Changelog
:cl:
fix: Seedvault now has tiny fans to unfuck unwanted atmos from lavaland.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
