### PR TITLE
Fixes SSD people showing up as dead

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -153,7 +153,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					ijob = 80
 
 				if (nanite_sensors || U.sensor_mode >= SENSOR_LIVING)
-					life_status = (!H.stat ? TRUE : FALSE)
+					life_status = ((H.stat < DEAD) ? TRUE : FALSE) //So anything less that dead is marked as alive. (Soft crit, concious, unconcious)
 				else
 					life_status = null
 


### PR DESCRIPTION
Fixes #141 

## Changelog
:cl:
fix: SSD people no longer show up as dead on crew monitors.
tweak: People who are in a state of unconciousness or softcrit no longer show up as dead on crew monitors.
/:cl:

