### PR TITLE
Raises the amount of metacoins you gain for stuff

### DIFF
--- a/code/__DEFINES/~wasp_defines/metacoin.dm
+++ b/code/__DEFINES/~wasp_defines/metacoin.dm
@@ -1,14 +1,14 @@
 /// Rewarded when you complete all your objectives as a traitor
-#define METACOIN_GREENTEXT_REWARD        200
+#define METACOIN_GREENTEXT_REWARD        300
 /// Rewarded when you earn a medal
-#define METACOIN_MEDAL_REWARD            100
+#define METACOIN_MEDAL_REWARD            200
 /// Rewarded when you complete a crew objective
-#define METACOIN_CO_REWARD				40
+#define METACOIN_CO_REWARD				100
 /// Rewarded when you escape on the shuttle
-#define METACOIN_ESCAPE_REWARD           30
+#define METACOIN_ESCAPE_REWARD           100
 /// Rewarded when you survive the round
-#define METACOIN_SURVIVE_REWARD          20
+#define METACOIN_SURVIVE_REWARD          50
 /// Rewarded when you don't survive the round, but stick around till the end
-#define METACOIN_NOTSURVIVE_REWARD       10
+#define METACOIN_NOTSURVIVE_REWARD       30
 /// Rewarded when you are alive and active for 10 minutes
-#define METACOIN_TENMINUTELIVING_REWARD  4
+#define METACOIN_TENMINUTELIVING_REWARD  10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This should change a few of the numbers in metacoin.dm so that people get more metacoins. The new values are 300 for greentext, 200 for medal (apparently according to marg this isn't the station medals, but achievements????), 100 for escaping, 50 for surviving, and 30 for playing the round. As well as 10 metacoins every 10 minutes you're alive. EDIT: Forgot to mention that crew objectives should also give 100 metacoins now. My bad.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should allow people to engage with the loadout system a bit more, since metacoin gain is pretty slow at the moment. Also makes the stuff that costs a ton of coins reasonably purchasable. Tried to not raise it too much so it still encourages participation and sticking around, but feedback is appreciated. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

tweak: Shifted some metacoin gain numbers around so getting them isn't as slow.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
