### PR TITLE
Fix vorak ruin atmos

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/Fast_Food.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Fast_Food.dmm
@@ -582,11 +582,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/macspace)
-"ck" = (
-/obj/machinery/light/floor,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/water,
-/area/ruin/space/has_grav/powered/macspace)
 "cl" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -922,14 +917,6 @@
 /obj/machinery/door/airlock/silver,
 /turf/open/floor/mineral/titanium,
 /area/ruin/space/has_grav/powered/macspace)
-"ds" = (
-/obj/vehicle/ridden/atv,
-/turf/open/floor/mineral/titanium,
-/area/ruin/space/has_grav/powered/macspace)
-"dt" = (
-/obj/vehicle/ridden/janicart/upgraded,
-/turf/open/floor/mineral/titanium,
-/area/ruin/space/has_grav/powered/macspace)
 "dx" = (
 /obj/structure/chair/wood/wings{
 	dir = 4;
@@ -1000,6 +987,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/macspace)
+"eB" = (
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/powered/macspace)
 "jH" = (
 /obj/structure/table,
 /obj/structure/table/wood/fancy/blue,
@@ -1017,11 +1009,22 @@
 /obj/machinery/atmospherics/components/unary/tank/oxygen,
 /turf/open/floor/mineral/titanium,
 /area/ruin/space/has_grav/powered/macspace)
+"JK" = (
+/obj/vehicle/ridden/atv,
+/turf/open/floor/mineral/titanium/airless,
+/area/ruin/space/has_grav/powered/macspace)
 "LY" = (
 /obj/structure/table,
 /obj/structure/table/wood/fancy/blue,
 /obj/item/reagent_containers/food/snacks/burger/jelly/slime,
 /turf/open/floor/carpet,
+/area/ruin/space/has_grav/powered/macspace)
+"OA" = (
+/obj/vehicle/ridden/janicart/upgraded,
+/turf/open/floor/mineral/titanium/airless,
+/area/ruin/space/has_grav/powered/macspace)
+"VM" = (
+/turf/open/floor/mineral/titanium/airless,
 /area/ruin/space/has_grav/powered/macspace)
 
 (1,1,1) = {"
@@ -1300,8 +1303,8 @@ ae
 ae
 ae
 ae
-de
-de
+VM
+VM
 ac
 "}
 (11,1,1) = {"
@@ -1328,8 +1331,8 @@ de
 dl
 dl
 ae
-ds
-de
+JK
+VM
 ac
 "}
 (12,1,1) = {"
@@ -1356,8 +1359,8 @@ de
 de
 de
 db
-de
-de
+VM
+VM
 aa
 "}
 (13,1,1) = {"
@@ -1384,8 +1387,8 @@ df
 de
 de
 ae
-ds
-de
+JK
+VM
 aa
 "}
 (14,1,1) = {"
@@ -1402,7 +1405,7 @@ aP
 bE
 bP
 bZ
-ck
+eB
 cl
 bM
 ao
@@ -1412,8 +1415,8 @@ dg
 de
 de
 dr
-de
-de
+VM
+VM
 aa
 "}
 (15,1,1) = {"
@@ -1440,8 +1443,8 @@ dg
 de
 de
 dr
-de
-de
+VM
+VM
 aa
 "}
 (16,1,1) = {"
@@ -1468,8 +1471,8 @@ df
 de
 de
 ae
-de
-de
+VM
+VM
 aa
 "}
 (17,1,1) = {"
@@ -1496,8 +1499,8 @@ dh
 dm
 de
 db
-de
-de
+VM
+VM
 aa
 "}
 (18,1,1) = {"
@@ -1524,8 +1527,8 @@ di
 dn
 dp
 ae
-ds
-de
+JK
+VM
 aa
 "}
 (19,1,1) = {"
@@ -1552,8 +1555,8 @@ dj
 do
 dq
 ae
-ds
-de
+JK
+VM
 aa
 "}
 (20,1,1) = {"
@@ -1580,8 +1583,8 @@ dk
 dk
 Fk
 ae
-de
-de
+VM
+VM
 ac
 "}
 (21,1,1) = {"
@@ -1608,8 +1611,8 @@ ae
 ae
 ae
 ae
-de
-dt
+VM
+OA
 ac
 "}
 (22,1,1) = {"

--- a/_maps/RandomRuins/SpaceRuins/power_puzzle.dmm
+++ b/_maps/RandomRuins/SpaceRuins/power_puzzle.dmm
@@ -482,9 +482,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/storage/central)
-"cG" = (
-/turf/open/floor/plating/asteroid,
-/area/ruin/space/has_grav)
 "cH" = (
 /obj/item/inducer,
 /obj/effect/decal/cleanable/dirt,
@@ -915,6 +912,9 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/storage/central)
+"VV" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/space/has_grav)
 "VX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -945,7 +945,7 @@ aa
 ah
 ah
 ah
-cG
+VV
 ah
 ah
 ah
@@ -977,7 +977,7 @@ ah
 ah
 ah
 ah
-cG
+VV
 ah
 ah
 ah


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes roundstart atmos errors for a couple space ruins.

## Changelog
:cl: BigFatAnimeTiddies
fix: Fixes roundstart atmos issues for a few space ruins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
