### PR TITLE
Alternate job title fixes

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -146,7 +146,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				if (I)
 					name = I.registered_name
 					assignment = I.assignment
-					ijob = jobs[I.assignment]
+					ijob = jobs[I.GetJobName] //Why didn't it do this already - Wasp Edit - Alt Titles
 				else
 					name = "Unknown"
 					assignment = ""

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -146,7 +146,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				if (I)
 					name = I.registered_name
 					assignment = I.assignment
-					ijob = jobs[I.GetJobName] //Why didn't it do this already - Wasp Edit - Alt Titles
+					ijob = jobs[I.GetJobName()] //Why didn't it do this already - Wasp Edit - Alt Titles
 				else
 					name = "Unknown"
 					assignment = ""

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1337,7 +1337,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				var/job_title = href_list["job_title"]
 				var/titles_list = list(job_title)
 				var/datum/job/J = SSjob.GetJob(job_title)
-				if(user.client.calc_exp_type(J.get_exp_req_type()) > (J.get_exp_req_amount() + 3000)) //If they have more than 50 hours (300 Minutes) past the required time needed in the department, give them access to the senior title
+				if(user.client.prefs.exp[job_title] > (J.get_exp_req_amount() + 3000)) //If they have more than 50 hours (300 Minutes) past the required time needed for the job, give them access to the senior title
 					if(J.senior_title)
 						titles_list += J.senior_title
 				for(var/i in J.alt_titles)

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -381,9 +381,9 @@
 	var/jobName = I.assignment
 	if(jobName in get_all_job_icons()) //Check if the job has a hud icon
 		return jobName
+	if(jobName in get_all_centcom_jobs()) //Return with the NT logo if it is a CentCom job
+		return "CentCom"
 	for(var/datum/job/J in SSjob.occupations)
 		if((jobName in J.alt_titles) || (jobName == J.senior_title))
 			return J.title
-	if(jobName in get_all_centcom_jobs()) //Return with the NT logo if it is a CentCom job
-		return "CentCom"
 	return "Unknown" //Return unknown if none of the above apply

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -382,7 +382,7 @@
 	if(jobName in get_all_job_icons()) //Check if the job has a hud icon
 		return jobName
 	for(var/datum/job/J in SSjob.occupations)
-		if(jobName in J.alt_titles || jobName == J.senior_title)
+		if((jobName in J.alt_titles) || (jobName == J.senior_title))
 			return J.title
 	if(jobName in get_all_centcom_jobs()) //Return with the NT logo if it is a CentCom job
 		return "CentCom"

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -187,10 +187,9 @@
 	H.dna.species.before_equip_job(src, H, visualsOnly)
 
 	if(outfit && preference_source && preference_source.prefs && preference_source.prefs.alt_titles_preferences[title])
-		var/outfitholder = "[outfit]/[lowertext(preference_source.prefs.alt_titles_preferences[title])]"
+		var/outfitholder = "[outfit]/[replacetext(lowertext(preference_source.prefs.alt_titles_preferences[title]), " ", "")]"
 		if(text2path(outfitholder) || !outfitholder)
-			outfit_override = text2path(outfitholder)
-
+			outfit = text2path(outfitholder)
 	if(outfit_override || outfit)
 		H.equipOutfit(outfit_override ? outfit_override : outfit, visualsOnly, preference_source)
 


### PR DESCRIPTION
## Changelog
:cl:
fix: Some alternate title's alternate uniforms will now actually work.
fix: Senior titles will now actually show up on the right part of the manifest 100% of the time.
fix: Crew monitors (should) now display alt titles jobs in the right position with the right colour.
tweak: Senior titles are now linked to job experience rather than departmental experience.
/:cl:
