### PR TITLE
just cargo things

### DIFF
--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -71,6 +71,15 @@
 	grind_results = list(/datum/reagent/bluespace = 20)
 	point_value = 30
 	var/crystal_type = /obj/item/stack/ore/bluespace_crystal/refined
+	
+/obj/item/stack/sheet/bluespace_crystal/fifty
+	amount = 50
+
+/obj/item/stack/sheet/bluespace_crystal/twenty
+	amount = 20
+
+/obj/item/stack/sheet/bluespace_crystal/five
+	amount = 5
 
 /obj/item/stack/sheet/bluespace_crystal/attack_self(mob/user)// to prevent the construction menu from ever happening
 	to_chat(user, "<span class='warning'>You cannot crush the polycrystal in-hand, try breaking one off.</span>")

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -117,6 +117,15 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 /obj/item/stack/sheet/mineral/diamond/get_main_recipes()
 	. = ..()
 	. += GLOB.diamond_recipes
+	
+/obj/item/stack/sheet/mineral/diamond/fifty
+	amount = 50
+
+/obj/item/stack/sheet/mineral/diamond/twenty
+	amount = 20
+
+/obj/item/stack/sheet/mineral/diamond/five
+	amount = 5
 
 /*
  * Uranium
@@ -145,6 +154,15 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 /obj/item/stack/sheet/mineral/uranium/get_main_recipes()
 	. = ..()
 	. += GLOB.uranium_recipes
+	
+/obj/item/stack/sheet/mineral/uranium/fifty
+	amount = 50
+
+/obj/item/stack/sheet/mineral/uranium/twenty
+	amount = 20
+
+/obj/item/stack/sheet/mineral/uranium/five
+	amount = 5
 
 /*
  * Plasma
@@ -190,6 +208,15 @@ GLOBAL_LIST_INIT(plasma_recipes, list ( \
 /obj/item/stack/sheet/mineral/plasma/fire_act(exposed_temperature, exposed_volume)
 	atmos_spawn_air("plasma=[amount*10];TEMP=[exposed_temperature]")
 	qdel(src)
+	
+/obj/item/stack/sheet/mineral/plasma/fifty
+	amount = 50
+
+/obj/item/stack/sheet/mineral/plasma/twenty
+	amount = 20
+
+/obj/item/stack/sheet/mineral/plasma/five
+	amount = 5
 
 /*
  * Gold
@@ -222,6 +249,15 @@ GLOBAL_LIST_INIT(gold_recipes, list ( \
 	. = ..()
 	. += GLOB.gold_recipes
 
+/obj/item/stack/sheet/mineral/gold/fifty
+	amount = 50
+
+/obj/item/stack/sheet/mineral/gold/twenty
+	amount = 20
+
+/obj/item/stack/sheet/mineral/gold/five
+	amount = 5
+
 /*
  * Silver
  */
@@ -252,6 +288,15 @@ GLOBAL_LIST_INIT(silver_recipes, list ( \
 /obj/item/stack/sheet/mineral/silver/get_main_recipes()
 	. = ..()
 	. += GLOB.silver_recipes
+	
+/obj/item/stack/sheet/mineral/silver/fifty
+	amount = 50
+
+/obj/item/stack/sheet/mineral/silver/twenty
+	amount = 20
+
+/obj/item/stack/sheet/mineral/silver/five
+	amount = 5
 
 /*
  * Clown
@@ -309,6 +354,12 @@ GLOBAL_LIST_INIT(titanium_recipes, list ( \
 
 /obj/item/stack/sheet/mineral/titanium/fifty
 	amount = 50
+	
+/obj/item/stack/sheet/mineral/titanium/twenty
+	amount = 20
+
+/obj/item/stack/sheet/mineral/titanium/five
+	amount = 5
 
 /*
  * Plastitanium

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -459,12 +459,9 @@
 	item_state = "duffel-syndiemed"
 
 /obj/item/storage/backpack/duffelbag/syndie/surgery/PopulateContents()
-	new /obj/item/scalpel(src)
-	new /obj/item/hemostat(src)
-	new /obj/item/retractor(src)
-	new /obj/item/circular_saw(src)
-	new /obj/item/surgicaldrill(src)
-	new /obj/item/cautery(src)
+	new /obj/item/surgicaldrill/advanced(src)
+	new /obj/item/scalpel/advanced(src)
+	new /obj/item/retractor/advanced(src)
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
 	new /obj/item/mmi/syndie(src)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -210,7 +210,7 @@
 
 /datum/supply_pack/emergency/spacesuit
 	name = "Space Suit Crate"
-	desc = "Contains one aging suit from Space-Goodwill and a jetpack. Requires EVA access to open."
+	desc = "Contains one aging suit from Space-Goodwill. Requires EVA access to open."
 	cost = 2500
 	access = ACCESS_EVA
 	contains = list(/obj/item/clothing/suit/space,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -215,8 +215,7 @@
 	access = ACCESS_EVA
 	contains = list(/obj/item/clothing/suit/space,
 					/obj/item/clothing/head/helmet/space,
-					/obj/item/clothing/mask/breath,
-					/obj/item/tank/jetpack/carbondioxide)
+					/obj/item/clothing/mask/breath)
 	crate_name = "space suit crate"
 	crate_type = /obj/structure/closet/crate/secure
 
@@ -443,7 +442,7 @@
 /datum/supply_pack/security/armory/chemimp
 	name = "Chemical Implants Crate"
 	desc = "Contains five Remote Chemical implants. Requires Armory access to open."
-	cost = 2000
+	cost = 1000
 	contains = list(/obj/item/storage/box/chemimp)
 	crate_name = "chemical implant crate"
 
@@ -1104,6 +1103,7 @@
 	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
 	crate_name = "BZ canister crate"
 	crate_type = /obj/structure/closet/crate/secure/science
+	dangerous = TRUE
 
 /datum/supply_pack/materials/carbon_dio
 	name = "Carbon Dioxide Canister"
@@ -1140,7 +1140,7 @@
 /datum/supply_pack/materials/nitrogen
 	name = "Nitrogen Canister"
 	desc = "Contains a canister of Nitrogen."
-	cost = 2000
+	cost = 1000
 	contains = list(/obj/machinery/portable_atmospherics/canister/nitrogen)
 	crate_name = "nitrogen canister crate"
 	crate_type = /obj/structure/closet/crate/large
@@ -1153,11 +1153,12 @@
 	contains = list(/obj/machinery/portable_atmospherics/canister/nitrous_oxide)
 	crate_name = "nitrous oxide canister crate"
 	crate_type = /obj/structure/closet/crate/secure
+	dangerous = TRUE
 
 /datum/supply_pack/materials/oxygen
 	name = "Oxygen Canister"
 	desc = "Contains a canister of Oxygen. Canned in Druidia."
-	cost = 1500
+	cost = 1000
 	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
 	crate_name = "oxygen canister crate"
 	crate_type = /obj/structure/closet/crate/large
@@ -1189,7 +1190,7 @@
 /datum/supply_pack/medical/bloodpacks
 	name = "Blood Pack Variety Crate"
 	desc = "Contains eight different blood packs for reintroducing blood to patients."
-	cost = 3500
+	cost = 1000
 	contains = list(/obj/item/reagent_containers/blood,
 					/obj/item/reagent_containers/blood,
 					/obj/item/reagent_containers/blood/APlus,
@@ -1242,7 +1243,7 @@
 /datum/supply_pack/medical/defibs
 	name = "Defibrillator Crate"
 	desc = "Contains two defibrillators for bringing the recently deceased back to life."
-	cost = 2500
+	cost = 1500
 	contains = list(/obj/item/defibrillator/loaded,
 					/obj/item/defibrillator/loaded)
 	crate_name = "defibrillator crate"
@@ -1409,7 +1410,7 @@
 /datum/supply_pack/science/rped
 	name = "RPED crate"
 	desc = "Need to rebuild the ORM but science got annihialted after a bomb test? Buy this for the most advanced parts NT can give you."
-	cost = 1500
+	cost = 1000
 	contains = list(/obj/item/storage/part_replacer/cargo)
 	crate_name = "\improper RPED crate"
 
@@ -1453,7 +1454,7 @@
 /datum/supply_pack/service/cargo_supples
 	name = "Cargo Supplies Crate"
 	desc = "Sold everything that wasn't bolted down? You can get right back to work with this crate containing stamps, an export scanner, destination tagger, hand labeler and some package wrapping."
-	cost = 1000
+	cost = 800
 	contains = list(/obj/item/stamp,
 					/obj/item/stamp/denied,
 					/obj/item/export_scanner,
@@ -1549,7 +1550,7 @@
 /datum/supply_pack/service/carpet_exotic
 	name = "Exotic Carpet Crate"
 	desc = "Exotic carpets straight from Space Russia, for all your decorating needs. Contains 100 tiles each of 8 different flooring patterns."
-	cost = 4000
+	cost = 3000
 	contains = list(/obj/item/stack/tile/carpet/blue/fifty,
 					/obj/item/stack/tile/carpet/blue/fifty,
 					/obj/item/stack/tile/carpet/cyan/fifty,

--- a/waspstation/code/modules/cargo/packs.dm
+++ b/waspstation/code/modules/cargo/packs.dm
@@ -78,7 +78,7 @@
 					/obj/item/construction/rcd,
 					/obj/item/pipe_dispenser,
 					/obj/item/lightreplacer)
-	cost = 3000
+	cost = 5000
 	crate_name = "advanced engineering tools crate"
 	dangerous = TRUE
 

--- a/waspstation/code/modules/cargo/packs.dm
+++ b/waspstation/code/modules/cargo/packs.dm
@@ -82,13 +82,6 @@
 	crate_name = "advanced engineering tools crate"
 	dangerous = TRUE
 
-/datum/supply_pack/service/vending/engivend
-	name = "EngiVend Supply Crate"
-	desc = "The engineers are out of metal foam grenades? This should help."
-	cost = 2000
-	contains = list(/obj/item/vending_refill/engivend)
-	crate_name = "engineering supply crate"
-
 /datum/supply_pack/materials/plasma20
 	name = "20 Plasma Sheets"
 	desc = "Your supposed to be mining this, not buying it."

--- a/waspstation/code/modules/cargo/packs.dm
+++ b/waspstation/code/modules/cargo/packs.dm
@@ -19,6 +19,214 @@
 					/obj/item/storage/belt/bandolier)
 	crate_name = "shotguns crate"
 	dangerous = TRUE
+	
+/datum/supply_pack/security/hardsuit
+	name = "Security Hardsuit Crate"
+	desc = "Contains a security hardsuit for catching criminals in space! Requires Security access to open."
+	cost = 3500
+	contains = list(/obj/item/clothing/suit/space/hardsuit/security)
+	crate_name = "security hardsuit crate"
+
+/datum/supply_pack/security/hardsuit3
+	name = "Bulk Security Hardsuit Crate"
+	desc = "Contains three security hardsuits for catching criminals in space! Requires Security access to open."
+	cost = 10000
+	contains = list(/obj/item/clothing/suit/space/hardsuit/security,
+					/obj/item/clothing/suit/space/hardsuit/security,
+					/obj/item/clothing/suit/space/hardsuit/security)
+	crate_name = "bulk security hardsuit crate"
+	
+/datum/supply_pack/engineering/hardsuit
+	name = "Engineering Hardsuit Crate"
+	desc = "Who took all the damn hardsuits? Not a problem, for some money we can hook you up with another hardsuit!"
+	cost = 3500
+	access = ACCESS_ENGINE
+	contains = list(/obj/item/clothing/suit/space/hardsuit/engine)
+	crate_name = "engineering hardsuit crate"
+
+/datum/supply_pack/engineering/hardsuit3
+	name = "Bulk Engineering Hardsuit Crate"
+	desc = "All the engineers with hardsuits walk into the SM or die to space carp, not a problem!, for some money we can hook you up with more hardsuits!"
+	cost = 10000
+	access = ACCESS_ENGINE
+	contains = list(/obj/item/clothing/suit/space/hardsuit/engine,
+					/obj/item/clothing/suit/space/hardsuit/engine,
+					/obj/item/clothing/suit/space/hardsuit/engine)
+	crate_name = "bulk engineering hardsuit crate"
+
+/datum/supply_pack/engineering/atmossuit
+	name = "Atmospherics Hardsuit Crate"
+	desc = "Atmospherics hardsuit suspiciously missing with multiple plasma fires throughout the station?, This hardsuit can help with that! They do cost a fair bit because of the materials required to insulate them. Requires engineering access to open."
+	cost = 8000
+	access = ACCESS_ATMOSPHERICS
+	contains = list(/obj/item/clothing/suit/space/hardsuit/engine/atmos)
+	crate_name = "atmospherics hardsuit crate"
+
+/datum/supply_pack/engineering/jetpack
+	name = "Jetpack Crate"
+	desc = "For when you need to go fast in space."
+	cost = 2000
+	contains = list(/obj/item/tank/jetpack/carbondioxide)
+	crate_name = "jetpack crate"
+	
+/datum/supply_pack/engineering/advtools
+	name = "Advanced Engineering Tools Crate"
+	desc = "A set of advanced engineering tools."
+	contains = list(/obj/item/crowbar/power,
+					/obj/item/weldingtool/experimental,
+					/obj/item/screwdriver/power,
+					/obj/item/construction/rcd,
+					/obj/item/pipe_dispenser,
+					/obj/item/lightreplacer)
+	cost = 3000
+	crate_name = "advanced engineering tools crate"
+	dangerous = TRUE
+	
+/datum/supply_pack/service/vending/engivend
+	name = "EngiVend Supply Crate"
+	desc = "The engineers are out of metal foam grenades? This should help."
+	cost = 2000
+	contains = list(/obj/item/vending_refill/engivend)
+	crate_name = "engineering supply crate"
+	
+/datum/supply_pack/materials/glass250
+	name = "250 Glass Sheets"
+	desc = "Holy SHEET thats a lot of glass."
+	cost = 5000
+	contains = list(/obj/item/stack/sheet/glass/fifty,
+					/obj/item/stack/sheet/glass/fifty,
+					/obj/item/stack/sheet/glass/fifty,
+					/obj/item/stack/sheet/glass/fifty,
+					/obj/item/stack/sheet/glass/fifty)
+	crate_name = "bulk glass sheets crate"
+	
+/datum/supply_pack/materials/iron250
+	name = "250 Iron Sheets"
+	desc = "Enough Iron to rebuild an entire station!"
+	cost = 5000
+	contains = list(/obj/item/stack/sheet/iron/fifty,
+					/obj/item/stack/sheet/iron/fifty,
+					/obj/item/stack/sheet/iron/fifty,
+					/obj/item/stack/sheet/iron/fifty,
+					/obj/item/stack/sheet/iron/fifty)
+	crate_name = "bulk iron sheets crate"
+	
+/datum/supply_pack/materials/plasma20
+	name = "20 Plasma Sheets"
+	desc = "Your supposed to be mining this, not buying it."
+	cost = 6000
+	contains = list(/obj/item/stack/sheet/mineral/plasma/twenty)
+	crate_name = "plasma sheets crate"
+
+/datum/supply_pack/materials/plasma50
+	name = "50 Plasma Sheets"
+	desc = "Your supposed to be mining this, not buying it."
+	cost = 15000
+	contains = list(/obj/item/stack/sheet/mineral/plasma/fifty)
+	crate_name = "bulk plasma sheets crate"
+	
+/datum/supply_pack/materials/silver20
+	name = "20 Silver Sheets"
+	desc = "Somewhat less shiny."
+	cost = 3000
+	contains = list(/obj/item/stack/sheet/mineral/silver/twenty)
+	crate_name = "silver sheets crate"
+
+/datum/supply_pack/materials/silver50
+	name = "50 Silver Sheets"
+	desc = "Somewhat less shiny."
+	cost = 7500
+	contains = list(/obj/item/stack/sheet/mineral/silver/fifty)
+	crate_name = "bulk silver sheets crate"
+	
+/datum/supply_pack/materials/gold20
+	name = "20 Gold Sheets"
+	desc = "Shiny."
+	cost = 4000
+	contains = list(/obj/item/stack/sheet/mineral/gold/twenty)
+	crate_name = "gold sheets crate"
+
+/datum/supply_pack/materials/gold50
+	name = "50 Gold Sheets"
+	desc = "Shiny."
+	cost = 10000
+	contains = list(/obj/item/stack/sheet/mineral/gold/fifty)
+	crate_name = "bulk gold sheets crate"
+	
+/datum/supply_pack/materials/uranium20
+	name = "20 Uranium Sheets"
+	desc = "Green rock make thog puke red."
+	cost = 4000
+	contains = list(/obj/item/stack/sheet/mineral/uranium/twenty)
+	crate_name = "uranium sheets crate"
+
+/datum/supply_pack/materials/uranium50
+	name = "50 Uranium Sheets"
+	desc = "Green rock make thog puke red."
+	cost = 10000
+	contains = list(/obj/item/stack/sheet/mineral/uranium/fifty)
+	crate_name = "bulk uranium sheets crate"
+	
+/datum/supply_pack/materials/titanium20
+	name = "20 Titanium Sheets"
+	desc = "Used for making big boy tanks and tools."
+	cost = 4000
+	contains = list(/obj/item/stack/sheet/mineral/titanium/twenty)
+	crate_name = "titanium sheets crate"
+
+/datum/supply_pack/materials/titanium50
+	name = "50 Titanium Sheets"
+	desc = "Used for making big boy tanks and tools."
+	cost = 1000
+	contains = list(/obj/item/stack/sheet/mineral/titanium/fifty)
+	crate_name = "titanium sheets crate"
+	
+/datum/supply_pack/materials/diamond
+	name = "A Diamond"
+	desc = "Impress your girl with this one!"
+	cost = 3500
+	contains = list(/obj/item/stack/sheet/mineral/diamond)
+	crate_name = "diamond sheet crate"
+
+/datum/supply_pack/materials/diamond5
+	name = "5 Diamonds"
+	desc = "If you like high technology, these materials can help!"
+	cost = 17500
+	contains = list(/obj/item/stack/sheet/mineral/diamond/five)
+	crate_name = "bulk diamond sheets crate"
+	
+/datum/supply_pack/medical/syringegun
+	name = "Syringe Gun Crate"
+	desc = "Contains a syringe guns. Requires chemistry access to open."
+	cost = 1000
+	access = ACCESS_CHEMISTRY
+	contains = list(/obj/item/gun/syringe)
+	crate_name = "syringe gun crate"
+	
+/datum/supply_pack/medical/synthflesh
+	name = "Synthflesh resupply pack"
+	desc = "Contains two 100u cartons of synthflesh, suitable for use in cloning machines."
+	cost = 2000
+	contains = list(/obj/item/reagent_containers/food/drinks/bottle/synthflesh,
+					/obj/item/reagent_containers/food/drinks/bottle/synthflesh)
+	crate_name = "rusty freezer"
+	crate_type = /obj/structure/closet/crate/freezer
+	
+/datum/supply_pack/medical/hardsuit
+	name = "Medical Hardsuit Crate"
+	desc = "A medical hardsuit resistant to diseases and useful for retrieving patients in space! Requires medical access to open."
+	cost = 5000
+	access = ACCESS_MEDICAL
+	contains = list(/obj/item/clothing/suit/space/hardsuit/medical)
+	crate_name = "medical hardsuit crate"
+	
+/datum/supply_pack/science/hardsuit
+	name = "Science Hardsuit Crate"
+	desc = "A science hardsuit for added safety during explosives test or for scientific activies outside of the station! Requires science access to open."
+	cost = 7500
+	access = ACCESS_RESEARCH
+	contains = list(/obj/item/clothing/suit/space/hardsuit/rd)
+	crate_name = "science hardsuit crate"
 
 /datum/supply_pack/costumes_toys/foamforce/vintage_foamforce
 	name = "Emmet's Vintage Heater Crate"
@@ -78,7 +286,7 @@
 	name = "Uplink Rechargement Crate"
 	desc = "^#!$&EVERYBODY WANTS MORE FANCY SOUVENIRS. OUR TELE-CRYSTAL REFINERY IS WILLING TO FULFILL A RUSH ORDER, BUT AT A BIT OF A PREMIUM. MAYBE BE A BIT MORE STINGY IN THE FUTURE!$*&@#@"
 	hidden = TRUE
-	cost = 15700
+	cost = 7500
 	contains = list(/obj/item/stack/telecrystal)
 	crate_name = "wizard costume crate"
 	crate_type = /obj/structure/closet/crate/wooden

--- a/waspstation/code/modules/cargo/packs.dm
+++ b/waspstation/code/modules/cargo/packs.dm
@@ -38,7 +38,7 @@
 
 /datum/supply_pack/engineering/hardsuit
 	name = "Engineering Hardsuit Crate"
-	desc = "Who took all the damn hardsuits? Not a problem, for some money we can hook you up with another hardsuit!"
+	desc = "Who took all the damn hardsuits? Not a problem, for some money, we can hook you up with another hardsuit!"
 	cost = 3500
 	access = ACCESS_ENGINE
 	contains = list(/obj/item/clothing/suit/space/hardsuit/engine)
@@ -46,7 +46,7 @@
 
 /datum/supply_pack/engineering/hardsuit3
 	name = "Bulk Engineering Hardsuit Crate"
-	desc = "All the engineers with hardsuits walk into the SM or die to space carp, not a problem!, for some money we can hook you up with more hardsuits!"
+	desc = "All the engineers with hardsuits walk into the SM or die to space carp? Not a problem! For a small fee we can hook you up with more hardsuits!"
 	cost = 10000
 	access = ACCESS_ENGINE
 	contains = list(/obj/item/clothing/suit/space/hardsuit/engine,
@@ -69,29 +69,16 @@
 	contains = list(/obj/item/tank/jetpack/carbondioxide)
 	crate_name = "jetpack crate"
 
-/datum/supply_pack/engineering/advtools
-	name = "Advanced Engineering Tools Crate"
-	desc = "A set of advanced engineering tools."
-	contains = list(/obj/item/crowbar/power,
-					/obj/item/weldingtool/experimental,
-					/obj/item/screwdriver/power,
-					/obj/item/construction/rcd,
-					/obj/item/pipe_dispenser,
-					/obj/item/lightreplacer)
-	cost = 5000
-	crate_name = "advanced engineering tools crate"
-	dangerous = TRUE
-
 /datum/supply_pack/materials/plasma20
 	name = "20 Plasma Sheets"
-	desc = "Your supposed to be mining this, not buying it."
+	desc = "You're supposed to be mining this, not buying it."
 	cost = 6000
 	contains = list(/obj/item/stack/sheet/mineral/plasma/twenty)
 	crate_name = "plasma sheets crate"
 
 /datum/supply_pack/materials/plasma50
 	name = "50 Plasma Sheets"
-	desc = "Your supposed to be mining this, not buying it."
+	desc = "You're supposed to be mining this, not buying it."
 	cost = 15000
 	contains = list(/obj/item/stack/sheet/mineral/plasma/fifty)
 	crate_name = "bulk plasma sheets crate"
@@ -161,14 +148,14 @@
 
 /datum/supply_pack/materials/diamond5
 	name = "5 Diamonds"
-	desc = "If you like high technology, these materials can help!"
+	desc = "If you like nice technology, this can help as well!"
 	cost = 17500
 	contains = list(/obj/item/stack/sheet/mineral/diamond/five)
 	crate_name = "bulk diamond sheets crate"
 
 /datum/supply_pack/medical/syringegun
 	name = "Syringe Gun Crate"
-	desc = "Contains a syringe guns. Requires chemistry access to open."
+	desc = "Contains a syringe gun. Requires chemistry access to open."
 	cost = 1000
 	access = ACCESS_CHEMISTRY
 	contains = list(/obj/item/gun/syringe)

--- a/waspstation/code/modules/cargo/packs.dm
+++ b/waspstation/code/modules/cargo/packs.dm
@@ -19,7 +19,7 @@
 					/obj/item/storage/belt/bandolier)
 	crate_name = "shotguns crate"
 	dangerous = TRUE
-	
+
 /datum/supply_pack/security/hardsuit
 	name = "Security Hardsuit Crate"
 	desc = "Contains a security hardsuit for catching criminals in space! Requires Security access to open."
@@ -35,7 +35,7 @@
 					/obj/item/clothing/suit/space/hardsuit/security,
 					/obj/item/clothing/suit/space/hardsuit/security)
 	crate_name = "bulk security hardsuit crate"
-	
+
 /datum/supply_pack/engineering/hardsuit
 	name = "Engineering Hardsuit Crate"
 	desc = "Who took all the damn hardsuits? Not a problem, for some money we can hook you up with another hardsuit!"
@@ -68,7 +68,7 @@
 	cost = 2000
 	contains = list(/obj/item/tank/jetpack/carbondioxide)
 	crate_name = "jetpack crate"
-	
+
 /datum/supply_pack/engineering/advtools
 	name = "Advanced Engineering Tools Crate"
 	desc = "A set of advanced engineering tools."
@@ -81,36 +81,14 @@
 	cost = 3000
 	crate_name = "advanced engineering tools crate"
 	dangerous = TRUE
-	
+
 /datum/supply_pack/service/vending/engivend
 	name = "EngiVend Supply Crate"
 	desc = "The engineers are out of metal foam grenades? This should help."
 	cost = 2000
 	contains = list(/obj/item/vending_refill/engivend)
 	crate_name = "engineering supply crate"
-	
-/datum/supply_pack/materials/glass250
-	name = "250 Glass Sheets"
-	desc = "Holy SHEET thats a lot of glass."
-	cost = 5000
-	contains = list(/obj/item/stack/sheet/glass/fifty,
-					/obj/item/stack/sheet/glass/fifty,
-					/obj/item/stack/sheet/glass/fifty,
-					/obj/item/stack/sheet/glass/fifty,
-					/obj/item/stack/sheet/glass/fifty)
-	crate_name = "bulk glass sheets crate"
-	
-/datum/supply_pack/materials/iron250
-	name = "250 Iron Sheets"
-	desc = "Enough Iron to rebuild an entire station!"
-	cost = 5000
-	contains = list(/obj/item/stack/sheet/iron/fifty,
-					/obj/item/stack/sheet/iron/fifty,
-					/obj/item/stack/sheet/iron/fifty,
-					/obj/item/stack/sheet/iron/fifty,
-					/obj/item/stack/sheet/iron/fifty)
-	crate_name = "bulk iron sheets crate"
-	
+
 /datum/supply_pack/materials/plasma20
 	name = "20 Plasma Sheets"
 	desc = "Your supposed to be mining this, not buying it."
@@ -124,7 +102,7 @@
 	cost = 15000
 	contains = list(/obj/item/stack/sheet/mineral/plasma/fifty)
 	crate_name = "bulk plasma sheets crate"
-	
+
 /datum/supply_pack/materials/silver20
 	name = "20 Silver Sheets"
 	desc = "Somewhat less shiny."
@@ -138,7 +116,7 @@
 	cost = 7500
 	contains = list(/obj/item/stack/sheet/mineral/silver/fifty)
 	crate_name = "bulk silver sheets crate"
-	
+
 /datum/supply_pack/materials/gold20
 	name = "20 Gold Sheets"
 	desc = "Shiny."
@@ -152,7 +130,7 @@
 	cost = 10000
 	contains = list(/obj/item/stack/sheet/mineral/gold/fifty)
 	crate_name = "bulk gold sheets crate"
-	
+
 /datum/supply_pack/materials/uranium20
 	name = "20 Uranium Sheets"
 	desc = "Green rock make thog puke red."
@@ -166,7 +144,7 @@
 	cost = 10000
 	contains = list(/obj/item/stack/sheet/mineral/uranium/fifty)
 	crate_name = "bulk uranium sheets crate"
-	
+
 /datum/supply_pack/materials/titanium20
 	name = "20 Titanium Sheets"
 	desc = "Used for making big boy tanks and tools."
@@ -180,7 +158,7 @@
 	cost = 1000
 	contains = list(/obj/item/stack/sheet/mineral/titanium/fifty)
 	crate_name = "titanium sheets crate"
-	
+
 /datum/supply_pack/materials/diamond
 	name = "A Diamond"
 	desc = "Impress your girl with this one!"
@@ -194,7 +172,7 @@
 	cost = 17500
 	contains = list(/obj/item/stack/sheet/mineral/diamond/five)
 	crate_name = "bulk diamond sheets crate"
-	
+
 /datum/supply_pack/medical/syringegun
 	name = "Syringe Gun Crate"
 	desc = "Contains a syringe guns. Requires chemistry access to open."
@@ -202,16 +180,7 @@
 	access = ACCESS_CHEMISTRY
 	contains = list(/obj/item/gun/syringe)
 	crate_name = "syringe gun crate"
-	
-/datum/supply_pack/medical/synthflesh
-	name = "Synthflesh resupply pack"
-	desc = "Contains two 100u cartons of synthflesh, suitable for use in cloning machines."
-	cost = 2000
-	contains = list(/obj/item/reagent_containers/food/drinks/bottle/synthflesh,
-					/obj/item/reagent_containers/food/drinks/bottle/synthflesh)
-	crate_name = "rusty freezer"
-	crate_type = /obj/structure/closet/crate/freezer
-	
+
 /datum/supply_pack/medical/hardsuit
 	name = "Medical Hardsuit Crate"
 	desc = "A medical hardsuit resistant to diseases and useful for retrieving patients in space! Requires medical access to open."
@@ -219,7 +188,7 @@
 	access = ACCESS_MEDICAL
 	contains = list(/obj/item/clothing/suit/space/hardsuit/medical)
 	crate_name = "medical hardsuit crate"
-	
+
 /datum/supply_pack/science/hardsuit
 	name = "Science Hardsuit Crate"
 	desc = "A science hardsuit for added safety during explosives test or for scientific activies outside of the station! Requires science access to open."
@@ -291,7 +260,7 @@
 	crate_name = "wizard costume crate"
 	crate_type = /obj/structure/closet/crate/wooden
 	dangerous = TRUE
-	
+
 /datum/supply_pack/medical/evilsurgery
 	name = "Super Surgical Supplies Crate"
 	desc = "Do you want to perform surgery, but DO have one of those fancy shmancy degrees? This could be just what you need to properly up your game."

--- a/waspstation/code/modules/cargo/packs.dm
+++ b/waspstation/code/modules/cargo/packs.dm
@@ -23,14 +23,14 @@
 /datum/supply_pack/security/hardsuit
 	name = "Security Hardsuit Crate"
 	desc = "Contains a security hardsuit for catching criminals in space! Requires Security access to open."
-	cost = 3500
+	cost = 4500
 	contains = list(/obj/item/clothing/suit/space/hardsuit/security)
 	crate_name = "security hardsuit crate"
 
 /datum/supply_pack/security/hardsuit3
 	name = "Bulk Security Hardsuit Crate"
 	desc = "Contains three security hardsuits for catching criminals in space! Requires Security access to open."
-	cost = 10000
+	cost = 11000
 	contains = list(/obj/item/clothing/suit/space/hardsuit/security,
 					/obj/item/clothing/suit/space/hardsuit/security,
 					/obj/item/clothing/suit/space/hardsuit/security)
@@ -177,7 +177,7 @@
 /datum/supply_pack/medical/hardsuit
 	name = "Medical Hardsuit Crate"
 	desc = "A medical hardsuit resistant to diseases and useful for retrieving patients in space! Requires medical access to open."
-	cost = 5000
+	cost = 4000
 	access = ACCESS_MEDICAL
 	contains = list(/obj/item/clothing/suit/space/hardsuit/medical)
 	crate_name = "medical hardsuit crate"

--- a/waspstation/code/modules/cargo/packs.dm
+++ b/waspstation/code/modules/cargo/packs.dm
@@ -291,6 +291,17 @@
 	crate_name = "wizard costume crate"
 	crate_type = /obj/structure/closet/crate/wooden
 	dangerous = TRUE
+	
+/datum/supply_pack/medical/evilsurgery
+	name = "Super Surgical Supplies Crate"
+	desc = "Do you want to perform surgery, but DO have one of those fancy shmancy degrees? This could be just what you need to properly up your game."
+	hidden = TRUE
+	cost = 6500
+	contains = list(/obj/item/storage/backpack/duffelbag/syndie/surgery,
+					/obj/item/storage/firstaid/tactical,
+					/obj/item/reagent_containers/medigel/sterilizine,
+					/obj/item/roller)
+	dangerous = TRUE
 
 /datum/supply_pack/costumes_toys/wardrobe/evil
 	name = "Waffle Corporation Fashion Crate"


### PR DESCRIPTION
## About The Pull Request

god i love powercreep, and i love Spam, and Spam is what is being cooked right now, so lets just get down to brass tacks

you can buy more things from cargo now, including...

the stuff on the CE's belt
certain departmental hardsuits
jetpacks
mats crates (hey mark remember those rounds on NSV when the ore silo didn't exist so cargo just got a huge trash bag of materials) 
BS crystals are not purchasable, so no spamming BSMs
bulk options
the telecrystal crate is no longer overpriced as fuck, you still probably aren't going to be buying revolvers for the entire station like it's Rimworld
the big bad surgical kit

also the big bad surgical kit (the one in the uplink) is no longer a waste of telecrystals

## Why It's Good For The Game

cargo will eventually begin to buy things other than guns and mindshields, and step one is to secure the keys

## Changelog
:cl:
add: a bunch of cargo crates
tweak: also the traitor surgical kit is actually useful
/:cl: