### PR TITLE
Dorf Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -415,9 +415,9 @@
 		var/obj/item/organ/alien/plasmavessel/vessel = getorgan(/obj/item/organ/alien/plasmavessel)
 		if(vessel)
 			stat(null, "Plasma Stored: [vessel.storedPlasma]/[vessel.max_plasma]")
-		var/obj/item/organ/dwarfgland/dwarfgland = getorgan(/obj/item/organ/dwarfgland)
+		var/obj/item/organ/dwarfgland/dwarfgland = getorgan(/obj/item/organ/dwarfgland)		// Begin Wasp Edit - Dwarf Alcohol Gland
 		if(dwarfgland)
-			stat(null, "Alcohol Stored: [dwarfgland.stored_alcohol]/[dwarfgland.max_alcohol]")
+			stat(null, "Alcohol Stored: [dwarfgland.stored_alcohol]/[dwarfgland.max_alcohol]")		// End Wasp Edit
 		if(locate(/obj/item/assembly/health) in src)
 			stat(null, "Health: [health]")
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -415,6 +415,9 @@
 		var/obj/item/organ/alien/plasmavessel/vessel = getorgan(/obj/item/organ/alien/plasmavessel)
 		if(vessel)
 			stat(null, "Plasma Stored: [vessel.storedPlasma]/[vessel.max_plasma]")
+		var/obj/item/organ/dwarfgland/dwarfgland = getorgan(/obj/item/organ/dwarfgland)
+		if(dwarfgland)
+			stat(null, "Alcohol Stored: [dwarfgland.stored_alcohol]/[dwarfgland.max_alcohol]")
 		if(locate(/obj/item/assembly/health) in src)
 			stat(null, "Health: [health]")
 

--- a/waspstation/code/modules/mob/living/carbon/human/species_types/dwarves.dm
+++ b/waspstation/code/modules/mob/living/carbon/human/species_types/dwarves.dm
@@ -92,7 +92,7 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 	w_class = WEIGHT_CLASS_NORMAL
 	var/stored_alcohol = 250 //They start with 250 units, that ticks down and eventaully bad effects occur
 	var/max_alcohol = 500 //Max they can attain, easier than you think to OD on alcohol.
-	var/heal_rate = 0.5 //The rate they heal damages over 400 alcohol stored. Default is 0.5 so we times 3 since 3 seconds.
+	var/heal_rate = 1.25 //The rate they heal damages over 400 alcohol stored. This has been buffed, but is still less effective than dedicated healing chems.
 	var/alcohol_rate = 0.25 //The rate the alcohol ticks down per each iteration of dwarf_eth_ticker completing.
 	//These count in on_life ticks which should be 2 seconds per every increment of 1 in a perfect world.
 	var/dwarf_eth_ticker = 0 //Currently set =< 1, that means this will fire the proc around every 2 seconds
@@ -128,7 +128,7 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 			if(last_alcohol_spam + 8 SECONDS < world.time)
 				to_chat(owner, "<span class='userdanger'>DAMNATION INCARNATE, WHY AM I CURSED WITH THIS DRY-SPELL? I MUST DRINK.</span>")
 				last_alcohol_spam = world.time
-			owner.adjustToxLoss(10)
+			owner.adjustToxLoss(2.5)
 		if(25 to 50)
 			if(last_alcohol_spam + 20 SECONDS < world.time)
 				to_chat(owner, "<span class='danger'>Oh DAMN, I need some brew!</span>")

--- a/waspstation/code/modules/mob/living/carbon/human/species_types/dwarves.dm
+++ b/waspstation/code/modules/mob/living/carbon/human/species_types/dwarves.dm
@@ -119,6 +119,7 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 	if(stored_alcohol > 400) //If they are over 400 they start regenerating
 		owner.adjustBruteLoss(-heal_amt) //But its alcohol, there will be other issues here.
 		owner.adjustFireLoss(-heal_amt) //Unless they drink casually all the time.
+		owner.adjustToxLoss(-heal_amt)
 		owner.adjustOxyLoss(-heal_amt)
 		owner.adjustCloneLoss(-heal_amt) //Also they will probably get brain damage if thats a thing here.
 	if(init_stored_alcohol + 0.5 < stored_alcohol) //recovering stored alcohol at a steady rate of +0.75, no spam.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a display in the status tab for dwarves to view their current stored alcohol. Unfortunately, I couldn't make this modular without creating tons of runtimes. I also increased the regen dwarves will receive for keeping their alcohol level above 400, and reduced the damage per tick for falling criticaly low on it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, there's no reliable way to tell whether you are recovering or draining alcohol except for easy-to-miss chat messages. Additionally, these messages are not useful for gauging whether or not you are in the regeneration threshold, only for gauging when you are below half your gland's capacity. This PR changes that. Additionally, if you fell into the dangerous threshold, you would die in a matter of seconds. For instance, on Metastation, you could very easily die before you could run the distance between the captain's quarters and the bar to get yourself a drink. This has been toned way back. Lastly, I felt the regeneration you'd be rewarded with for keeping drinks on your person and your stored alcohol above 400 was too low to make up for their inherent slowdown, so I have buffed it. It is still less effective than chemistry, and you won't outheal someone who wants to kill you, but you will heal out of crit, and if you are a clever dwarf, you can buy yourself some more time to survive down on Lavaland when you've run out of patches and medipens.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds a status tab display for stored alcohol.
tweak: Substantially buffs regen for having 400+ stored alcohol. Ultimately still more useful for recovery than confrontation.
tweak: Greatly lowers the toxin damage per cycle for alcohol deprivation. Was 10, now 2.5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
