### PR TITLE
Replaces Orange with Mark

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -22,16 +22,18 @@
 	slowdown = 10
 	},
 /area/ruin/unpowered)
-"f" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
+"g" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
 /turf/open/floor/sepia{
 	slowdown = 10
 	},
 /area/ruin/unpowered)
-"g" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
+"J" = (
+/obj/structure/table/wood,
+/obj/item/toy/plush/lizardplushie{
+	name = "Mark"
+	},
 /turf/open/floor/sepia{
 	slowdown = 10
 	},
@@ -80,7 +82,7 @@ a
 c
 d
 d
-f
+J
 a
 b
 a


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A lovable plush Mark is now at the end of the Sloth ruin instead of Orange.

![image](https://user-images.githubusercontent.com/6519623/89507238-402f5280-d79a-11ea-87cb-b2ace64571b3.png)

![image](https://user-images.githubusercontent.com/6519623/89507249-4291ac80-d79a-11ea-95a7-caba5d9be242.png)


## Changelog
:cl:
tweak: Sloth has replaced their fruit with a plushie.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
