### PR TITLE
minor fix to hypercharged slime cells

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -96,7 +96,7 @@ Slimecrossing Items
 	desc = "A charged yellow slime extract, infused with even more plasma. It almost hurts to touch."
 	rating = 7 //Roughly 1.5 times the original.
 	maxcharge = 20000 //2 times the normal one.
-	chargerate = 225 //1.5 times the normal rate.
+	chargerate = 2250 //1.5 times the normal rate.
 
 //Barrier cube - Chilling Grey
 /obj/item/barriercube


### PR DESCRIPTION

## About The Pull Request

raises the charge rate for hypercharged slime cells from 225 to 2250, the original value.

## Why It's Good For The Game

i don't know, is it?

## Changelog
:cl:
fix: hypercharged slime cores have their proper recharge rate as well.
/:cl:
