### PR TITLE
Revenant can READ!

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -333,9 +333,9 @@ em						{font-style: normal;	font-weight: bold;}
 .purple					{color: #9956d3;}
 .holoparasite			{color: #88809c;}
 
-.revennotice			{color: #1d2953;}
-.revenboldnotice		{color: #1d2953;	font-weight: bold;}
-.revenbignotice			{color: #1d2953;	font-weight: bold;	font-size: 185%;}
+.revennotice			{color: #5631b5;}
+.revenboldnotice		{color: #5631b5;	font-weight: bold;}
+.revenbignotice			{color: #5631b5;	font-weight: bold;	font-size: 185%;}
 .revenminor				{color: #823abb}
 .revenwarning			{color: #760fbb;	font-style: italic;}
 .revendanger			{color: #760fbb;	font-weight: bold;	font-size: 185%;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -332,9 +332,9 @@ h1.alert, h2.alert		{color: #000000;}
 .purple					{color: #5e2d79;}
 .holoparasite			{color: #35333a;}
 
-.revennotice			{color: #1d2953;}
-.revenboldnotice		{color: #1d2953;	font-weight: bold;}
-.revenbignotice			{color: #1d2953;	font-weight: bold;	font-size: 185%;}
+.revennotice			{color: #5631b5;}
+.revenboldnotice		{color: #5631b5;	font-weight: bold;}
+.revenbignotice			{color: #5631b5;	font-weight: bold;	font-size: 185%;}
 .revenminor				{color: #823abb}
 .revenwarning			{color: #760fbb;	font-style: italic;}
 .revendanger			{color: #760fbb;	font-weight: bold;	font-size: 185%;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -91,9 +91,9 @@ h1.alert, h2.alert		{color: #000000;}
 .purple					{color: #5e2d79;}
 .holoparasite			{color: #35333a;}
 
-.revennotice			{color: #1d2953;}
-.revenboldnotice		{color: #1d2953;	font-weight: bold;}
-.revenbignotice			{color: #1d2953;	font-weight: bold;	font-size: 3;}
+.revennotice			{color: #5631b5;}
+.revenboldnotice		{color: #5631b5;	font-weight: bold;}
+.revenbignotice			{color: #5631b5;	font-weight: bold;	font-size: 3;}
 .revenminor				{color: #823abb}
 .revenwarning			{color: #760fbb;	font-style: italic;}
 .revendanger			{color: #760fbb;	font-weight: bold;	font-size: 3;}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously, most of revenant's text (anything that doesn't reveal you immediately) was something close to black. This is, obviously, not a good idea for dark mode, unless you've had years of training as an alien with no nightvision.

The text color has been changed to a dark purple, making it actually legible. It's also stilldarker than the more danger-alerting text colors Rev has, allowing differentiation in how bad a situation is.

## Why It's Good For The Game

I like to see.

## Changelog
:cl: Epsil
tweak: you can now see ALL the text that revenant shows you. no more black wit a little blue on dark mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
