### PR TITLE
Mentor bugfixes and QOL

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -80,8 +80,6 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/datum/admins/proc/open_borgopanel
 	)
 
-GLOBAL_LIST_INIT(mentor_verbs, list(/client/proc/cmd_mentor_pm_panel, /client/proc/show_mentor_memo, /client/proc/cmd_mentor_say))
-GLOBAL_PROTECT(mentor_verbs)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(/client/proc/unban_panel, /client/proc/ban_panel, /client/proc/stickybanpanel))
 GLOBAL_PROTECT(admin_verbs_ban)
 GLOBAL_LIST_INIT(admin_verbs_sounds, list(/client/proc/play_local_sound, /client/proc/play_direct_mob_sound, /client/proc/play_sound, /client/proc/set_round_end_sound))

--- a/code/modules/mentor/mentor_ranks.dm
+++ b/code/modules/mentor/mentor_ranks.dm
@@ -24,6 +24,7 @@
 			if(!D)  //will occur if an invalid rank is provided
 				continue
 			D.associate(GLOB.directory[ckey])	//find the client for a ckey if they are connected and associate them with the new mentor datum
+		qdel(query)
 	else
 		log_world("Using legacy mentor system.")
 		var/list/Lines = world.file2list("config/mentors.txt")

--- a/code/modules/mentor/mentor_verbs.dm
+++ b/code/modules/mentor/mentor_verbs.dm
@@ -1,0 +1,14 @@
+GLOBAL_LIST_INIT(mentor_verbs, list(
+	/client/proc/cmd_mentor_pm_panel,
+	/client/proc/show_mentor_memo,
+	/client/proc/cmd_mentor_say,
+	/client/proc/cmd_mentor_dementor
+	))
+GLOBAL_PROTECT(mentor_verbs)
+
+/client/proc/add_mentor_verbs()
+	if(check_mentor())
+		verbs += GLOB.mentor_verbs
+
+/client/proc/remove_mentor_verbs()
+	verbs -= GLOB.mentor_verbs

--- a/code/modules/mentor/verbs/dementor.dm
+++ b/code/modules/mentor/verbs/dementor.dm
@@ -1,0 +1,19 @@
+/client/proc/cmd_mentor_dementor()
+	set category = "Mentor"
+	set name = "Dementor"
+	if(!check_mentor())
+		return
+	remove_mentor_verbs()
+	if (/client/proc/mentor_unfollow in verbs)
+		mentor_unfollow()
+	GLOB.mentors -= src
+	verbs += /client/proc/cmd_mentor_rementor
+
+/client/proc/cmd_mentor_rementor()
+	set category = "Mentor"
+	set name = "Rementor"
+	if(!check_mentor())
+		return
+	add_mentor_verbs()
+	GLOB.mentors += src
+	verbs -= /client/proc/cmd_mentor_rementor

--- a/code/modules/mentor/verbs/mentor_memo.dm
+++ b/code/modules/mentor/verbs/mentor_memo.dm
@@ -50,6 +50,8 @@
 				return
 			log_admin("[key_name(src)] has set a mentor memo: [memotext]")
 			message_admins("[key_name_admin(src)] has set a mentor memo:<br>[memotext]")
+			qdel(query_memocheck)
+			qdel(query_memoadd)
 		if("Edit")
 			var/datum/DBQuery/query_memolist = SSdbcore.NewQuery("SELECT ckey FROM [format_table_name("mentor_memo")]")
 			if(!query_memolist.Execute())
@@ -91,6 +93,9 @@
 				else
 					log_admin("[key_name(src)] has edited [target_sql_ckey]'s mentor memo from [old_memo] to [new_memo]")
 					message_admins("[key_name_admin(src)] has edited [target_sql_ckey]'s mentor memo from<br>[old_memo]<br>to<br>[new_memo]")
+				qdel(update_query)
+			qdel(query_memolist)
+			qdel(query_memofind)
 		if("Show")
 			var/datum/DBQuery/query_memoshow = SSdbcore.NewQuery("SELECT ckey, memotext, timestamp, last_editor FROM [format_table_name("mentor_memo")]")
 			if(!query_memoshow.Execute())
@@ -139,3 +144,5 @@
 			else
 				log_admin("[key_name(src)] has removed [target_sql_ckey]'s mentor memo.")
 				message_admins("[key_name_admin(src)] has removed [target_sql_ckey]'s mentor memo.")
+			qdel(query_memodellist)
+			qdel(query_memodel)

--- a/code/modules/mentor/verbs/mentorpm.dm
+++ b/code/modules/mentor/verbs/mentorpm.dm
@@ -39,11 +39,16 @@
 			mentorhelp(msg)	//Mentor we are replying to left. Mentorhelp instead
 		return
 
+	to_chat(GLOB.admins | GLOB.mentors, "<font color='notice'>[src] has started replying to [whom]'s mhelp.</font>")
+
 	//get message text, limit its length.and clean/escape html
 	if(!msg)
 		msg = input(src,"Message:", "Private message") as text|null
+
 		if(!msg)
+			to_chat(GLOB.admins | GLOB.mentors, "<span class='notice'>[src] has stopped their reply to [whom]'s mhelp.</span>")
 			return
+
 		if(!C)
 			if(holder)
 				to_chat(src, "<span class='warning'>Error: Mentor-PM: Client not found.</span>")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2053,6 +2053,8 @@
 #include "code\modules\mentor\follow.dm"
 #include "code\modules\mentor\holder2.dm"
 #include "code\modules\mentor\mentor_ranks.dm"
+#include "code\modules\mentor\mentor_verbs.dm"
+#include "code\modules\mentor\verbs\dementor.dm"
 #include "code\modules\mentor\verbs\mentor_memo.dm"
 #include "code\modules\mentor\verbs\mentorhelp.dm"
 #include "code\modules\mentor\verbs\mentorpm.dm"


### PR DESCRIPTION
## About the PR
Ports a few things from: Citadel-Station-13/Citadel-Station-13#5235 and https://github.com/Citadel-Station-13/Citadel-Station-13#11519, query fixes by me

## Changelog
:cl:
fix: No more undeleted mentor queries annoying admins.
tweak: Mentor PMs now show when people start and stop responding to them to other mentors, preventing dog piling on one mhelp.
add: Mentors can now de-mentor (in the mentor panel or using the command bar) so that they don't get accidentally told IC information if they are, for example, an antag or sec.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
