### PR TITLE
Flash nerf.

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -72,7 +72,7 @@
 	return TRUE
 
 //BYPASS CHECKS ALSO PREVENTS BURNOUT!
-/obj/item/assembly/flash/proc/AOE_flash(bypass_checks = FALSE, range = 2, power = 5, targeted = FALSE, mob/user)
+/obj/item/assembly/flash/proc/AOE_flash(bypass_checks = FALSE, range = 2, power = 3, targeted = FALSE, mob/user)
 	if(!bypass_checks && !try_use_flash())
 		return FALSE
 	var/list/mob/targets = get_flash_targets(get_turf(src), range, FALSE)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -72,7 +72,7 @@
 	return TRUE
 
 //BYPASS CHECKS ALSO PREVENTS BURNOUT!
-/obj/item/assembly/flash/proc/AOE_flash(bypass_checks = FALSE, range = 3, power = 5, targeted = FALSE, mob/user)
+/obj/item/assembly/flash/proc/AOE_flash(bypass_checks = FALSE, range = 2, power = 5, targeted = FALSE, mob/user)
 	if(!bypass_checks && !try_use_flash())
 		return FALSE
 	var/list/mob/targets = get_flash_targets(get_turf(src), range, FALSE)
@@ -126,7 +126,6 @@
 				to_chat(M, "<span class='userdanger'>[user] blinds you with the flash!</span>")
 			else
 				to_chat(M, "<span class='userdanger'>You are blinded by [src]!</span>")
-			M.Paralyze(rand(80,120))
 		else if(user)
 			visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>")
 			to_chat(user, "<span class='warning'>You fail to blind [M] with the flash!</span>")


### PR DESCRIPTION
Nerfs the flashbulb. Removes the instant hardstun for a direct hit, and reduces the AoE to 2 tiles (from 3). I didn't touch the flash power on the AoE or normal strikes, as I didn't want to screw with values I didn't completely understand, but from what I can tell, the duration is longer on a direct hit, so that should still encourage the use of the normal strike. I may do some testing and tweak it, but idk.

Somehow boredom led to this. Who even knows any more.

Edit: I changed my mind, lowered the power stat to 3 (from 5) on the AoE flash. Direct still remains 15. If I understand correctly, this is the duration on the blind and disorient on the flashbulb. If it's too weak to use the AoE, it can be changed if necessary, but this should mean the AoE is used as  either a quick escape or the first move in a follow up second flash.