### PR TITLE
Fixes Pubby Disposals

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -16161,21 +16161,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"aQA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aQB" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -26272,6 +26263,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpV" = (
@@ -27575,6 +27567,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsJ" = (
@@ -28128,6 +28121,7 @@
 /obj/item/radio/intercom{
 	pixel_x = 30
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "buj" = (
@@ -28494,22 +28488,22 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bvm" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bvn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -28518,6 +28512,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bvo" = (
@@ -28540,6 +28537,9 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bvp" = (
@@ -28554,6 +28554,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bvq" = (
@@ -45783,6 +45786,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cre" = (
@@ -48169,12 +48175,6 @@
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/plasteel/white,
 /area/engine/gravity_generator)
-"cCO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/security/brig)
 "cCP" = (
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/plasteel/white,
@@ -48839,9 +48839,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
-"ego" = (
-/turf/closed/wall,
-/area/space)
 "egK" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
@@ -49831,6 +49828,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gAG" = (
@@ -50736,10 +50736,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/storage/emergency/port)
-"iGZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
 "iHg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -53421,6 +53417,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "oSc" = (
@@ -80827,7 +80826,7 @@ aAL
 luM
 aAL
 aAL
-aQA
+aHE
 aAL
 aAL
 aTO
@@ -84145,7 +84144,7 @@ apj
 ajM
 ajM
 ajM
-cCO
+ajM
 ajM
 ajM
 avL
@@ -98534,7 +98533,7 @@ aaa
 aaa
 aaa
 aaa
-ego
+aiS
 fbM
 atn
 tgc
@@ -98791,7 +98790,7 @@ aaa
 aaa
 aaa
 aaa
-ego
+aiS
 akn
 atn
 nEz
@@ -99048,7 +99047,7 @@ aaa
 aaa
 aaa
 aaa
-ego
+aiS
 akn
 atn
 atn
@@ -99305,7 +99304,7 @@ aaa
 aaa
 aaa
 aaa
-iGZ
+aiT
 akn
 ajv
 atn
@@ -99562,7 +99561,7 @@ aaa
 aaa
 aaa
 aaa
-iGZ
+aiT
 akn
 ajv
 atn
@@ -99819,7 +99818,7 @@ aaa
 aaa
 aaa
 aaa
-ego
+aiS
 asm
 ajv
 atn
@@ -100076,7 +100075,7 @@ aaa
 aaa
 aaa
 aaa
-iGZ
+aiT
 akn
 ajv
 atn
@@ -100333,7 +100332,7 @@ aaa
 aaa
 aaa
 aaa
-iGZ
+aiT
 akn
 ajv
 atn
@@ -100590,7 +100589,7 @@ aaa
 aaa
 aaa
 aaa
-ego
+aiS
 akn
 ajv
 atn
@@ -100847,7 +100846,7 @@ aaa
 aaa
 aaa
 aaa
-ego
+aiS
 akn
 ajv
 ato
@@ -101104,7 +101103,7 @@ aaa
 aaa
 aaa
 aaa
-ego
+aiS
 asn
 wEb
 ale
@@ -101361,7 +101360,7 @@ aaa
 aaa
 aaa
 aaa
-ego
+aiS
 aiT
 aiT
 aiS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disposal chute in Medbay lobby now properly connects to the disposal line. 

Disposal chute in main hall outside the Janitor closet no longer spits trash in the hall.

Deleted a rogue, singular, disposal pipe that was in a brig wall.

Added the external maint wall by the holodeck in dorms to the Dorm area and not space so it isn't lit up for no reason.

## Why It's Good For The Game

Fixes mapping error

## Changelog
:cl: BigFatAnimeTiddies
fix: Pubbystation blueprints were reviewed and have had the Disposal lines fixed. Janitors rejoice. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
