### PR TITLE
add CMO, RD, CE to protected jobs list for traitor mode

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -38,11 +38,11 @@
 	if(CONFIG_GET(flag/protect_roles_from_antagonist))
 		for(var/id in (CONFIG_GET(keyed_list/no_traitor_head)))
 			switch(id)
-				if("CHIEF_MEDICAL_OFFICER")
+				if("chief_medical_officer")
 					protected_jobs += "Chief Medical Officer"
-				if("RESEARCH_DIRECTOR")
+				if("research_director")
 					protected_jobs += "Research Director"
-				if("CHIEF_ENGINEER")
+				if("chief_engineer")
 					protected_jobs += "Chief Engineer"
 
 	if(CONFIG_GET(flag/protect_assistant_from_antagonist))

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -12,7 +12,7 @@
 	antag_flag = ROLE_TRAITOR
 	false_report_weight = 20 //Reports of traitors are pretty common.
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Brig Physician", "Lieutenant", "Prisoner", "Chief Medical Officer", "Research Director", "Chief Engineer") // Waspstation edit - ALL Heads, Brig Physicians, Second Officer
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Brig Physician", "Lieutenant", "Prisoner")
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4
@@ -36,7 +36,14 @@
 /datum/game_mode/traitor/pre_setup()
 
 	if(CONFIG_GET(flag/protect_roles_from_antagonist))
-		restricted_jobs += protected_jobs
+		for(var/id in (CONFIG_GET(keyed_list/no_traitor_head)))
+			switch(id)
+				if("CHIEF_MEDICAL_OFFICER")
+					protected_jobs += "Chief Medical Officer"
+				if("RESEARCH_DIRECTOR")
+					protected_jobs += "Research Director"
+				if("CHIEF_ENGINEER")
+					protected_jobs += "Chief Engineer"
 
 	if(CONFIG_GET(flag/protect_assistant_from_antagonist))
 		restricted_jobs += "Assistant"

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -12,7 +12,7 @@
 	antag_flag = ROLE_TRAITOR
 	false_report_weight = 20 //Reports of traitors are pretty common.
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Brig Physician", "Lieutenant", "Prisoner") // Waspstation edit - Brig Physicians, Second Officer
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Brig Physician", "Lieutenant", "Prisoner", "Chief Medical Officer", "Research Director", "Chief Engineer", "Quartermaster") // Waspstation edit - ALL Heads, Brig Physicians, Second Officer
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -12,7 +12,7 @@
 	antag_flag = ROLE_TRAITOR
 	false_report_weight = 20 //Reports of traitors are pretty common.
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Brig Physician", "Lieutenant", "Prisoner", "Chief Medical Officer", "Research Director", "Chief Engineer", "Quartermaster") // Waspstation edit - ALL Heads, Brig Physicians, Second Officer
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Brig Physician", "Lieutenant", "Prisoner", "Chief Medical Officer", "Research Director", "Chief Engineer") // Waspstation edit - ALL Heads, Brig Physicians, Second Officer
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -218,6 +218,12 @@ SECURITY_SCALING_COEFF 8
 TRAITOR_OBJECTIVES_AMOUNT 2
 BROTHER_OBJECTIVES_AMOUNT 2
 
+## Whtether or not Dept heads are valid for traitor selection.
+
+NO_TRAITOR_HEAD CHIEF_MEDICAL_OFFICER
+NO_TRAITOR_HEAD RESEARCH_DIRECTOR
+NO_TRAITOR_HEAD CHIEF_ENGINEER
+
 ## Uncomment to prohibit jobs that start with loyalty
 ## implants from being most antagonists.
 PROTECT_ROLES_FROM_ANTAGONIST

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3082,6 +3082,7 @@
 #include "waspstation\code\_onclick\adjacent.dm"
 #include "waspstation\code\_onclick\hud\ghost.dm"
 #include "waspstation\code\controllers\configuration\entries\general.dm"
+#include "waspstation\code\controllers\configuration\entries\game_options.dm"
 #include "waspstation\code\controllers\subsystem\autotransfer.dm"
 #include "waspstation\code\controllers\subsystem\job.dm"
 #include "waspstation\code\controllers\subsystem\minimaps.dm"

--- a/waspstation/code/controllers/configuration/entries/game_options.dm
+++ b/waspstation/code/controllers/configuration/entries/game_options.dm
@@ -1,0 +1,3 @@
+/datum/config_entry/keyed_list/no_traitor_head
+	key_mode = KEY_MODE_TEXT
+	value_mode = VALUE_MODE_FLAG


### PR DESCRIPTION
## About The Pull Request

Adds CMO, RD, and CE, to the banlist for traitor role at roundstart.

## Why It's Good For The Game

People have been bitching about this for awhile, time to see if it survives the vote. Trivial change either way that can be reverted.

## Changelog
:cl:
add: Added Chief Medical Officer, Research Director, and Chief Engineer to `protected_jobs` list for traitor game mode.
/:cl: