### PR TITLE
Small QoL Brig additions

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -78,13 +78,16 @@
 /obj/structure/closet/secure_closet/hos/PopulateContents()
 	..()
 	new /obj/item/card/id/departmental_budget/sec(src) //WaspStation edit - budget card
+	new /obj/item/storage/box/deputy(src) // WaspStation edit - Small QoL Brig additions
 	new /obj/item/clothing/neck/cloak/hos(src)
 	new /obj/item/clothing/under/rank/command(src) // WaspStation edit - better command uniforms
 	new /obj/item/cartridge/hos(src)
+	new /obj/item/radio/headset/heads/hos/alt(src) // WaspStation edit - Small QoL Brig additions
 	new /obj/item/radio/headset/heads/hos(src)
 	new /obj/item/clothing/under/rank/security/head_of_security/parade/female(src)
 	new /obj/item/clothing/under/rank/security/head_of_security/parade(src)
 	new /obj/item/clothing/suit/armor/vest/leather(src)
+	new /obj/item/clothing/suit/armor/hos/trenchcoat(src) // WaspStation edit - Small QoL Brig additions
 	new /obj/item/clothing/suit/armor/hos(src)
 	new /obj/item/clothing/under/rank/security/head_of_security/skirt(src)
 	new /obj/item/clothing/under/rank/security/head_of_security/alt(src)
@@ -129,6 +132,7 @@
 	new /obj/item/storage/box/flashbangs(src)
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/flashlight/seclite(src)
+	new /obj/item/megaphone/sec(src) // WaspStation edit - Small QoL Brig additions
 	new /obj/item/clothing/gloves/krav_maga/sec(src)
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/gun/ballistic/shotgun/automatic/combat/compact(src)

--- a/waspstation/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/waspstation/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -5,6 +5,7 @@
 
 /obj/structure/closet/secure_closet/brig_phys/PopulateContents()
 	..()
+	new /obj/item/defibrillator/loaded(src)
 	new /obj/item/radio/headset/headset_medsec(src)
 	new	/obj/item/storage/firstaid/regular(src)
 	new	/obj/item/storage/firstaid/fire(src)


### PR DESCRIPTION
## About The Pull Request
Few extras added to various sec lockers.

## Why It's Good For The Game
Bunch of small quality of life additions for seccies. Brig Physician doesn't have to rob medbay for their defib. Various items which were only available on some maps are now on them all.

Deputy armbands being on all maps rather than just Delta should result in more people getting promoted without having to be made a full officer.

Warden could really use with a megaphone and the QM has one so I figured why not the Warden too. And the HOS gets spares of items incase they were promoted to that position.

## Changelog
:cl:
add: Brig Physician gets a defibrillator in their locker 
add: Warden's locker now has a megaphone
add: HOS' locker now has a box of deputy armbands, spare trenchcoat and bowmans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
