### PR TITLE
Allows pAIs to go through door hatches

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -5,7 +5,7 @@
 	mouse_opacity = MOUSE_OPACITY_ICON
 	density = FALSE
 	hud_type = /datum/hud/pai
-	pass_flags = PASSTABLE | PASSMOB
+	pass_flags = PASSTABLE | PASSMOB | PASSDOORHATCH
 	mob_size = MOB_SIZE_TINY
 	desc = "A generic pAI mobile hard-light holographics emitter. It seems to be deactivated."
 	weather_immunities = list("ash")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A rather small change, but one that I think would be interesting nonetheless. This allows pAI holoshells to go underneath the door hatches previously only usable by drones and mice.
## Why It's Good For The Game
 This allows them slightly better freedom of movement, which, due to not being able to have access, often lead to them getting stuck in one room for the entire round.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Personal AI holoshells can now go through the door hatches on most station doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
