### PR TITLE
Allows compact combat shotgun to be used with only one hand

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -70,6 +70,7 @@
 	icon_state = "cshotgunc"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com/compact
 	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_MEDIUM
 
 //Dual Feed Shotgun
 


### PR DESCRIPTION

## About The Pull Request

the compact combat shotgun once again only needs one hand to use

## Why It's Good For The Game

and unlike the shitty hybrid taser it stops a criminal in their tracks in two hits. Bang, bang, and they're fucking done. 

## Changelog
:cl:
tweak: the compact combat shotgun only needs one hand to use again
/:cl:
