### PR TITLE
Fuck windows

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -366,7 +366,7 @@
 	armor = list("melee" = 80, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 25, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 100)
 	max_integrity = 75
 	explosion_block = 1
-	damage_deflection = 11
+	damage_deflection = 5
 	state = RWINDOW_SECURE
 	glass_type = /obj/item/stack/sheet/rglass
 	rad_insulation = RAD_HEAVY_INSULATION
@@ -492,7 +492,7 @@
 	heat_resistance = 50000
 	armor = list("melee" = 80, "bullet" = 20, "laser" = 0, "energy" = 0, "bomb" = 60, "bio" = 100, "rad" = 100, "fire" = 99, "acid" = 100)
 	max_integrity = 500
-	damage_deflection = 21
+	damage_deflection = 11
 	explosion_block = 2
 	glass_type = /obj/item/stack/sheet/plasmarglass
 
@@ -700,7 +700,7 @@
 	smooth = SMOOTH_TRUE
 	canSmoothWith = null
 	explosion_block = 3
-	damage_deflection = 11 //The same as normal reinforced windows.3
+	damage_deflection = 5
 	glass_type = /obj/item/stack/sheet/plastitaniumglass
 	glass_amount = 2
 	rad_insulation = RAD_HEAVY_INSULATION

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -700,7 +700,7 @@
 	smooth = SMOOTH_TRUE
 	canSmoothWith = null
 	explosion_block = 3
-	damage_deflection = 5
+	damage_deflection = 5		// Wasp Edit - Weakens R-Windows
 	glass_type = /obj/item/stack/sheet/plastitaniumglass
 	glass_amount = 2
 	rad_insulation = RAD_HEAVY_INSULATION

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -492,7 +492,7 @@
 	heat_resistance = 50000
 	armor = list("melee" = 80, "bullet" = 20, "laser" = 0, "energy" = 0, "bomb" = 60, "bio" = 100, "rad" = 100, "fire" = 99, "acid" = 100)
 	max_integrity = 500
-	damage_deflection = 11
+	damage_deflection = 11		// Wasp Edit - Weakens R-Windows
 	explosion_block = 2
 	glass_type = /obj/item/stack/sheet/plasmarglass
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -366,7 +366,7 @@
 	armor = list("melee" = 80, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 25, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 100)
 	max_integrity = 75
 	explosion_block = 1
-	damage_deflection = 5
+	damage_deflection = 5		// Wasp Edit - Weakens R-Windows
 	state = RWINDOW_SECURE
 	glass_type = /obj/item/stack/sheet/rglass
 	rad_insulation = RAD_HEAVY_INSULATION


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Fuck windows

Some chuckle fuck thought it was a good idea to make reinforced windows and reinforced plasmawindows robust as shit against damage and I'm taking that away from them, mostly.

Reinforced(and plastitanium) windows had 11 damage deflection, to the smoothbrains reading this; what that means is when you hit the windows ~~it subtracts 11 damage from the attack regardless of the source~~ **eliminates melee damage lower than 11** before its armor value is taken into consideration. This means anything less then a toolbox, which does 12 damage, will do no damage to the window. In comparison; a fire extinguisher does 10 damage, a wrench and crowbar do about 5 damage each, a potted plant does about 10 damage, a chair does 8, etc; little to no actual round start object is capable of breaking a reinforced window other then the tool box and welder. Which is fairly absurd, so I lowered the value or reinforced glass down to a little less then half so that people can actually break into places if they need too, but will still take some time to get through. 

I also did the same with reinforced plasma glass, as it was effectively immune to damage with its damage deflection of 21, I lowered it to 11, meaning only the fire axe is able to break through it. By lowering it its making it possible to break but still very annoying to do so.

## Why It's Good For The Game

Theres alot of instances where breaking into or out of places is possibly the only option you have, and by making windows nearly unbreakable limits the choices you have, and by lowering the value it offers some more possibilities for traitors to do potential traitor shinanigains.

## Changelog
:cl:
Balance: Reduced reinforced, plasma, and reinforced plasma glass damage deflection.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Edit by @Superyodeler: Corrected damage deflection, clarifies Balance, removed Removes: Mark. 