### PR TITLE
Adds Magboots to Engineering Hardsuit Storage Units

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -60,6 +60,7 @@
 /obj/machinery/suit_storage_unit/engine
 	suit_type = /obj/item/clothing/suit/space/hardsuit/engine
 	mask_type = /obj/item/clothing/mask/breath
+	storage_type= /obj/item/clothing/shoes/magboots
 
 /obj/machinery/suit_storage_unit/atmos
 	suit_type = /obj/item/clothing/suit/space/hardsuit/engine/atmos


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a pair of magboots to the Engineering suit storage units.

## Why It's Good For The Game

They honestly should have been there a long while ago. It's a roundstart source of magboots for Engineering, outside of breaking into EVA (which they should have access to IMO), and with Monstermos in the works, they will more than likely need magboots with how fast rooms can potentially depressurize.

## Changelog
:cl:
add: Engineering suit storage units come stocked with a pair of magboots now, alongside the usual hardsuit equipment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
