### PR TITLE
Fixes bug with malf AI camera upgrade module

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -728,7 +728,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 	unlock_sound = 'sound/items/rped.ogg'
 
 /datum/AI_Module/upgrade/upgrade_cameras/upgrade(mob/living/silicon/ai/AI)
-	AI.see_override = SEE_INVISIBLE_MINIMUM //Night-vision, without which X-ray would be very limited in power.
+	AI.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE //Night-vision, without which X-ray would be very limited in power.
 	AI.update_sight()
 
 	var/upgraded_cameras = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes a see_invisible value that was being adjusted to be a lighting_alpha value that is adjusted when a malf AI uses the camera upgrades so that it no longer effectively blinds them.

The lighting_alpha value is the same value that nightvision goggles use, so players should be familiar with how things look with it, so that they will still be able to discern lighting levels in an area.

## Why It's Good For The Game

Bugfix

## Changelog
:cl:
fix: Malfunctioning AIs will no longer be effectively blinded when choosing to use the camera upgrade module.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
