### PR TITLE
Bluespace Miner Nerf

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -117,7 +117,7 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 /obj/item/stack/sheet/mineral/diamond/get_main_recipes()
 	. = ..()
 	. += GLOB.diamond_recipes
-	
+
 /obj/item/stack/sheet/mineral/diamond/fifty
 	amount = 50
 
@@ -154,7 +154,7 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 /obj/item/stack/sheet/mineral/uranium/get_main_recipes()
 	. = ..()
 	. += GLOB.uranium_recipes
-	
+
 /obj/item/stack/sheet/mineral/uranium/fifty
 	amount = 50
 
@@ -177,7 +177,7 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 	max_integrity = 100
 	custom_materials = list(/datum/material/plasma=MINERAL_MATERIAL_AMOUNT)
 	grind_results = list(/datum/reagent/toxin/plasma = 20)
-	point_value = 20
+	point_value = 5
 	merge_type = /obj/item/stack/sheet/mineral/plasma
 	material_type = /datum/material/plasma
 	walltype = /turf/closed/wall/mineral/plasma
@@ -208,7 +208,7 @@ GLOBAL_LIST_INIT(plasma_recipes, list ( \
 /obj/item/stack/sheet/mineral/plasma/fire_act(exposed_temperature, exposed_volume)
 	atmos_spawn_air("plasma=[amount*10];TEMP=[exposed_temperature]")
 	qdel(src)
-	
+
 /obj/item/stack/sheet/mineral/plasma/fifty
 	amount = 50
 
@@ -288,7 +288,7 @@ GLOBAL_LIST_INIT(silver_recipes, list ( \
 /obj/item/stack/sheet/mineral/silver/get_main_recipes()
 	. = ..()
 	. += GLOB.silver_recipes
-	
+
 /obj/item/stack/sheet/mineral/silver/fifty
 	amount = 50
 
@@ -354,7 +354,7 @@ GLOBAL_LIST_INIT(titanium_recipes, list ( \
 
 /obj/item/stack/sheet/mineral/titanium/fifty
 	amount = 50
-	
+
 /obj/item/stack/sheet/mineral/titanium/twenty
 	amount = 20
 

--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -6,7 +6,7 @@
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/bluespace_miner
 	layer = BELOW_OBJ_LAYER
-	var/list/ore_rates = list(/datum/material/iron = 0.6, /datum/material/glass = 0.6, /*/datum/material/copper = 0.4,*/ /datum/material/plasma = 0.2,  /datum/material/silver = 0.2, /datum/material/gold = 0.1, /datum/material/titanium = 0.1, /datum/material/uranium = 0.1, /datum/material/diamond = 0.1)
+	var/list/ore_rates = list(/datum/material/iron = 0.6, /datum/material/glass = 0.6, /*/datum/material/copper = 0.4,*/ /datum/material/plasma = 0.05,  /datum/material/silver = 0.2, /datum/material/gold = 0.1, /datum/material/titanium = 0.1, /datum/material/uranium = 0.1)
 	var/datum/component/remote_materials/materials
 
 /obj/machinery/mineral/bluespace_miner/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes Diamonds from the BSM available minerals. Reduces plasma sheet output (and cargo value) to 25% of current. 

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/1953773/87259600-7408a800-c47a-11ea-9b3d-9e0b85a57418.png)
Because this is bullshit. Diamonds can be purchased from cargo, they don't need to be pulled out of thin air.

## Changelog
:cl:
balance: BSMs no longer produce Diamonds, and produce Plasma at 25% the rate.
balance: Plasma sheets export for 25% their original value. (20pts -> 5pts)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
