### PR TITLE
Ghosts can no longer speen

### DIFF
--- a/waspstation/code/modules/mob/emote.dm
+++ b/waspstation/code/modules/mob/emote.dm
@@ -4,8 +4,7 @@
 	key = "speen"
 	key_third_person = "speeeens"
 	restraint_check = TRUE
-	mob_type_allowed_typecache = list(/mob/living, /mob/dead/observer)
-	mob_type_ignore_stat_typecache = list(/mob/dead/observer)
+	mob_type_allowed_typecache = /mob/living
 
 /datum/emote/speen/run_emote(mob/user, params,  type_override, intentional)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
*speen can no longer be emoted by ghosts.

## Why It's Good For The Game
Cringe "observergang" would rather speen around alive players than play, detracting from their RP experience with the intrusive noise.

## Changelog
:cl:
del: Ghosts can no longer *speen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
