### PR TITLE
Trekchem Changes (Consider them nerfs)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1035,13 +1035,16 @@
 
 /datum/reagent/medicine/bicaridinep
 	name = "Bicaridine Plus"
-	description = "Restores bruising. Overdose causes it instead. More effective than standardized Bicaridine."
+	description = "Restores bruising and slowly stems bleeding. Overdose causes it instead. More effective than standardized Bicaridine."
 	reagent_state = LIQUID
 	color = "#bf0000"
 	overdose_threshold = 25
 
 /datum/reagent/medicine/bicaridinep/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-2*REM, 0)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.bleed_rate = max(H.bleed_rate - .25, 0) 
 	..()
 	. = 1
 
@@ -1076,6 +1079,8 @@
 
 /datum/reagent/medicine/dexalinp/on_mob_life(mob/living/carbon/M)
 	M.adjustOxyLoss(-2*REM, 0)
+	if(C.blood_volume < BLOOD_VOLUME_NORMAL)
+		C.blood_volume += 1     //twice the rate of regular iron 
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1044,7 +1044,7 @@
 	M.adjustBruteLoss(-2*REM, 0)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.bleed_rate = max(H.bleed_rate - .25, 0) 
+		H.bleed_rate = max(H.bleed_rate - 0.25, 0) 
 	..()
 	. = 1
 
@@ -1079,8 +1079,8 @@
 
 /datum/reagent/medicine/dexalinp/on_mob_life(mob/living/carbon/M)
 	M.adjustOxyLoss(-2*REM, 0)
-	if(C.blood_volume < BLOOD_VOLUME_NORMAL)
-		C.blood_volume += 1     //twice the rate of regular iron 
+	if(ishuman(M) && M.blood_volume < BLOOD_VOLUME_NORMAL)
+		M.blood_volume += 1
 	..()
 	. = 1
 
@@ -1539,6 +1539,14 @@
 	color = "#FFFFD0"
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 
+/datum/reagent/medicine/silibinin/expose_mob(mob/living/carbon/M, method=INJECT, reac_volume)
+	if(method != INJECT)
+		return
+	
+	M.adjustOrganLoss(ORGAN_SLOT_LIVER, -1)  //on injection, will heal the liver. This will (hopefully) fix dead livers.
+	
+	..()
+
 /datum/reagent/medicine/silibinin/on_mob_life(mob/living/carbon/M)
 	M.adjustOrganLoss(ORGAN_SLOT_LIVER, -2)//Add a chance to cure liver trauma once implemented.
 	..()
@@ -1549,17 +1557,17 @@
 	description = "A purple mixture of short polyelectrolyte chains not easily synthesized in the laboratory. It is valued as an intermediate in the synthesis of the cutting edge pharmaceuticals."
 	reagent_state = SOLID
 	color = "#9423FF"
-	metabolization_rate = 0.25 * REAGENTS_METABOLISM
+	metabolization_rate = 0.15 * REAGENTS_METABOLISM
 	overdose_threshold = 50
 	taste_description = "numbing bitterness"
 
 /datum/reagent/medicine/polypyr/on_mob_life(mob/living/carbon/M) //I wanted a collection of small positive effects, this is as hard to obtain as coniine after all.
 	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, -0.25)
-	M.adjustBruteLoss(-0.35, 0)
+	M.adjustBruteLoss(-0.5, 0)
 	if(prob(50))
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
-			H.bleed_rate = max(H.bleed_rate - 1, 0)
+			H.bleed_rate = max(H.bleed_rate - 2, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1015,21 +1015,38 @@
 	M.reagents.remove_reagent(/datum/reagent/consumable/sugar, 3)
 	..()
 
-//Trek Chems, used primarily by medibots. Only heals a specific damage type, but is very efficient.
+//Trek Chems, simple to mix but weak as healing. Second tier trekchems will heal faster.
 /datum/reagent/medicine/bicaridine
 	name = "Bicaridine"
 	description = "Restores bruising. Overdose causes it instead."
 	reagent_state = LIQUID
-	color = "#C8A5DC"
+	color = "#bf0000"
 	overdose_threshold = 30
 
 /datum/reagent/medicine/bicaridine/on_mob_life(mob/living/carbon/M)
-	M.adjustBruteLoss(-2*REM, 0)
+	M.adjustBruteLoss(-0.5*REM, 0)
 	..()
 	. = 1
 
 /datum/reagent/medicine/bicaridine/overdose_process(mob/living/M)
-	M.adjustBruteLoss(4*REM, FALSE, FALSE, BODYPART_ORGANIC)
+	M.adjustBruteLoss(2*REM, FALSE, FALSE, BODYPART_ORGANIC)
+	..()
+	. = 1
+
+/datum/reagent/medicine/bicaridinep
+	name = "Bicaridine Plus"
+	description = "Restores bruising. Overdose causes it instead. More effective than standardized Bicaridine."
+	reagent_state = LIQUID
+	color = "#bf0000"
+	overdose_threshold = 25
+
+/datum/reagent/medicine/bicaridinep/on_mob_life(mob/living/carbon/M)
+	M.adjustBruteLoss(-2*REM, 0)
+	..()
+	. = 1
+
+/datum/reagent/medicine/bicaridinep/overdose_process(mob/living/M)
+	M.adjustBruteLoss(6*REM, FALSE, FALSE, BODYPART_ORGANIC)
 	..()
 	. = 1
 
@@ -1037,70 +1054,87 @@
 	name = "Dexalin"
 	description = "Restores oxygen loss. Overdose causes it instead."
 	reagent_state = LIQUID
-	color = "#C8A5DC"
+	color = "#0080FF"
 	overdose_threshold = 30
 
 /datum/reagent/medicine/dexalin/on_mob_life(mob/living/carbon/M)
-	M.adjustOxyLoss(-2*REM, 0)
+	M.adjustOxyLoss(-0.5*REM, 0)
 	..()
 	. = 1
 
 /datum/reagent/medicine/dexalin/overdose_process(mob/living/M)
-	M.adjustOxyLoss(4*REM, 0)
+	M.adjustOxyLoss(2*REM, 0)
 	..()
 	. = 1
 
 /datum/reagent/medicine/dexalinp
 	name = "Dexalin Plus"
-	description = "Restores oxygen loss. Overdose causes it instead. It is highly effective."
+	description = "Restores oxygen loss. Overdose causes it instead. More effective than standardized Dexalin."
 	reagent_state = LIQUID
 	color = "#0040FF"
 	overdose_threshold = 25
 
 /datum/reagent/medicine/dexalinp/on_mob_life(mob/living/carbon/M)
-	M.adjustOxyLoss(-4*REM, 0)
+	M.adjustOxyLoss(-2*REM, 0)
 	..()
 	. = 1
 
 /datum/reagent/medicine/dexalinp/overdose_process(mob/living/M)
-	M.adjustOxyLoss(8*REM, 0)
+	M.adjustOxyLoss(6*REM, 0)
 	..()
 	. = 1
 
 /datum/reagent/medicine/kelotane
 	name = "Kelotane"
-	description = "Restores fire damage. Overdose causes it instead."
+	description = "Heals burn damage. Overdose causes it instead."
 	reagent_state = LIQUID
-	color = "#C8A5DC"
+	color = "#FFa800"
 	overdose_threshold = 30
 
 /datum/reagent/medicine/kelotane/on_mob_life(mob/living/carbon/M)
-	M.adjustFireLoss(-2*REM, 0)
+	M.adjustFireLoss(-0.5*REM, 0)
 	..()
 	. = 1
 
 /datum/reagent/medicine/kelotane/overdose_process(mob/living/M)
-	M.adjustFireLoss(4*REM, FALSE, FALSE, BODYPART_ORGANIC)
+	M.adjustFireLoss(2*REM, FALSE, FALSE, BODYPART_ORGANIC)
+	..()
+	. = 1
+
+/datum/reagent/medicine/dermaline
+	name = "Dermaline"
+	description = "Heals burn damage. Overdose causes it instead. Superior to standardized Kelotane in healing capacity."
+	reagent_state = LIQUID
+	color = "#FF8000"
+	overdose_threshold = 25
+
+/datum/reagent/medicine/dermaline/on_mob_life(mob/living/carbon/M)
+	M.adjustFireLoss(-2*REM, 0)
+	..()
+	. = 1
+
+/datum/reagent/medicine/dermaline/overdose_process(mob/living/M)
+	M.adjustFireLoss(6*REM, FALSE, FALSE, BODYPART_ORGANIC)
 	..()
 	. = 1
 
 /datum/reagent/medicine/antitoxin
-	name = "Anti-Toxin"
+	name = "Dylovene"
 	description = "Heals toxin damage and removes toxins in the bloodstream. Overdose causes toxin damage."
 	reagent_state = LIQUID
-	color = "#C8A5DC"
+	color = "#00a000"
 	overdose_threshold = 30
 	taste_description = "a roll of gauze"
 
 /datum/reagent/medicine/antitoxin/on_mob_life(mob/living/carbon/M)
-	M.adjustToxLoss(-2*REM, 0)
+	M.adjustToxLoss(-0.5*REM, 0)
 	for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
 		M.reagents.remove_reagent(R.type,1)
 	..()
 	. = 1
 
 /datum/reagent/medicine/antitoxin/overdose_process(mob/living/M)
-	M.adjustToxLoss(4*REM, 0) // End result is 2 toxin loss taken, because it heals 2 and then removes 4.
+	M.adjustToxLoss(2*REM, 0) // End result is 1.5 toxin loss taken, because it heals 0.5 and then removes 2.
 	..()
 	. = 1
 
@@ -1117,28 +1151,33 @@
 
 /datum/reagent/medicine/tricordrazine
 	name = "Tricordrazine"
-	description = "Has a high chance to heal all types of damage. Overdose instead causes it."
+	description = "A weak dilutant that slowly heals brute, burn, and toxin damage."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
-	overdose_threshold = 30
-	taste_description = "grossness"
+	taste_description = "water that has been standing still in a glass on a counter overnight"
 
 /datum/reagent/medicine/tricordrazine/on_mob_life(mob/living/carbon/M)
 	if(prob(80))
-		M.adjustBruteLoss(-1*REM, 0)
-		M.adjustFireLoss(-1*REM, 0)
-		M.adjustOxyLoss(-1*REM, 0)
-		M.adjustToxLoss(-1*REM, 0)
+		M.adjustBruteLoss(-0.25*REM, 0)
+		M.adjustFireLoss(-0.25*REM, 0)
+		M.adjustToxLoss(-0.25*REM, 0)
 		. = 1
 	..()
+/datum/reagent/medicine/tetracordrazine //waspstation edit: Yes
+	name = "Tetracordrazine"
+	description = "A weak dilutant similar to Tricordrazine that slowly heals all damage types."
+	reagent_state = LIQUID
+	color = "#C8A5DC"
+	taste_description = "bottled water that has been sitting out in the sun with a single chili flake in it"
 
-/datum/reagent/medicine/tricordrazine/overdose_process(mob/living/M)
-	M.adjustToxLoss(2*REM, 0)
-	M.adjustOxyLoss(2*REM, 0)
-	M.adjustBruteLoss(2*REM, FALSE, FALSE, BODYPART_ORGANIC)
-	M.adjustFireLoss(2*REM, FALSE, FALSE, BODYPART_ORGANIC)
+/datum/reagent/medicine/tetracordrazine/on_mob_life(mob/living/carbon/M)
+	if(prob(80))
+		M.adjustBruteLoss(-0.25*REM, 0)
+		M.adjustFireLoss(-0.25*REM, 0)
+		M.adjustToxLoss(-0.25*REM, 0)
+		M.adjustOxyLoss(-0.5*REM, 0)
+		. = 1
 	..()
-	. = 1
 
 /datum/reagent/medicine/regen_jelly
 	name = "Regenerative Jelly"
@@ -1534,25 +1573,26 @@
 
 /datum/reagent/medicine/carthatoline
 	name = "Carthatoline"
-	description = "Carthatoline is strong evacuant used to treat severe poisoning."
+	description = "An evacuant that induces vomiting and purges toxins, as well as healing toxin damage. Superior to Dylovene. Overdose causes toxin damage."
 	reagent_state = LIQUID
 	color = "#225722"
+	overdose_threshold = 25
 
 /datum/reagent/medicine/carthatoline/on_mob_life(mob/living/carbon/M)
-	M.adjustToxLoss(-5*REM, 0)
+	M.adjustToxLoss(-2*REM, 0)
 	if(M.getToxLoss() && prob(10))
 		M.vomit(1)
 	for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
-		M.reagents.remove_reagent(R.type,1)
+		M.reagents.remove_reagent(R.type,2)
 	..()
 	. = 1
 
 /datum/reagent/medicine/carthatoline/overdose_process(mob/living/M)
-	M.adjustToxLoss(10*REM, 0) // End result is 5 toxin loss taken, because it heals 5 and then removes 10.
+	M.adjustToxLoss(6*REM, 0) // End result is 4 toxin loss taken. Do your own math.
 	..()
 	. = 1
 
-/datum/reagent/medicine/hepanephrodaxon
+/* /datum/reagent/medicine/hepanephrodaxon    //Waspstation edit: Temporary removal of overloaded chem
 	name = "Hepanephrodaxon"
 	description = "Used to repair the common tissues involved in filtration."
 	taste_description = "glue"
@@ -1584,7 +1624,7 @@
 	..()
 	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	ADD_TRAIT(L, TRAIT_STUNRESISTANCE, type)
-	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/hepanephrodaxon)
+	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/hepanephrodaxon) */ 
 
 /datum/reagent/medicine/bonefixingjuice
 	name = "C4L-Z1UM Agent"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -219,8 +219,8 @@
 	icon_state = "stimpen"
 	item_state = "stimpen"
 	volume = 57
-	amount_per_transfer_from_this = 57
-	list_reagents = list(/datum/reagent/medicine/salbutamol = 10, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/tricordrazine = 15, /datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/lavaland_extract = 2, /datum/reagent/medicine/omnizine = 5)
+	amount_per_transfer_from_this = 58
+	list_reagents = list(/datum/reagent/medicine/salbutamol = 10, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/bicaridinep = 8, /datum/reagent/medicine/dermaline = 8, /datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/lavaland_extract = 2, /datum/reagent/medicine/omnizine = 5)
 
 /obj/item/reagent_containers/hypospray/medipen/atropine
 	name = "atropine autoinjector"

--- a/waspstation/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/waspstation/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -4,7 +4,7 @@
 
 /datum/chemical_reaction/bicaridinep
 	results = list(/datum/reagent/medicine/bicaridinep = 3)
-	required_reagents = list(/datum/reagent/bicaridine = 1, /datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/sodiumchloride = 1)
+	required_reagents = list(/datum/reagent/medicine/bicaridine = 1, /datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/sodiumchloride = 1)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
 
 /datum/chemical_reaction/kelotane
@@ -26,7 +26,7 @@
 
 /datum/chemical_reaction/dexalinp
 	results = list(/datum/reagent/medicine/dexalinp = 3)
-	required_reagents = list(/datum/reagent/medicine/dexalin = 1, /datum/reagent/carbon = 1, /datum/reagent/iron = 1)
+	required_reagents = list(/datum/reagents/medicine/dexalin = 1, /datum/reagent/carbon = 1, /datum/reagent/iron = 1)
 
 /datum/chemical_reaction/tricordrazine
 	results = list(/datum/reagent/medicine/tricordrazine = 3)

--- a/waspstation/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/waspstation/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -26,7 +26,7 @@
 
 /datum/chemical_reaction/dexalinp
 	results = list(/datum/reagent/medicine/dexalinp = 3)
-	required_reagents = list(/datum/reagents/medicine/dexalin = 1, /datum/reagent/carbon = 1, /datum/reagent/iron = 1)
+	required_reagents = list(/datum/reagent/medicine/dexalin = 1, /datum/reagent/carbon = 1, /datum/reagent/iron = 1)
 
 /datum/chemical_reaction/tricordrazine
 	results = list(/datum/reagent/medicine/tricordrazine = 3)
@@ -34,7 +34,7 @@
 
 /datum/chemical_reaction/tetracordrazine
 	results = list(/datum/reagent/medicine/tetracordrazine = 4)
-	required_reagents = list(/datum/reagent/medicine/tricordrazine = 3, datum/reagent/medicine/dexalin = 1)
+	required_reagents = list(/datum/reagent/medicine/tricordrazine = 3, /datum/reagent/medicine/dexalin = 1)
 /datum/chemical_reaction/synthflesh
 	results = list(/datum/reagent/medicine/synthflesh = 3)
 	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1)

--- a/waspstation/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/waspstation/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -2,9 +2,18 @@
 	results = list(/datum/reagent/medicine/bicaridine = 3)
 	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/oxygen = 1, /datum/reagent/consumable/sugar = 1)
 
+/datum/chemical_reaction/bicaridinep
+	results = list(/datum/reagent/medicine/bicaridinep = 3)
+	required_reagents = list(/datum/reagent/bicaridine = 1, /datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/sodiumchloride = 1)
+	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
+
 /datum/chemical_reaction/kelotane
 	results = list(/datum/reagent/medicine/kelotane = 2)
 	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/silicon = 1)
+
+/datum/chemical_reaction/dermaline
+	results = list(/datum/reagent/medicine/dermaline = 3)
+	required_reagents = list(/datum/reagent/medicine/kelotane = 1, /datum/reagent/acetone = 1, /datum/reagent/phosphorus = 1)
 
 /datum/chemical_reaction/antitoxin
 	results = list(/datum/reagent/medicine/antitoxin = 3)
@@ -13,7 +22,7 @@
 /datum/chemical_reaction/dexalin
 	results = list(/datum/reagent/medicine/dexalin = 5)
 	required_reagents = list(/datum/reagent/oxygen = 5)
-	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
+	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
 
 /datum/chemical_reaction/dexalinp
 	results = list(/datum/reagent/medicine/dexalinp = 3)
@@ -23,6 +32,9 @@
 	results = list(/datum/reagent/medicine/tricordrazine = 3)
 	required_reagents = list(/datum/reagent/medicine/bicaridine = 1, /datum/reagent/medicine/kelotane = 1, /datum/reagent/medicine/antitoxin = 1)
 
+/datum/chemical_reaction/tetracordrazine
+	results = list(/datum/reagent/medicine/tetracordrazine = 4)
+	required_reagents = list(/datum/reagent/medicine/tricordrazine = 3, datum/reagent/medicine/dexalin = 1)
 /datum/chemical_reaction/synthflesh
 	results = list(/datum/reagent/medicine/synthflesh = 3)
 	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1)
@@ -34,16 +46,17 @@
 
 /datum/chemical_reaction/corazone
 	results = list(/datum/reagent/medicine/corazone = 3)
+	required_reagents = list(/datum/reagent/phenol = 2, /datum/reagent/lithium = 1)
 
 /datum/chemical_reaction/carthatoline
 	results = list(/datum/reagent/medicine/carthatoline = 3)
 	required_reagents = list(/datum/reagent/medicine/antitoxin = 1, /datum/reagent/carbon = 2)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
 
-/datum/chemical_reaction/hepanephrodaxon
+/*/datum/chemical_reaction/hepanephrodaxon //waspstation edit: temporary removal of an overloaded chem
 	results = list(/datum/reagent/medicine/hepanephrodaxon = 5)
 	required_reagents = list(/datum/reagent/medicine/carthatoline = 2, /datum/reagent/carbon = 2, /datum/reagent/lithium = 1)
-	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
+	required_catalysts = list(/datum/reagent/toxin/plasma = 5)*/
 
 /datum/chemical_reaction/system_cleaner
 	results = list(/datum/reagent/medicine/system_cleaner = 4)


### PR DESCRIPTION
## About The Pull Request

This PR does the following: 
Nerfs the healing of basic trekchems down to 0.5 damage per tick for all basic types. 
Adds Bicaridine Plus and Dermaline, "Upgraded" versions of Bicaridine and Kelotane that heal 2 damage per tick.
Lowers Dexalin Plus' healing to 2 damage per tick. 
Lowers Carthatoline's healing to 2 damage per tick but increased the purge rate to 2.
Lowers the healing of Tricordrazine down to an average of .2 damage of all types healed per tick. No longer heals oxyloss.
Added Tetracordrazine, which heals at the same rate of Tricord but also heals oxyloss. Make by mixing 3 units Tricord with 1 unit Dexalin.
Removed Tricordrazine's OD.
Commented out Hepanephrodaxon and it's recipe. Will be readded at a later date along with more chem changes.
Readds corazone's recipe.

I'm coming for you next, goonchems.

## Why It's Good For The Game

The basic trekchem nerfs are to encourage putting effort into mixing more involved chems, such as libital, trophazole, salicylic, etc. instead of simple 3 button press chems that heal just as well. 
The tricordrazine nerf is to encourage its use as a dilutant rather as a cureall for basic damage.
The (temporary) removal of Hepanephrodaxon is because.. it's OP as hell? As of right now, it heals 12 toxin damage per tick (more than thializid, anti-toxin, pentetic, and charcoal combined) on top of healing liver damage, on top of healing 10 stamina damage per tick, on top of having a *beneficial* OD that makes you sleep immune, speeds you up, and gives you Pump-Up's stun resistance!  All this for a chem you can mix with just a chem dispenser and a bar of plasma for a catalyst is very powerful.

## Changelog
:cl:
add: New chems. Bicaridine Plus, Dermaline, and Tetracordrazine.
del: Hepanephrodaxon. Will return at a later date.
balance: Lowered the healing on many trekchems
balance: Tricordrazine no longer has an OD
fix: Corazone has a recipe again
/:cl: