### PR TITLE
Job titles on radio messages now show custom ID assignments before defaulting to manifest assignments

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -182,10 +182,13 @@ INITIALIZE_IMMEDIATE(/atom/movable/virtualspeaker)
 
 	// The mob's job identity
 	if(ishuman(M))
-		// Humans use their job as seen on the crew manifest. This is so the AI
-		// can know their job even if they don't carry an ID.
+		// Humans use their job as seen on the crew manifest if they don't have an ID with a job assigned. This is so the AI
+		// and other crewmembers can know their job even if they don't carry an ID or aren't assigned to anything.
 		var/datum/data/record/findjob = find_record("name", name, GLOB.data_core.general)
-		if(findjob)
+		var/mob/living/carbon/human/H = M
+		if(H.get_assignment(FALSE, FALSE))
+			job = H.get_assignment()
+		else if(findjob)
 			job = findjob.fields["rank"]
 		else
 			job = "Unknown"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Read title

## Why It's Good For The Game
Comms agents can actually do something without being immediately caught, and people who have been re-assigned to some job are now known to be that job.

## Changelog
:cl:
tweak: Radio messages now show custom assignments before defaulting to manifest assignments.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
