### PR TITLE
[Port] Nightmare now properly spawns with Lighteater #50174

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -154,6 +154,11 @@
 		playsound(owner, 'sound/hallucinations/far_noise.ogg', 50, TRUE)
 		respawn_progress = 0
 
+/obj/item/organ/heart/nightmare/get_availability(datum/species/S)
+	if(istype(S,/datum/species/shadow/nightmare))
+		return TRUE
+	return ..()
+
 //Weapon
 
 /obj/item/light_eater


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nightmares use NOBLOOD and the default heart's get_availability checks for NOBLOOD so it didn't realize that the nightmare does in fact need the heart.

[Sauce](https://github.com/tgstation/tgstation/pull/50174)

## Changelog
:cl: BigFatAnimeTiddies
fix: Fixes Nightmares spawning without Lighteater
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
