### PR TITLE
[Bugfixes] Shocked Grilles and Cable Melting

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -167,7 +167,7 @@
 	if(!T)
 		return FALSE
 	for(var/atom/movable/AM in T)
-		if(AM.flags_1 & PREVENT_CLICK_UNDER_1 && AM.density && AM.layer > layer)
+		if(AM.flags_1 & PREVENT_CLICK_UNDER_1 && AM.density && (AM.layer > layer || (T.intact && HAS_TRAIT(AM, TRAIT_T_RAY_VISIBLE))))
 			return TRUE
 	return FALSE
 

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -102,6 +102,10 @@
 			step_towards(M,src)
 	for(var/obj/O in range(0,src))
 		if(!O.anchored)
+			if(isturf(O.loc))
+				var/turf/T = O.loc
+				if(T.intact && HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
+					continue
 			var/mob/living/target = locate() in view(4,src)
 			if(target && !target.stat)
 				O.throw_at(target, 5, 10)

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -141,6 +141,10 @@
 	for(var/obj/O in range(0,src))
 		if(O.type == src.type)
 			continue
+		if(isturf(O.loc))
+			var/turf/T = O.loc
+			if(T.intact && HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
+				continue
 		if(lifetime % reagent_divisor)
 			reagents.expose(O, VAPOR, fraction)
 	var/hit = 0

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -66,7 +66,7 @@ GENE SCANNER
 	var/list/t_ray_images = list()
 	for(var/obj/O in orange(distance, viewer) )
 
-		if(O.invisibility == INVISIBILITY_MAXIMUM || HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
+		if(HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
 			var/image/I = new(loc = get_turf(O))
 			var/mutable_appearance/MA = new(O)
 			MA.alpha = 128

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -91,6 +91,10 @@
 	return TRUE
 
 /obj/blob_act(obj/structure/blob/B)
+	if(isturf(loc))
+		var/turf/T = loc
+		if(T.intact && HAS_TRAIT(src, TRAIT_T_RAY_VISIBLE))
+			return
 	take_damage(400, BRUTE, "melee", 0, get_dir(src, B))
 
 /obj/proc/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, armor_penetration = 0) //used by attack_alien, attack_animal, and attack_slime
@@ -198,6 +202,10 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 
 ///Called when the obj is exposed to fire.
 /obj/fire_act(exposed_temperature, exposed_volume)
+	if(isturf(loc))
+		var/turf/T = loc
+		if(T.intact && HAS_TRAIT(src, TRAIT_T_RAY_VISIBLE))
+			return
 	if(exposed_temperature && !(resistance_flags & FIRE_PROOF))
 		take_damage(clamp(0.02 * exposed_temperature, 0, 20), BURN, "fire", 0)
 	if(!(resistance_flags & ON_FIRE) && (resistance_flags & FLAMMABLE) && !(resistance_flags & FIRE_PROOF))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -400,7 +400,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 /turf/singularity_act()
 	if(intact)
 		for(var/obj/O in contents) //this is for deleting things like wires contained in the turf
-			if(O.invisibility == INVISIBILITY_MAXIMUM)
+			if(HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
 				O.singularity_act()
 	ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 	return(2)
@@ -484,6 +484,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		acid_type = /obj/effect/acid/alien
 	var/has_acid_effect = FALSE
 	for(var/obj/O in src)
+		if(intact && HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
+			return
 		if(istype(O, acid_type))
 			var/obj/effect/acid/A = O
 			A.acid_level = min(acid_volume * acidpwr, 12000)//capping acid level to limit power of the acid

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -916,7 +916,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/static/list/stored_t_ray_images = list()
 	for(var/obj/O in orange(client.view, src) )
 
-		if(O.invisibility == INVISIBILITY_MAXIMUM)
+		if(HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
 			var/image/I = new(loc = get_turf(O))
 			var/mutable_appearance/MA = new(O)
 			MA.alpha = 128
@@ -958,7 +958,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/proc/possess_mouse(mob/living/simple_animal/mouse/M)
 	if(!M)
-		return FALSE		
+		return FALSE
 
 	if(!SSticker.HasRoundStarted())
 		to_chat(usr, "<span class='warning'>The round hasn't started yet!</span>")

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -390,7 +390,6 @@
 	for(var/obj/structure/cable/C in src)
 		if(C.d1 == 0)
 			return C
-		return C
 	return null
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Grilles are no longer shocked by simply existing on a cable. Cable noded grills still shock.

Cables not longer phase through the floor to burn themselves to a crisp, just because the room is on fire, making alternative power sources such as the Turbine nonfunctional due to the one bit of cable going through the burn chamber. Courtesy of @LemonInTheDark [TG #52158](https://github.com/tgstation/tgstation/pull/52158)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Grilles are no longer shocked by simply existing on a wire. A node is still required to shock them.
fix: Wires will no longer burn if they're under a tile that's on fire
code: Reinserted some old checks for if something is over/under a tile
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
