### PR TITLE
Makes armor multiplicative

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -32,7 +32,7 @@
 			var/obj/item/clothing/C = bp
 			if(C.body_parts_covered & def_zone.body_part)
 				protection += C.armor.getRating(d_type)
-	protection += physiology.armor.getRating(d_type)
+	protection += physiology.armor.getRating(d_type) * (100 - protection) / 100		// Wasp Edit - Makes armor multiplicative
 	return protection
 
 /mob/living/carbon/human/on_hit(obj/projectile/P)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Makes armor gained from clothing and armor gained from physiology (such as from nanites) stack multiplicatively instead of additively. This will make it harder to reach absurd armor values without reducing the benefit to players who aren't using any other form of armor.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I think this will reduce nanite armor's abuse potential while still leaving it a very viable option for those with and those without other forms of protection. 

## Changelog
:cl:
balance: worn armor and physiological armor stacks multiplicatively
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
