### PR TITLE
Adds sticky tape to vendomat

### DIFF
--- a/code/modules/vending/assist.dm
+++ b/code/modules/vending/assist.dm
@@ -4,6 +4,7 @@
 					/obj/item/assembly/signaler = 4,
 					/obj/item/wirecutters = 1,
 					/obj/item/cartridge/signal = 4,
+					/obj/item/stack/sticky_tape = 4,
 					/obj/item/stock_parts/matter_bin = 3,
 					/obj/item/stock_parts/manipulator = 3,
 					/obj/item/stock_parts/micro_laser = 3,


### PR DESCRIPTION
Does what it says on the tin. Adds four rolls of sticky tape to the vendor, using the default price (125) . I considered changing it to make it lower, but this price should keep one graytider from buying every roll of tape roundstart.