### PR TITLE
Swapped nukie implants order so you don't have to destroy your firearm auth to get a macrobomb

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -154,10 +154,10 @@
 		var/obj/item/U = new uplink_type(H, H.key, tc)
 		H.equip_to_slot_or_del(U, ITEM_SLOT_BACKPACK)
 
-	var/obj/item/implant/weapons_auth/W = new/obj/item/implant/weapons_auth(H)
-	W.implant(H)
 	var/obj/item/implant/explosive/E = new/obj/item/implant/explosive(H)
 	E.implant(H)
+	var/obj/item/implant/weapons_auth/W = new/obj/item/implant/weapons_auth(H)
+	W.implant(H)
 	H.faction |= ROLE_SYNDICATE
 	H.update_icons()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Implant removal forces you to remove the firearms authentication implant before removing the microbomb. The most common usecase for implant removal is a nukie wanting to add a macrobomb into themselves, and currently it's not possible to do this and still keep an intact firearm auth implant because it is destroyed on removal due to lacking an implant case.

## Why It's Good For The Game
Makes it possible for nukies for swap bomb implants without losing firearm authentication. 

## Changelog
:cl:
tweak: Nuke operative chest implants reversed - now you can remove the microbomb implant without having to scrap the firearm authentication implant. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
