### PR TITLE
removes wishgranter

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -27,13 +27,6 @@
 	description = "WELCOME TO CLOWN PLANET! HONK HONK HONK etc.!"
 	suffix = "lavaland_biodome_clown_planet.dmm"
 
-/datum/map_template/ruin/lavaland/cube
-	name = "The Wishgranter Cube"
-	id = "wishgranter-cube"
-	description = "Nothing good can come from this. Learn from their mistakes and turn around."
-	suffix = "lavaland_surface_cube.dmm"
-	cost = 10
-	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/seed_vault
 	name = "Seed Vault"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Deletes the lavaland wishgranter 
## Why It's Good For The Game
Only reason it exists is to give miners murderbone objectives while having heavily unbalanced gear, or, remove, don't improve
## Changelog
:cl:
del: deleted wishgranter
balance: miners cant get free murderbone with their OP gear now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
