### PR TITLE
Makes enviroskirts linked to the suitskirt pref

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -13,9 +13,6 @@
 	new /obj/item/clothing/neck/cloak/ce(src)
 	new /obj/item/clothing/under/rank/engineering/chief_engineer(src)
 	new /obj/item/clothing/under/rank/engineering/chief_engineer/skirt(src)
-	new /obj/item/clothing/under/plasmaman/engineering/ce(src) //WS edit plasmaman customization begin
-	new /obj/item/clothing/under/plasmaman/engineering/ce/skirt(src)
-	new /obj/item/clothing/head/helmet/space/plasmaman/engineering/ce(src) //WS edit plasmaman customization end
 	new /obj/item/clothing/head/hardhat/white(src)
 	new /obj/item/clothing/head/hardhat/weldhat/white(src)
 	new /obj/item/clothing/gloves/color/yellow(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -93,9 +93,6 @@
 	new /obj/item/clothing/suit/toggle/labcoat/cmo(src)
 	new /obj/item/clothing/under/rank/medical/chief_medical_officer(src)
 	new /obj/item/clothing/under/rank/medical/chief_medical_officer/skirt(src)
-	new /obj/item/clothing/under/plasmaman/cmo(src) //WS edit plasmaman customization begin
-	new /obj/item/clothing/under/plasmaman/cmo/skirt(src)
-	new /obj/item/clothing/head/helmet/space/plasmaman/cmo(src) //WS edit plasmaman customization end
 	new /obj/item/clothing/shoes/sneakers/brown	(src)
 	new /obj/item/cartridge/cmo(src)
 	new /obj/item/radio/headset/heads/cmo(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -18,9 +18,6 @@
 	new /obj/item/clothing/under/rank/rnd/research_director/alt/skirt(src)
 	new /obj/item/clothing/under/rank/rnd/research_director/turtleneck(src)
 	new /obj/item/clothing/under/rank/rnd/research_director/turtleneck/skirt(src)
-	new /obj/item/clothing/under/plasmaman/rd(src) //WS edit plasmaman customization begin
-	new /obj/item/clothing/under/plasmaman/rd/skirt(src)
-	new /obj/item/clothing/head/helmet/space/plasmaman/rd(src) //WS edit plasmaman customization end
 	new /obj/item/clothing/shoes/sneakers/brown(src)
 	new /obj/item/cartridge/rd(src)
 	new /obj/item/radio/headset/heads/rd(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -22,9 +22,6 @@
 	new /obj/item/clothing/shoes/sneakers/brown(src)
 	new /obj/item/clothing/under/rank/command/captain(src)
 	new /obj/item/clothing/under/rank/command/captain/skirt(src)
-	new /obj/item/clothing/under/plasmaman/command(src) //WS edit plasmaman customization begin
-	new /obj/item/clothing/under/plasmaman/command/skirt(src)
-	new /obj/item/clothing/head/helmet/space/plasmaman/command(src) //WS edit plasmaman customization end
 	new /obj/item/clothing/suit/armor/vest/capcarapace(src)
 	new /obj/item/clothing/head/caphat(src)
 	new /obj/item/clothing/under/rank/command/captain/parade(src)
@@ -57,9 +54,6 @@
 	new /obj/item/clothing/head/beret/hop(src) //Waspstation edit - More Berets
 	new /obj/item/clothing/under/rank/command/head_of_personnel(src) //WaspStation Edit - Better Command Uniforms
 	new /obj/item/clothing/under/rank/command/head_of_personnel/skirt(src) //WaspStation Edit - Better Command Uniforms
-	new /obj/item/clothing/under/plasmaman/hop(src) //WS edit begin
-	new /obj/item/clothing/under/plasmaman/hop/skirt(src)
-	new /obj/item/clothing/head/helmet/space/plasmaman/hop(src) //WS edit end
 	new /obj/item/clothing/head/hopcap(src)
 	new /obj/item/cartridge/head_of_personnel(src)
 	new /obj/item/radio/headset/heads/head_of_personnel(src)
@@ -99,9 +93,6 @@
 	new /obj/item/clothing/under/rank/security/head_of_security/skirt(src)
 	new /obj/item/clothing/under/rank/security/head_of_security/alt(src)
 	new /obj/item/clothing/under/rank/security/head_of_security/alt/skirt(src)
-	new /obj/item/clothing/under/plasmaman/security/hos(src) //WS edit begin
-	new /obj/item/clothing/under/plasmaman/security/hos/skirt(src)
-	new /obj/item/clothing/head/helmet/space/plasmaman/security/hos(src) //WS edit end
 	new /obj/item/clothing/head/HoS(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses/eyepatch(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses/gars/supergars(src)

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -165,8 +165,8 @@
 		if(PREF_SKIRT)
 			holder = "[O.uniform]/skirt"
 		if(PREF_GREYSUIT)
+			O.head = /obj/item/clothing/head/helmet/space/plasmaman
 			holder = "/obj/item/clothing/under/plasmaman"
-
 		else
 			holder = "[O.uniform]"
 

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -160,7 +160,7 @@
 		if("Clown")
 			O = new /datum/outfit/plasmaman/clown
 
-	var/holder
+	var/holder		// Wasp Edit Begin - Plasma skirtsuit prefs
 	switch(H.jumpsuit_style)
 		if(PREF_SKIRT)
 			holder = "[O.uniform]/skirt"
@@ -171,7 +171,7 @@
 			holder = "[O.uniform]"
 
 	if(text2path(holder))
-		O.uniform = text2path(holder)
+		O.uniform = text2path(holder)		// Wasp Edit End
 
 	H.equipOutfit(O, visualsOnly)
 	H.internal = H.get_item_for_held_index(2)

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -160,6 +160,18 @@
 		if("Clown")
 			O = new /datum/outfit/plasmaman/clown
 
+	var/holder
+	switch(H.jumpsuit_style)
+		if(PREF_SKIRT)
+			holder = "[O.uniform]/skirt"
+		if(PREF_GREYSUIT)
+			holder = /obj/item/clothing/under/plasmaman
+		else
+			holder = "[O.uniform]"
+
+	if(text2path(holder))
+		O.uniform = text2path(holder)
+
 	H.equipOutfit(O, visualsOnly)
 	H.internal = H.get_item_for_held_index(2)
 	H.update_internals_hud_icon(1)

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -165,7 +165,8 @@
 		if(PREF_SKIRT)
 			holder = "[O.uniform]/skirt"
 		if(PREF_GREYSUIT)
-			holder = /obj/item/clothing/under/plasmaman
+			holder = "/obj/item/clothing/under/plasmaman"
+
 		else
 			holder = "[O.uniform]"
 
@@ -222,4 +223,3 @@
 					H.emote("sigh")
 		H.reagents.remove_reagent(chem.type, chem.metabolization_rate)
 		return TRUE
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
kill me

## Why It's Good For The Game
is anything anymore

## Changelog
:cl:
tweak: enviroskirts are now linked to the suitskirt preference
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
