### PR TITLE
A Different BSM Nerf

### DIFF
--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -10,8 +10,10 @@
 	var/mining_rate = 10 //Amount of material gained on a mining tick
 	var/mining_chance = 30 //Chance a mining tick results in materials gained
 	//Ores that can be mined (and their weight)
-	var/list/minable_ores = list(/datum/material/iron = 6, /datum/material/glass = 6, /*/datum/material/copper = 0.4,*/ /datum/material/plasma = 2)
-	var/list/upgraded_ores = list(/datum/material/silver = 3, /datum/material/gold = 2, /datum/material/titanium = 2, /datum/material/uranium = 1)
+	var/list/minable_ores = list(/datum/material/iron = 6, /datum/material/glass = 6, /*/datum/material/copper = 0.4,*/)
+	var/list/tier2_ores = list(/datum/material/plasma = 2, /datum/material/silver = 3, /datum/material/titanium = 2)
+	var/list/tier3_ores = list(/datum/material/gold = 2, /datum/material/uranium = 1)
+	var/list/tier4_ores = list(/datum/material/diamond = 1)
 	var/datum/component/remote_materials/materials
 
 /obj/machinery/mineral/bluespace_miner/Initialize(mapload)
@@ -24,10 +26,12 @@
 
 /obj/machinery/mineral/bluespace_miner/RefreshParts()
 	for(var/obj/item/stock_parts/scanning_module/SM in component_parts)
+		if (SM.rating > 1)
+			minable_ores |= tier2_ores
 		if (SM.rating > 2)
-			minable_ores |= upgraded_ores
-		if (SM.rating > 3)
-			minable_ores |= list(/datum/material/diamond = 1)
+			minable_ores |= tier3_ores
+		if(SM.rating > 3)
+			minable_ores |= tier4_ores
 	for(var/obj/item/stock_parts/micro_laser/ML in component_parts)
 		mining_rate = 10 ** (ML.rating)
 	var/P = 0
@@ -52,4 +56,4 @@
 
 /obj/machinery/mineral/bluespace_miner/proc/mine()
 	var/datum/material/ore = pickweight(minable_ores)
-	materials.mat_container.insert_amount_mat((minable_ores[ore] * mining_rate), ore)
+	materials.mat_container.insert_amount_mat((mining_rate), ore)

--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -6,7 +6,12 @@
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/bluespace_miner
 	layer = BELOW_OBJ_LAYER
-	var/list/ore_rates = list(/datum/material/iron = 0.6, /datum/material/glass = 0.6, /*/datum/material/copper = 0.4,*/ /datum/material/plasma = 0.2,  /datum/material/silver = 0.2, /datum/material/gold = 0.1, /datum/material/titanium = 0.1, /datum/material/uranium = 0.1, /datum/material/diamond = 0.1)
+
+	var/mining_rate = 10 //Amount of material gained on a mining tick
+	var/mining_chance = 30 //Chance a mining tick results in materials gained
+	//Ores that can be mined (and their weight)
+	var/list/minable_ores = list(/datum/material/iron = 6, /datum/material/glass = 6, /*/datum/material/copper = 0.4,*/ /datum/material/plasma = 2)
+	var/list/upgraded_ores = list(/datum/material/silver = 3, /datum/material/gold = 2, /datum/material/titanium = 2, /datum/material/uranium = 1)
 	var/datum/component/remote_materials/materials
 
 /obj/machinery/mineral/bluespace_miner/Initialize(mapload)
@@ -16,6 +21,19 @@
 /obj/machinery/mineral/bluespace_miner/Destroy()
 	materials = null
 	return ..()
+
+/obj/machinery/mineral/bluespace_miner/RefreshParts()
+	for(var/obj/item/stock_parts/scanning_module/SM in component_parts)
+		if (SM.rating > 2)
+			minable_ores |= upgraded_ores
+		if (SM.rating > 3)
+			minable_ores |= list(/datum/material/diamond = 1)
+	for(var/obj/item/stock_parts/micro_laser/ML in component_parts)
+		mining_rate = 10 ** (ML.rating)
+	var/P = 0
+	for(var/obj/item/stock_parts/manipulator/M in component_parts)
+		P += sqrt(M.rating) * 16
+	mining_chance = P
 
 /obj/machinery/mineral/bluespace_miner/examine(mob/user)
 	. = ..()
@@ -27,9 +45,11 @@
 /obj/machinery/mineral/bluespace_miner/process()
 	if(!materials?.silo || materials?.on_hold())
 		return
-	var/datum/component/material_container/mat_container = materials.mat_container
-	if(!mat_container || panel_open || !powered())
+	if(!materials.mat_container || panel_open || !powered())
 		return
-	var/datum/material/ore = pick(ore_rates)
-	mat_container.insert_amount_mat((ore_rates[ore] * 1000), ore)
+	if(prob(mining_chance))
+		mine()
 
+/obj/machinery/mineral/bluespace_miner/proc/mine()
+	var/datum/material/ore = pickweight(minable_ores)
+	materials.mat_container.insert_amount_mat((minable_ores[ore] * mining_rate), ore)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alters the BSM rate based on the tier of parts included.
Volume of material gained each tick is determined by the micro-laser
Chance of mining *any* material each tick determined by manipulators (from ~50% at T1 to 96% at T4)
~~Gold, Silver, Titanium, and Uranium require T3 scanner to mine, T4 for diamond~~
EDIT: Scanners unlock more materials to mine by tier:
T1: Iron, Glass
T2: Plasma, Silver, Titanium
T3: Gold, Uranium
T4: Diamond

Matter bins still do nothing but we're overhauling this for deep mining (#320) anyway.

Additionally, the material chosen to be made each tick is now weighed, meaning you will mine more common mats such as iron and glass on average, compared to rarer materials.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Solves the same issues addressed by #342 while giving BSM's more interaction with stock parts.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Bluespace miners now scale with stock parts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
