### PR TITLE
Adds cheap sunglasses

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -186,16 +186,6 @@
 
 //Here lies green glasses, so ugly they died. RIP
 
-/obj/item/clothing/glasses/cheapsuns
-	name = "cheap sunglasses"
-	desc = "Strangely ancient technology used to help provide rudimentary eye cover."
-	icon_state = "sun"
-	item_state = "sunglasses"
-	darkness_view = 1
-	tint = 1
-	glass_colour_type = /datum/client_colour/glass_colour/gray
-	dog_fashion = /datum/dog_fashion/head
-
 /obj/item/clothing/glasses/sunglasses
 	name = "sunglasses"
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks flashes."

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -186,6 +186,16 @@
 
 //Here lies green glasses, so ugly they died. RIP
 
+/obj/item/clothing/glasses/cheapsuns
+	name = "cheap sunglasses"
+	desc = "Strangely ancient technology used to help provide rudimentary eye cover."
+	icon_state = "sun"
+	item_state = "sunglasses"
+	darkness_view = 1
+	tint = 1
+	glass_colour_type = /datum/client_colour/glass_colour/gray
+	dog_fashion = /datum/dog_fashion/head
+
 /obj/item/clothing/glasses/sunglasses
 	name = "sunglasses"
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks flashes."

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -76,7 +76,7 @@
 		            /obj/item/clothing/suit/jacket/letterman = 2,
 		            /obj/item/clothing/suit/jacket/letterman_red = 2,
 		            /obj/item/clothing/glasses/regular = 2,
-					/obj/item/clothing/glasses/cheapsuns = 2,
+					/obj/item/clothing/glasses/cheapsuns = 2, // Wasp Edit - Cheap sunglasses
 		            /obj/item/clothing/glasses/regular/jamjar = 1,
 		            /obj/item/clothing/glasses/orange = 1,
 		            /obj/item/clothing/glasses/red = 1,

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -76,6 +76,7 @@
 		            /obj/item/clothing/suit/jacket/letterman = 2,
 		            /obj/item/clothing/suit/jacket/letterman_red = 2,
 		            /obj/item/clothing/glasses/regular = 2,
+					/obj/item/clothing/glasses/cheapsuns = 2,
 		            /obj/item/clothing/glasses/regular/jamjar = 1,
 		            /obj/item/clothing/glasses/orange = 1,
 		            /obj/item/clothing/glasses/red = 1,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3151,6 +3151,7 @@
 #include "waspstation\code\modules\client\loadout\loadout_suit.dm"
 #include "waspstation\code\modules\client\loadout\loadout_uniform.dm"
 #include "waspstation\code\modules\client\verbs\minimap.dm"
+#include "waspstation\code\modules\clothing\glasses\_glasses.dm"
 #include "waspstation\code\modules\clothing\glasses\hud.dm"
 #include "waspstation\code\modules\clothing\head\berets.dm"
 #include "waspstation\code\modules\clothing\head\cowboy.dm"

--- a/waspstation/code/modules/client/loadout/loadout_eyewear.dm
+++ b/waspstation/code/modules/client/loadout/loadout_eyewear.dm
@@ -51,6 +51,10 @@
 	display_name = "monocle"
 	path = /obj/item/clothing/glasses/monocle
 
+/datum/gear/eyewear/cheapsuns
+	display_name = "cheap sunglasses"
+	path = /obj/item/clothing/glasses/cheapsuns
+
 /datum/gear/eyewear/blindfold
 	display_name = "blindfold"
 	path = /obj/item/clothing/glasses/blindfold

--- a/waspstation/code/modules/clothing/glasses/_glasses.dm
+++ b/waspstation/code/modules/clothing/glasses/_glasses.dm
@@ -1,0 +1,9 @@
+/obj/item/clothing/glasses/cheapsuns
+	name = "cheap sunglasses"
+	desc = "Strangely ancient technology used to help provide rudimentary eye cover."
+	icon_state = "sun"
+	item_state = "sunglasses"
+	darkness_view = 1
+	tint = 1
+	glass_colour_type = /datum/client_colour/glass_colour/gray
+	dog_fashion = /datum/dog_fashion/head


### PR DESCRIPTION
## About The Pull Request
Adds cheap sunglasses, which use the same sprite but a different name and are not flashproof. Added to ClothesMate and metacoins shop.

## Why It's Good For The Game
Sunglasses are a nice clothes option but right now are generally only obtainable by powergaming for them. 

## Changelog
:cl:
add: Adds non-flashproof cheap sunglasses to ClothesMate and metacoins shop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
