### PR TITLE
Pyroclastic anom rebalance

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -265,13 +265,13 @@
 /obj/effect/anomaly/pyro/anomalyEffect()
 	..()
 	ticks++
-	if(ticks < 25)
+	if(ticks < 25) // WaspStation Edit - Pyroclastic Rebalance
 		return
 	else
 		ticks = 0
 	var/turf/open/T = get_turf(src)
 	if(istype(T))
-		T.atmos_spawn_air("o2=5;plasma=5;TEMP=700")
+		T.atmos_spawn_air("o2=5;plasma=5;TEMP=700") // WaspStation Edit - Pyroclastic Rebalance
 
 /obj/effect/anomaly/pyro/detonate()
 	INVOKE_ASYNC(src, .proc/makepyroslime)

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -265,13 +265,13 @@
 /obj/effect/anomaly/pyro/anomalyEffect()
 	..()
 	ticks++
-	if(ticks < 5)
+	if(ticks < 25)
 		return
 	else
 		ticks = 0
 	var/turf/open/T = get_turf(src)
 	if(istype(T))
-		T.atmos_spawn_air("o2=5;plasma=5;TEMP=1000")
+		T.atmos_spawn_air("o2=5;plasma=5;TEMP=250")
 
 /obj/effect/anomaly/pyro/detonate()
 	INVOKE_ASYNC(src, .proc/makepyroslime)

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -271,7 +271,7 @@
 		ticks = 0
 	var/turf/open/T = get_turf(src)
 	if(istype(T))
-		T.atmos_spawn_air("o2=5;plasma=5;TEMP=250")
+		T.atmos_spawn_air("o2=5;plasma=5;TEMP=700")
 
 /obj/effect/anomaly/pyro/detonate()
 	INVOKE_ASYNC(src, .proc/makepyroslime)

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -279,7 +279,7 @@
 /obj/effect/anomaly/pyro/proc/makepyroslime()
 	var/turf/open/T = get_turf(src)
 	if(istype(T))
-		T.atmos_spawn_air("o2=250;plasma=250;TEMP=700") //Make it hot and burny for the new slime
+		T.atmos_spawn_air("o2=250;plasma=250;TEMP=700") // WaspStation Edit - Pyroclastic Rebalance
 	var/new_colour = pick("red", "orange")
 	var/mob/living/simple_animal/slime/S = new(T, new_colour)
 	S.rabid = TRUE

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -271,7 +271,7 @@
 		ticks = 0
 	var/turf/open/T = get_turf(src)
 	if(istype(T))
-		T.atmos_spawn_air("o2=5;plasma=5;TEMP=700") // WaspStation Edit - Pyroclastic Rebalance
+		T.atmos_spawn_air("o2=5;plasma=5;TEMP=500") // WaspStation Edit - Pyroclastic Rebalance
 
 /obj/effect/anomaly/pyro/detonate()
 	INVOKE_ASYNC(src, .proc/makepyroslime)
@@ -279,7 +279,7 @@
 /obj/effect/anomaly/pyro/proc/makepyroslime()
 	var/turf/open/T = get_turf(src)
 	if(istype(T))
-		T.atmos_spawn_air("o2=500;plasma=500;TEMP=1000") //Make it hot and burny for the new slime
+		T.atmos_spawn_air("o2=250;plasma=250;TEMP=700") //Make it hot and burny for the new slime
 	var/new_colour = pick("red", "orange")
 	var/mob/living/simple_animal/slime/S = new(T, new_colour)
 	S.rabid = TRUE

--- a/code/modules/events/anomaly_pyro.dm
+++ b/code/modules/events/anomaly_pyro.dm
@@ -1,9 +1,9 @@
 /datum/round_event_control/anomaly/anomaly_pyro
 	name = "Anomaly: Pyroclastic"
 	typepath = /datum/round_event/anomaly/anomaly_pyro
-	
+
 	max_occurrences = 5
-	weight = 20
+	weight = 15 // WaspStation Edit - Pyroclastic Rebalance
 
 /datum/round_event/anomaly/anomaly_pyro
 	startWhen = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces the tick rate for a pyro anomaly spawning Oxygen/Plasma, and reduces the temperature, making them less of a cataclysmic event when they spawn.

## Why It's Good For The Game

Monstermos made cleaning these up a 20-30 minute affair, for a single anomaly that goes all the way to the slime stage. This should hopefully reduce the pain of doing so (a bit).

## Changelog
:cl:
balance: reduced the tick rate for pyroclastic anomalies to 1/5th original (5 ticks/emission to 25 ticks/emission)
balance: reduced the temperature for tick spawned plasma/oxygen by 500 Kelvin
balance: reduced the temperature and mols of detonation spawned plasma/oxygen by 300 Kelvin and 250mols.
balance: reduced the weight for pyroclastic anomaly spawns from 20 to 15.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
