### PR TITLE
Fix loadout uniform preventing ID/PDA from spawning

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -152,7 +152,7 @@
   * If visualsOnly is true, you can omit any work that doesn't visually appear on the character sprite
   */
 /datum/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE, client/preference_source = null) //WaspStation Edit - Alt-Job Titles
-	pre_equip(H, visualsOnly)
+	pre_equip(H, visualsOnly, preference_source)
 
 	//Start with uniform,suit,backpack for additional slots
 	if(uniform)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -301,16 +301,19 @@
 		if(PREF_GREYSUIT)
 			holder = "/obj/item/clothing/under/color/grey"
 		// WaspStation Edit - Fix Loadout Uniforms not spawning ID/PDA
-		if(PREF_LOADOUT && preference_source != null)
-			var/datum/pref_loadout_uniform = null
-			for(var/gear in preference_source.prefs.equipped_gear)
-				var/datum/gear/G = GLOB.gear_datums[gear]
-				if (G.slot == ITEM_SLOT_ICLOTHING)
-					pref_loadout_uniform = G.path
-			if (pref_loadout_uniform == null)
-				holder = "[uniform]"
+		if(PREF_LOADOUT)
+			if (preference_source == null)
+				holder = "[uniform]" // Who are we getting the loadout pref from anyways?
 			else
-				uniform = pref_loadout_uniform
+				var/datum/pref_loadout_uniform = null
+				for(var/gear in preference_source.prefs.equipped_gear)
+					var/datum/gear/G = GLOB.gear_datums[gear]
+					if (G.slot == ITEM_SLOT_ICLOTHING)
+						pref_loadout_uniform = G.path
+				if (pref_loadout_uniform == null)
+					holder = "[uniform]"
+				else
+					uniform = pref_loadout_uniform
 		// End WaspStation Edit - Fix Loadout Uniforms not spawning ID/PDA
 		else
 			holder = "[uniform]"

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -110,7 +110,10 @@
 				if(!permitted)
 					to_chat(M, "<span class='warning'>Your current species or role does not permit you to spawn with [gear]!</span>")
 					continue
-
+				// WaspStation Edit - Fix Loadout Uniforms not spawning ID/PDA
+				if(G.slot == ITEM_SLOT_ICLOTHING)
+					continue // Handled in pre_equip
+				//End WaspStation Edit - Fix Loadout Uniforms not spawning ID/PDA
 				if(G.slot)
 					if(!H.equip_to_slot_or_del(G.spawn_item(H), G.slot))
 						gear_leftovers += G
@@ -268,7 +271,7 @@
 
 	var/pda_slot = ITEM_SLOT_BELT
 
-/datum/outfit/job/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE, client/preference_source = null)
 	switch(H.backpack)
 		if(GBACKPACK)
 			back = /obj/item/storage/backpack //Grey backpack
@@ -297,8 +300,18 @@
 			holder = "[alt_uniform]"
 		if(PREF_GREYSUIT)
 			holder = "/obj/item/clothing/under/color/grey"
-		if(PREF_LOADOUT)
-			uniform = null
+		// WaspStation Edit - Fix Loadout Uniforms not spawning ID/PDA
+		if(PREF_LOADOUT && preference_source != null)
+			var/datum/pref_loadout_uniform = null
+			for(var/gear in preference_source.prefs.equipped_gear)
+				var/datum/gear/G = GLOB.gear_datums[gear]
+				if (G.slot == ITEM_SLOT_ICLOTHING)
+					pref_loadout_uniform = G.path
+			if (pref_loadout_uniform == null)
+				holder = "[uniform]"
+			else
+				uniform = pref_loadout_uniform
+		// End WaspStation Edit - Fix Loadout Uniforms not spawning ID/PDA
 		else
 			holder = "[uniform]"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes an issue where selecting Loadout Uniform as a suit preference prevents the ID/PDA from being added to the player's character at roundstart.

## Why It's Good For The Game

My sanity needs this. Please.

## Changelog
:cl:
fix: PDA/ID now properly spawn when a Uniform is selected in loadout preferences
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
