### PR TITLE
hitscan lasers

### DIFF
--- a/code/game/objects/effects/temporary_visuals/projectiles/impact.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/impact.dm
@@ -36,3 +36,8 @@
 
 /obj/effect/projectile/impact/wormhole
 	icon_state = "wormhole_g"
+
+/obj/effect/projectile/impact/emitter
+	name = "emitter impact"
+	icon_state = "impact_emitter"
+	

--- a/code/game/objects/effects/temporary_visuals/projectiles/impact.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/impact.dm
@@ -40,4 +40,3 @@
 /obj/effect/projectile/impact/emitter
 	name = "emitter impact"
 	icon_state = "impact_emitter"
-	

--- a/code/game/objects/effects/temporary_visuals/projectiles/muzzle.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/muzzle.dm
@@ -28,3 +28,7 @@
 
 /obj/effect/projectile/muzzle/wormhole
 	icon_state = "wormhole_g"
+
+/obj/effect/projectile/muzzle/emitter
+	icon_state = "muzzle_emitter"
+	

--- a/code/game/objects/effects/temporary_visuals/projectiles/muzzle.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/muzzle.dm
@@ -31,4 +31,3 @@
 
 /obj/effect/projectile/muzzle/emitter
 	icon_state = "muzzle_emitter"
-	

--- a/code/game/objects/effects/temporary_visuals/projectiles/tracer.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/tracer.dm
@@ -69,4 +69,3 @@
 
 /obj/effect/projectile/tracer/emitter
 	icon_state = "emitter"
-	

--- a/code/game/objects/effects/temporary_visuals/projectiles/tracer.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/tracer.dm
@@ -66,3 +66,7 @@
 
 /obj/effect/projectile/tracer/wormhole
 	icon_state = "wormhole_g"
+
+/obj/effect/projectile/tracer/emitter
+	icon_state = "emitter"
+	

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -96,6 +96,7 @@
 	icon_state = "scatterlaser"
 	range = 255
 	damage = 6
+	hitscan = FALSE
 
 /obj/projectile/beam/laser/accelerator/Range()
 	..()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -81,6 +81,7 @@
 	tracer_type = /obj/effect/projectile/tracer/disabler
 	muzzle_type = /obj/effect/projectile/muzzle/disabler
 	impact_type = /obj/effect/projectile/impact/disabler
+	hitscan = FALSE
 
 /obj/projectile/beam/pulse
 	name = "pulse"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -14,11 +14,12 @@
 	ricochets_max = 50	//Honk!
 	ricochet_chance = 80
 	reflectable = REFLECT_NORMAL
-
-/obj/projectile/beam/laser
+	hitscan = TRUE
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
+
+/obj/projectile/beam/laser
 
 /obj/projectile/beam/laser/heavylaser
 	name = "heavy laser"
@@ -116,6 +117,9 @@
 	damage = 30
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
+	tracer_type = /obj/effect/projectile/tracer/emitter
+	muzzle_type = /obj/effect/projectile/muzzle/emitter
+	impact_type = /obj/effect/projectile/impact/emitter
 
 /obj/projectile/beam/emitter/singularity_pull()
 	return //don't want the emitters to miss


### PR DESCRIPTION
## About The Pull Request

this makes most laser weapons hitscan, excluding the accelerator laser cannon.

## Why It's Good For The Game

it's not

## Changelog
:cl:
tweak: most laser weapons are now hitscan. Sigh.
/:cl: