### PR TITLE
AAC Reliability Improvement

### DIFF
--- a/code/game/machinery/airlock_cycle_control.dm
+++ b/code/game/machinery/airlock_cycle_control.dm
@@ -553,7 +553,7 @@
 					if(assume_roles)
 						for(var/adir in GLOB.cardinals)
 							var/turf/check_turf = get_step(T2, adir)
-							if(check_turf.loc != T2.loc)
+							if(check_turf.initial_gas_mix != OPENTURF_DEFAULT_ATMOS)
 								airlocks[A] = 1
 								break
 		for(var/obj/machinery/atmospherics/components/unary/vent_pump/vent in T)

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -7,6 +7,7 @@
 	temperature = TCMB
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = 700000
+	initial_gas_mix = AIRLESS_ATMOS
 
 	FASTDMM_PROP(\
 		pipe_astar_cost = 5\


### PR DESCRIPTION

## About The Pull Request
Makes AACs check for a turf with something different than the initial default gasmix, such as space and airless tiles.

## Changelog
:cl:
fix: Advanced Airlock Controllers should now be <i>slightly</i> more reliable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
