### PR TITLE
Tanks now tell internal mol

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -82,7 +82,7 @@
 			. += "<span class='notice'>If you want any more information you'll need to get closer.</span>"
 		return
 
-	. += "<span class='notice'>The pressure gauge reads [round(src.air_contents.return_pressure(),0.01)] kPa.</span>"
+	. += "<span class='notice'>The gauge reads [round(air_contents.total_moles(), 0.01)] mol at [round(src.air_contents.return_pressure(),0.01)] kPa.</span>"	//yogs can read mols
 
 	var/celsius_temperature = src.air_contents.temperature-T0C
 	var/descriptive


### PR DESCRIPTION
## About The Pull Request

Examining tanks tells you the pressure level but not how many mols of gas it contains. This is quite misleading because mols is actually the more useful number to know so people can keep track of how long their oxygen tank will last. This adds internal mols as an additional measure.

![](https://user-images.githubusercontent.com/5571930/62797834-b11a2c80-baaa-11e9-8eb9-c983fcc244e8.PNG)

## Why It's Good For The Game
Showing mols gives a better estimation of how long your air supply will actually last. It also helps prevent failing the noob trap plasma tank objective which asks you to get 28 mols of plasma. This amount is neither the max you can fill a tank up to nor is it the amount of gas a regular plasma tank starts with. 

## Changelog
:cl:
add: Tanks now show internal mol
/:cl:

Ports: https://github.com/yogstation13/Yogstation/pull/6545
