### PR TITLE
Reduces the chance of accident prone people venting the arrival and escape shuttles.

### DIFF
--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -5,12 +5,6 @@
 "b" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
-"c" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Arrivals Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/arrival)
 "d" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
@@ -153,6 +147,13 @@
 "S" = (
 /turf/open/floor/mineral/titanium,
 /area/shuttle/arrival)
+"T" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Arrivals Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
 
 (1,1,1) = {"
 a
@@ -200,13 +201,13 @@ x
 b
 "}
 (6,1,1) = {"
-c
+T
 f
 r
 r
 r
 f
-c
+T
 "}
 (7,1,1) = {"
 b
@@ -263,13 +264,13 @@ z
 b
 "}
 (13,1,1) = {"
-c
+T
 f
 S
 S
 S
 f
-c
+T
 "}
 (14,1,1) = {"
 b

--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -155,18 +155,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
-"n" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Arrival Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/arrival)
 "o" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -475,20 +463,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
+"X" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Arrival Shuttle Airlock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
+/area/shuttle/arrival)
 
 (1,1,1) = {"
 a
 d
 f
 g
-n
+X
 g
 h
 h
 h
 h
 z
-n
+X
 g
 g
 a
@@ -633,14 +634,14 @@ a
 d
 f
 g
-n
+X
 g
 h
 h
 h
 h
 z
-n
+X
 g
 g
 a

--- a/_maps/shuttles/arrival_donut.dmm
+++ b/_maps/shuttles/arrival_donut.dmm
@@ -36,10 +36,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
-"k" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/plating,
-/area/shuttle/arrival)
 "l" = (
 /obj/machinery/light{
 	dir = 8
@@ -73,6 +69,11 @@
 	name = "donut arrivals shuttle"
 	},
 /turf/open/floor/plating/airless,
+/area/shuttle/arrival)
+"H" = (
+/obj/machinery/door/airlock/titanium,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
 /area/shuttle/arrival)
 
 (1,1,1) = {"
@@ -170,12 +171,12 @@ a
 b
 b
 b
-k
+H
 b
 o
 o
 b
-k
+H
 b
 b
 a

--- a/_maps/shuttles/arrival_kilo.dmm
+++ b/_maps/shuttles/arrival_kilo.dmm
@@ -8,16 +8,6 @@
 "c" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
-"d" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Arrival Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/arrival)
 "e" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/mineral/titanium,
@@ -73,8 +63,8 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle,
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 1
+	dir = 1;
+	icon_state = "tube"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
@@ -90,23 +80,10 @@
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 1
+	dir = 1;
+	icon_state = "tube"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/arrival)
-"m" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
 "n" = (
 /obj/structure/shuttle/engine/propulsion/left{
@@ -133,28 +110,12 @@
 /obj/item/flashlight,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
-"q" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
 "r" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/door/airlock/shuttle{
+	name = "Arrival Shuttle Airlock"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "s" = (
 /obj/effect/turf_decal/tile/blue{
@@ -162,17 +123,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
-"t" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/chair/comfy/shuttle,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "u" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -208,16 +158,6 @@
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/arrival)
-"w" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
 "x" = (
 /obj/effect/turf_decal/bot,
@@ -260,41 +200,6 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
-"C" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
-"D" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/airlock/shuttle{
-	name = "Arrival Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/arrival)
-"E" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
 "F" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -318,50 +223,18 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "I" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
-"J" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/item/radio/intercom{
+	pixel_x = 28
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
-"K" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
 "L" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/arrival)
-"M" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "N" = (
 /obj/effect/turf_decal/bot,
@@ -371,17 +244,33 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "O" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/arrival)
+"R" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Arrival Shuttle Airlock"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/arrival)
+"W" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 
 (1,1,1) = {"
@@ -412,73 +301,73 @@ i
 c
 "}
 (4,1,1) = {"
-d
-m
-r
-q
-J
-m
+R
+s
+s
+s
+s
+s
 f
 "}
 (5,1,1) = {"
 e
 j
-w
 s
-K
+s
+s
 x
 e
 "}
 (6,1,1) = {"
 f
 k
-w
+s
 y
-K
+s
 N
 f
 "}
 (7,1,1) = {"
 f
 k
-w
+s
 z
-K
+s
 N
 f
 "}
 (8,1,1) = {"
 f
 k
-w
+s
 A
-K
+s
 N
 f
 "}
 (9,1,1) = {"
 c
 l
-w
 s
-K
+s
+s
 B
 c
 "}
 (10,1,1) = {"
-d
-q
-C
-E
-O
-q
+R
+s
+I
+s
+s
+s
 f
 "}
 (11,1,1) = {"
 b
 c
 c
-D
+r
 L
 c
 b
@@ -486,9 +375,9 @@ b
 (12,1,1) = {"
 c
 e
-t
-I
-M
+O
+F
+W
 e
 c
 "}

--- a/_maps/shuttles/arrival_pubby.dmm
+++ b/_maps/shuttles/arrival_pubby.dmm
@@ -5,12 +5,6 @@
 "b" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
-"c" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Arrivals Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/arrival)
 "d" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
@@ -142,6 +136,13 @@
 "C" = (
 /turf/open/floor/mineral/titanium,
 /area/shuttle/arrival)
+"K" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Arrivals Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
 
 (1,1,1) = {"
 a
@@ -176,12 +177,12 @@ s
 b
 "}
 (5,1,1) = {"
-c
+K
 f
 o
 o
 f
-c
+K
 "}
 (6,1,1) = {"
 b
@@ -224,12 +225,12 @@ u
 b
 "}
 (11,1,1) = {"
-c
+K
 f
 C
 C
 f
-c
+K
 "}
 (12,1,1) = {"
 b

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -10,41 +10,9 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"ae" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
 "ah" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"ai" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"aj" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dir = 2;
-	dwidth = 10;
-	height = 13;
-	name = "Asteroid emergency shuttle";
-	width = 28
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"al" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "am" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -443,6 +411,20 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"lJ" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Fw" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "Jx" = (
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -452,6 +434,28 @@
 	use_power = 0
 	},
 /turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"MR" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Rs" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dir = 2;
+	dwidth = 10;
+	height = 13;
+	name = "Asteroid emergency shuttle";
+	width = 28
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -530,7 +534,7 @@ bE
 ad
 "}
 (6,1,1) = {"
-ae
+lJ
 aq
 aq
 aq
@@ -620,7 +624,7 @@ aa
 aa
 "}
 (12,1,1) = {"
-ai
+Fw
 at
 at
 at
@@ -710,7 +714,7 @@ aa
 aa
 "}
 (18,1,1) = {"
-aj
+Rs
 at
 at
 at
@@ -800,7 +804,7 @@ bF
 ac
 "}
 (24,1,1) = {"
-al
+MR
 aw
 aw
 aw

--- a/_maps/shuttles/emergency_backup.dmm
+++ b/_maps/shuttles/emergency_backup.dmm
@@ -5,11 +5,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape/backup)
-"c" = (
-/obj/machinery/door/airlock/titanium,
-/obj/docking_port/mobile/emergency/backup,
-/turf/open/floor/plating,
-/area/shuttle/escape/backup)
 "f" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/random,
@@ -40,6 +35,12 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape/backup)
+"A" = (
+/obj/machinery/door/airlock/titanium,
+/obj/docking_port/mobile/emergency/backup,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape/backup)
 "F" = (
 /obj/structure/table/wood,
 /obj/item/paper/fluff/stations/centcom/broken_evac,
@@ -55,7 +56,7 @@
 (1,1,1) = {"
 m
 m
-c
+A
 m
 m
 m

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -219,13 +219,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"aK" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "aL" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -284,19 +277,6 @@
 /obj/structure/table,
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/food/drinks/bottle/lizardwine,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
-"aT" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "The Emergency Escape Bar"
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -369,16 +349,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"bg" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
 "bi" = (
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
@@ -388,6 +358,20 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"bl" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "The Emergency Escape Bar"
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "bm" = (
@@ -400,12 +384,6 @@
 /obj/effect/spawner/structure/window/shuttle,
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"bo" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "bp" = (
 /turf/open/floor/plasteel/freezer,
@@ -662,6 +640,32 @@
 /obj/machinery/sleeper,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"jm" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"sS" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"Cg" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
 "Yn" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -678,17 +682,17 @@ aa
 ab
 ab
 ab
-aK
+Cg
 ab
-aT
+bl
 ab
 ac
 ac
 ac
 ab
-bg
+jm
 ab
-bo
+sS
 ab
 ab
 ab

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -194,14 +194,7 @@
 /area/shuttle/escape)
 "K" = (
 /obj/machinery/door/airlock/titanium,
-/obj/docking_port/mobile/emergency{
-	dir = 8;
-	dwidth = 6;
-	height = 18;
-	name = "Birdboat emergency escape shuttle";
-	port_direction = 4;
-	width = 14
-	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "L" = (
@@ -296,6 +289,19 @@
 /obj/structure/table/glass,
 /obj/item/defibrillator/loaded,
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Z" = (
+/obj/machinery/door/airlock/titanium,
+/obj/docking_port/mobile/emergency{
+	dir = 8;
+	dwidth = 6;
+	height = 18;
+	name = "Birdboat emergency escape shuttle";
+	port_direction = 4;
+	width = 14
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -577,8 +583,8 @@ p
 u
 b
 b
-G
 K
+Z
 b
 b
 g

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -171,13 +171,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"aI" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "aJ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -191,15 +184,6 @@
 "aM" = (
 /obj/structure/table,
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"aP" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Box emergency shuttle"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aQ" = (
 /obj/structure/extinguisher_cabinet{
@@ -234,12 +218,6 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"aV" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aW" = (
 /obj/structure/extinguisher_cabinet{
@@ -364,6 +342,31 @@
 "ga" = (
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"he" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"If" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"OS" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Box emergency shuttle"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "XC" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium/white,
@@ -377,17 +380,17 @@ aa
 ad
 ad
 ad
-aI
+If
 ad
-aP
+OS
 ad
 ac
 ac
 ac
 ad
-aV
+he
 ad
-aV
+he
 ad
 ad
 ad

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -639,13 +639,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"bv" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "bw" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -695,18 +688,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/escape)
-"bE" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dwidth = 15;
-	height = 20;
-	name = "Cere emergency shuttle";
-	width = 42
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "bF" = (
 /obj/structure/closet/crate/bin,
@@ -934,12 +915,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/escape)
-"bY" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "bZ" = (
 /obj/structure/extinguisher_cabinet{
@@ -1729,12 +1704,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
+"ip" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dwidth = 15;
+	height = 20;
+	name = "Cere emergency shuttle";
+	width = 42
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "pf" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	use_power = 0
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"uE" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"xN" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -1751,17 +1754,17 @@ ab
 ab
 ab
 ab
-bv
+xN
 ab
-bE
+ip
 ab
 aa
 aa
 aa
 ab
-bY
+uE
 ab
-bY
+uE
 ab
 aa
 aa

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -174,15 +174,6 @@
 /obj/item/toy/sword,
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
-"aI" = (
-/obj/machinery/door/airlock/bananium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Snappop(tm)!"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "aJ" = (
 /obj/item/toy/snappop/phoenix,
 /obj/machinery/light/small{
@@ -236,12 +227,6 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/bananium,
-/area/shuttle/escape)
-"aQ" = (
-/obj/machinery/door/airlock/bananium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aR" = (
 /obj/item/toy/snappop/phoenix,
@@ -340,6 +325,23 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"tt" = (
+/obj/machinery/door/airlock/bananium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Jq" = (
+/obj/machinery/door/airlock/bananium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Snappop(tm)!"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "Zf" = (
 /obj/structure/closet/emcloset,
 /obj/item/toy/sword,
@@ -356,15 +358,15 @@ ab
 ab
 ab
 ab
-aI
+Jq
 ab
 ac
 ac
 ac
 ab
-aQ
+tt
 ab
-aQ
+tt
 ab
 ab
 ab

--- a/_maps/shuttles/emergency_construction.dmm
+++ b/_maps/shuttles/emergency_construction.dmm
@@ -30,28 +30,8 @@
 "f" = (
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"g" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "h" = (
 /obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"i" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency/shuttle_build{
-	dwidth = 9;
-	height = 15;
-	name = "Shuttle Under Construction";
-	port_direction = 4;
-	preferred_direction = 2;
-	width = 26
-	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "j" = (
@@ -175,6 +155,28 @@
 "p" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
+"x" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"G" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency/shuttle_build{
+	dwidth = 9;
+	height = 15;
+	name = "Shuttle Under Construction";
+	port_direction = 4;
+	preferred_direction = 2;
+	width = 26
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 a
@@ -184,17 +186,17 @@ e
 h
 e
 e
-g
+x
 e
-i
+G
 e
 e
 h
 e
 e
-g
+x
 e
-g
+x
 e
 p
 a

--- a/_maps/shuttles/emergency_cramped.dmm
+++ b/_maps/shuttles/emergency_cramped.dmm
@@ -6,13 +6,6 @@
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"c" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "d" = (
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
@@ -54,18 +47,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"k" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dwidth = 3;
-	height = 5;
-	name = "Secure Transport Vessel 5";
-	width = 14
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "l" = (
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -92,12 +73,6 @@
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/shuttle/escape)
-"q" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "r" = (
 /obj/structure/closet/crate/secure/weapon,
@@ -141,20 +116,48 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
+"A" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dwidth = 3;
+	height = 5;
+	name = "Secure Transport Vessel 5";
+	width = 14
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"V" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"W" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 a
-c
+V
 a
-k
+A
 a
 b
 b
 b
 a
-q
+W
 a
-q
+W
 a
 a
 "}

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -32,6 +32,19 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/escape)
+"bJ" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/docking_port/mobile/emergency{
+	height = 22;
+	name = "The NTSS Independence";
+	width = 44
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/wood,
+/area/shuttle/escape)
 "ca" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/wood,
@@ -456,6 +469,14 @@
 /obj/machinery/computer/warrant,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
+"qe" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/wood,
+/area/shuttle/escape)
 "qr" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -769,6 +790,14 @@
 "xj" = (
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"xJ" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/wood,
+/area/shuttle/escape)
 "yn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -858,18 +887,6 @@
 /obj/item/kirbyplants/photosynthetic,
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
-/area/shuttle/escape)
-"CR" = (
-/obj/machinery/door/airlock/shuttle,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/docking_port/mobile/emergency{
-	height = 22;
-	name = "The NTSS Independence";
-	width = 44
-	},
-/turf/open/floor/wood,
 /area/shuttle/escape)
 "Do" = (
 /obj/effect/turf_decal/tile/blue{
@@ -1663,8 +1680,8 @@ kd
 kd
 kd
 jt
-qE
-CR
+qe
+bJ
 jt
 kd
 kd
@@ -1680,8 +1697,8 @@ kd
 kd
 kd
 jt
-qE
-qE
+qe
+qe
 jt
 kd
 kd
@@ -2629,8 +2646,8 @@ kd
 kd
 kd
 jt
-aY
-aY
+xJ
+xJ
 jt
 kd
 kd
@@ -2646,8 +2663,8 @@ kd
 kd
 kd
 jt
-aY
-aY
+xJ
+xJ
 jt
 kd
 kd

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -482,15 +482,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
-"aO" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/escape)
 "aP" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium,
@@ -531,20 +522,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/shuttle/escape)
-"aW" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dwidth = 11;
-	height = 18;
-	name = "Delta emergency shuttle";
-	port_direction = 4;
-	preferred_direction = 2;
-	width = 30
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aX" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -766,16 +743,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"bv" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/escape)
 "bw" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
@@ -875,15 +842,6 @@
 /area/shuttle/escape)
 "bK" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
-"bL" = (
-/obj/machinery/door/airlock/external{
-	name = "Emergency Recovery Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1372,9 +1330,55 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
+"gW" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dwidth = 11;
+	height = 18;
+	name = "Delta emergency shuttle";
+	port_direction = 4;
+	preferred_direction = 2;
+	width = 30
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "hB" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"iW" = (
+/obj/machinery/door/airlock/external{
+	name = "Emergency Recovery Airlock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"qs" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"re" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -1387,17 +1391,17 @@ hB
 hB
 af
 af
-aO
+re
 aT
-aW
+gW
 af
 hB
 hB
 hB
 af
-aO
+re
 af
-bv
+qs
 af
 af
 af
@@ -1925,8 +1929,8 @@ hB
 af
 af
 hB
-bL
-bL
+iW
+iW
 hB
 af
 aa

--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -101,24 +101,9 @@
 "t" = (
 /turf/open/floor/light/colour_cycle,
 /area/shuttle/escape)
-"u" = (
-/obj/docking_port/mobile/emergency{
-	name = "Disco Inferno"
-	},
-/obj/machinery/door/airlock/gold{
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100);
-	heat_proof = 1;
-	resistance_flags = 2
-	},
-/turf/open/floor/mineral/plasma,
-/area/shuttle/escape)
 "v" = (
 /obj/machinery/jukebox/disco/indestructible,
 /turf/open/floor/light/colour_cycle,
-/area/shuttle/escape)
-"w" = (
-/obj/machinery/door/airlock/gold,
-/turf/open/floor/wood,
 /area/shuttle/escape)
 "x" = (
 /turf/open/floor/wood,
@@ -218,6 +203,23 @@
 "O" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/escape)
+"V" = (
+/obj/docking_port/mobile/emergency{
+	name = "Disco Inferno"
+	},
+/obj/machinery/door/airlock/gold{
+	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100);
+	heat_proof = 1;
+	resistance_flags = 2
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plasma,
+/area/shuttle/escape)
+"Y" = (
+/obj/machinery/door/airlock/gold,
+/obj/structure/fans/tiny,
+/turf/open/floor/wood,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 a
@@ -229,7 +231,7 @@ b
 b
 c
 b
-u
+V
 b
 c
 c
@@ -237,7 +239,7 @@ c
 b
 O
 b
-w
+Y
 b
 c
 b

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -235,34 +235,11 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"aP" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "aQ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"aR" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"aS" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Donut emergency shuttle";
-	width = 34
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aT" = (
 /obj/structure/extinguisher_cabinet,
@@ -491,6 +468,32 @@
 /obj/structure/table/optable,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"mi" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"JE" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"RH" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Donut emergency shuttle";
+	width = 34
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -506,17 +509,17 @@ aa
 aa
 ab
 ab
-aP
+mi
 ab
-aS
+RH
 ab
 aa
 aa
 aa
 ab
-aR
+JE
 ac
-aR
+JE
 ab
 aa
 ab
@@ -974,17 +977,17 @@ aa
 aa
 ab
 ab
-aR
+JE
 ac
-aR
+JE
 ab
 aa
 aa
 aa
 ab
-aR
+JE
 ac
-aR
+JE
 ab
 aa
 ab

--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -24,12 +24,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"g" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "h" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"
@@ -39,6 +33,7 @@
 	name = "NES Port";
 	width = 19
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "l" = (
@@ -208,6 +203,13 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"U" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "V" = (
 /obj/machinery/light{
 	dir = 1
@@ -343,7 +345,7 @@ d
 d
 "}
 (9,1,1) = {"
-g
+U
 r
 r
 r
@@ -353,7 +355,7 @@ r
 r
 r
 r
-g
+U
 "}
 (10,1,1) = {"
 h
@@ -366,7 +368,7 @@ r
 r
 r
 r
-g
+U
 "}
 (11,1,1) = {"
 d

--- a/_maps/shuttles/emergency_imfedupwiththisworld.dmm
+++ b/_maps/shuttles/emergency_imfedupwiththisworld.dmm
@@ -6,16 +6,6 @@
 /obj/machinery/light_switch,
 /turf/closed/wall/mineral/wood,
 /area/shuttle/escape)
-"c" = (
-/obj/docking_port/mobile/emergency{
-	dwidth = 1;
-	height = 10;
-	name = "Oh Hi Marg";
-	width = 12
-	},
-/obj/machinery/door/airlock/wood,
-/turf/open/floor/wood,
-/area/shuttle/escape)
 "d" = (
 /turf/open/floor/wood,
 /area/shuttle/escape)
@@ -187,10 +177,21 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/wood,
 /area/shuttle/escape)
+"Q" = (
+/obj/docking_port/mobile/emergency{
+	dwidth = 1;
+	height = 10;
+	name = "Oh Hi Marg";
+	width = 12
+	},
+/obj/machinery/door/airlock/wood,
+/obj/structure/fans/tiny,
+/turf/open/floor/wood,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 a
-c
+Q
 a
 a
 a

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -49,41 +49,6 @@
 /obj/machinery/recharger,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"ak" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/box/corners,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"al" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/chair/comfy/shuttle,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"am" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "an" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -93,74 +58,8 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"ao" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/shuttle{
-	name = "External Shuttle Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"ap" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/crowbar/red,
-/obj/item/storage/lockbox/loyalty,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"aq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/chair/comfy/shuttle,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"ar" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/recharger,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "as" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"at" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = -24
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "au" = (
 /obj/structure/table/reinforced,
@@ -176,25 +75,6 @@
 /obj/item/gun/energy/e_gun/mini,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"av" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = 24
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "aw" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -203,46 +83,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"ax" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"ay" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"az" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "aA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -250,48 +90,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"aB" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"aC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "aD" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"aE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "aF" = (
 /obj/structure/table/reinforced,
@@ -300,19 +101,6 @@
 	dir = 1
 	},
 /obj/item/storage/fancy/donut_box,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"aG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "aH" = (
@@ -325,17 +113,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"aI" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "aJ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/security/glass{
@@ -344,38 +121,8 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"aK" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "aL" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"aM" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -395,29 +142,6 @@
 "aO" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"aP" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"aQ" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "aR" = (
 /obj/item/clothing/suit/hazardvest{
@@ -454,103 +178,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"aS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"aT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"aU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/item/kirbyplants{
-	icon_state = "applebush"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"aV" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"aW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"aX" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"aY" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"aZ" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
 "ba" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle{
@@ -561,68 +188,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"bb" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_one_access_txt = "63"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"bc" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"bd" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"be" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"bf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/storage/box/zipties{
-	pixel_y = 4
-	},
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "bg" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
@@ -630,38 +195,6 @@
 "bh" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"bi" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"bj" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"bk" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "bl" = (
 /obj/effect/turf_decal/bot,
@@ -704,55 +237,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"bq" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Kilo emergency shuttle"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"br" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bs" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bt" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "bu" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle,
@@ -769,26 +253,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"bw" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "by" = (
 /obj/structure/sign/departments/engineering{
 	pixel_y = 32
@@ -800,31 +264,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"bz" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bA" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "bB" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle{
@@ -834,63 +273,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"bC" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bD" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bE" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bF" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bH" = (
 /obj/effect/turf_decal/bot,
@@ -909,54 +291,12 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"bJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "bK" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"bL" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bM" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bN" = (
 /obj/machinery/vending/wallmed{
@@ -985,114 +325,6 @@
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
-"bR" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bS" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bT" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bW" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bX" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"bY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "bZ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle{
@@ -1104,16 +336,6 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"ca" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "cb" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -1121,68 +343,11 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"cc" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cd" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"ce" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cf" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "cg" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/o2,
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"ch" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/item/kirbyplants{
-	icon_state = "applebush"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "ci" = (
 /obj/structure/table,
@@ -1191,16 +356,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "cj" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"ck" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -1260,50 +415,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"cp" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"cq" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-05"
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"cr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"cs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
 "ct" = (
 /obj/structure/closet/crate/medical,
 /obj/item/storage/firstaid/regular,
@@ -1328,85 +439,10 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"cu" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/sleeper,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"cv" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cw" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cx" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cy" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/sleeper,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "cz" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/recharge_station,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"cA" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"cB" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "cC" = (
 /obj/effect/turf_decal/delivery,
@@ -1432,59 +468,10 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"cE" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cF" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "cG" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cH" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cI" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -1542,44 +529,6 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"cN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cO" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/chair/office/light,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cP" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cQ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/chair/office/light,
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "cR" = (
 /obj/structure/table,
@@ -1677,6 +626,402 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"eL" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = -24
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"fu" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"gc" = (
+/obj/effect/turf_decal/box/corners,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"hl" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"hE" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"is" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/recharger,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"iu" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/item/storage/box/zipties{
+	pixel_y = 4
+	},
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"kS" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/airlock/shuttle{
+	name = "External Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"lX" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"nT" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"pP" = (
+/obj/machinery/door/airlock/command{
+	name = "Shuttle Control";
+	req_one_access_txt = "19"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"rN" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"sV" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"tw" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "applebush"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"ty" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Kilo emergency shuttle"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"ub" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"vm" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"vC" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"xM" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"yO" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"yW" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"AT" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Dc" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock";
+	req_one_access_txt = "63"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Ew" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"GK" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Jb" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Lf" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/chair/office/light,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Lw" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"NB" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/item/crowbar/red,
+/obj/item/storage/lockbox/loyalty,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Qm" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"RS" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = 24
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"RY" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Ui" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/sleeper,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Vg" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Vm" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Vy" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"WF" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Xd" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/item/kirbyplants{
+	icon_state = "applebush"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"YE" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"ZT" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -1686,17 +1031,17 @@ ac
 ab
 ac
 ai
-bb
+Dc
 ab
-bq
+ty
 ab
 ac
 ac
 ac
 ab
-bX
+YE
 ab
-bX
+YE
 ai
 ab
 as
@@ -1709,22 +1054,22 @@ aa
 aa
 aa
 ac
-ap
-az
-az
-aS
-bc
+NB
+Lw
+Lw
+hl
+aA
 ac
-br
+cb
 bB
 bI
 bI
 bI
 bB
-bx
+cb
 ac
 cj
-cr
+cj
 cC
 cK
 cT
@@ -1736,22 +1081,22 @@ aa
 aa
 aa
 ab
-aq
+Vm
 aA
 aA
 aA
-bd
+aA
 bm
-bs
-bC
-bJ
-bM
-bJ
-bS
-bY
-cf
-ck
-cs
+cb
+cb
+cb
+ub
+cb
+cb
+cb
+RY
+cj
+cj
 cD
 cL
 cU
@@ -1763,18 +1108,18 @@ aa
 aa
 aa
 ac
-ar
-aB
+is
 aA
 aA
-be
+aA
+xM
 ac
-bt
-br
+cb
+cb
 bK
 bN
 bu
-bD
+cb
 bK
 ac
 cl
@@ -1791,17 +1136,17 @@ ab
 ac
 ai
 as
-aC
-aI
-aT
-bf
+WF
+aA
+Ew
+iu
 ab
 bu
-bD
+cb
 bK
 bO
 bu
-bD
+cb
 bZ
 as
 ab
@@ -1824,17 +1169,17 @@ ac
 as
 as
 bv
-bD
+cb
 bK
 bP
 bu
-bD
+cb
 bK
 cg
 cm
-cu
-cE
-cN
+Ui
+Vy
+cb
 cW
 cL
 dc
@@ -1843,25 +1188,25 @@ cT
 (7,1,1) = {"
 ac
 ae
-ak
-at
-aE
-aK
-aU
+gc
+eL
+nT
+yW
+tw
 bg
 bn
-bw
-bE
+cb
+cb
 bK
 bQ
 bu
-bT
-ca
-bC
+cb
+cb
+cb
 cn
-cv
-cF
-cO
+cG
+cb
+Lf
 cX
 ac
 dc
@@ -1870,25 +1215,25 @@ de
 (8,1,1) = {"
 ac
 af
-al
+rN
 au
 aF
 aL
-aV
-aN
+yO
+pP
 aO
-bx
-bF
-bL
-bL
-bL
-bU
 cb
-ch
+cb
+cb
+cb
+cb
+cb
+cb
+Xd
 ac
-cw
+Qm
 cG
-cP
+cb
 cY
 ab
 cS
@@ -1897,25 +1242,25 @@ cS
 (9,1,1) = {"
 ac
 ag
-am
-av
-aG
-aM
-aW
+ZT
+RS
+AT
+Vg
+fu
 bh
 bo
-bt
-br
+cb
+cb
 bK
 bN
 bu
-bV
-cc
-bG
+cb
+cb
+cb
 cn
-cx
-cH
-cP
+cG
+cb
+cb
 cZ
 ac
 dc
@@ -1932,17 +1277,17 @@ ab
 as
 as
 by
-bD
+cb
 bK
 bO
 bu
-bD
+cb
 bK
 ci
 cm
-cy
-cI
-cQ
+Ui
+hE
+Lf
 da
 cL
 dc
@@ -1955,15 +1300,15 @@ ai
 as
 as
 aO
-aX
-bi
+vm
+vm
 ab
 bu
-bD
+cb
 bK
 bP
 bu
-bD
+cb
 bZ
 as
 ab
@@ -1981,16 +1326,16 @@ aa
 ab
 aw
 ac
-aP
-aY
-bj
+cj
+Jb
+Jb
 ac
-bw
-bE
+cb
+cb
 bK
 bQ
 bu
-bD
+cb
 bK
 ac
 co
@@ -2005,23 +1350,23 @@ cS
 (13,1,1) = {"
 aa
 aa
-ao
-ax
+kS
+cj
 aH
-aQ
-aZ
-bk
+cj
+cj
+cj
 bp
-bz
-bG
-bJ
-bR
-bJ
-bW
-cd
-cf
-cp
-cA
+cb
+cb
+cb
+lX
+cb
+cb
+cb
+bp
+cj
+cj
 cJ
 cL
 cU
@@ -2033,22 +1378,22 @@ aa
 aa
 aa
 ab
-ay
+sV
 ac
 aR
 ba
 bl
 ac
-bA
+GK
 bH
 bl
 bl
 bl
 bH
-ce
+GK
 ac
-cq
-cB
+vC
+cj
 aR
 cK
 cT

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -5,37 +5,6 @@
 "ab" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape/luxury)
-"ac" = (
-/obj/machinery/door/airlock/external{
-	name = "Economy-Class"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape/luxury)
-"ad" = (
-/obj/machinery/scanner_gate/luxury_shuttle{
-	layer = 2.6
-	},
-/obj/machinery/door/airlock/silver{
-	name = "First Class"
-	},
-/turf/open/floor/carpet/orange,
-/area/shuttle/escape/luxury)
-"ae" = (
-/obj/docking_port/mobile/emergency{
-	dir = 2;
-	dwidth = 5;
-	height = 14;
-	name = "Luxurious Emergency Shuttle";
-	width = 25
-	},
-/obj/machinery/scanner_gate/luxury_shuttle{
-	layer = 2.6
-	},
-/obj/machinery/door/airlock/silver{
-	name = "First Class"
-	},
-/turf/open/floor/carpet/orange,
-/area/shuttle/escape/luxury)
 "af" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Cell";
@@ -78,8 +47,8 @@
 /area/shuttle/escape/luxury)
 "ap" = (
 /obj/structure/chair/comfy/teal{
-	icon_state = "comfychair";
-	dir = 4
+	dir = 4;
+	icon_state = "comfychair"
 	},
 /turf/open/floor/mineral/diamond,
 /area/shuttle/escape)
@@ -226,8 +195,8 @@
 /area/shuttle/escape/luxury)
 "aM" = (
 /obj/structure/chair/comfy/teal{
-	icon_state = "comfychair";
-	dir = 4
+	dir = 4;
+	icon_state = "comfychair"
 	},
 /turf/open/floor/mineral/diamond,
 /area/shuttle/escape/luxury)
@@ -455,8 +424,8 @@
 	layer = 2.9
 	},
 /turf/open/floor/holofloor/beach/coast_t{
-	icon_state = "sandwater_t";
-	dir = 8
+	dir = 8;
+	icon_state = "sandwater_t"
 	},
 /area/shuttle/escape/luxury)
 "bx" = (
@@ -523,8 +492,8 @@
 "bG" = (
 /obj/machinery/door/window/eastleft,
 /turf/open/floor/holofloor/beach/coast_t{
-	icon_state = "sandwater_t";
-	dir = 8
+	dir = 8;
+	icon_state = "sandwater_t"
 	},
 /area/shuttle/escape/luxury)
 "bH" = (
@@ -563,8 +532,8 @@
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/eastright,
 /turf/open/floor/holofloor/beach/coast_t{
-	icon_state = "sandwater_t";
-	dir = 8
+	dir = 8;
+	icon_state = "sandwater_t"
 	},
 /area/shuttle/escape/luxury)
 "bN" = (
@@ -956,6 +925,13 @@
 	},
 /turf/open/floor/carpet/green,
 /area/shuttle/escape/luxury)
+"el" = (
+/obj/machinery/door/airlock/external{
+	name = "Economy-Class"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
+/area/shuttle/escape/luxury)
 "qa" = (
 /obj/structure/toilet{
 	pixel_y = 8
@@ -965,6 +941,14 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape/luxury)
+"BC" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/luxury)
 "Lt" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Cell";
@@ -972,6 +956,33 @@
 	},
 /obj/machinery/scanner_gate/luxury_shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/luxury)
+"Nh" = (
+/obj/machinery/scanner_gate/luxury_shuttle{
+	layer = 2.6
+	},
+/obj/machinery/door/airlock/silver{
+	name = "First Class"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/carpet/orange,
+/area/shuttle/escape/luxury)
+"TU" = (
+/obj/docking_port/mobile/emergency{
+	dir = 2;
+	dwidth = 5;
+	height = 14;
+	name = "Luxurious Emergency Shuttle";
+	width = 25
+	},
+/obj/machinery/scanner_gate/luxury_shuttle{
+	layer = 2.6
+	},
+/obj/machinery/door/airlock/silver{
+	name = "First Class"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/carpet/orange,
 /area/shuttle/escape/luxury)
 
 (1,1,1) = {"
@@ -1103,7 +1114,7 @@ bC
 ab
 "}
 (9,1,1) = {"
-ac
+el
 ax
 bs
 bC
@@ -1135,7 +1146,7 @@ av
 ay
 "}
 (11,1,1) = {"
-af
+BC
 at
 at
 bD
@@ -1231,7 +1242,7 @@ ch
 ag
 "}
 (17,1,1) = {"
-ae
+TU
 ao
 bw
 bG
@@ -1263,7 +1274,7 @@ ao
 ag
 "}
 (19,1,1) = {"
-ad
+Nh
 ao
 ao
 ao

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -9,28 +9,9 @@
 "ad" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"af" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "ag" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"ah" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dir = 2;
-	dwidth = 5;
-	height = 14;
-	name = "Meta emergency shuttle";
-	width = 25
-	},
-/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "al" = (
 /obj/structure/table,
@@ -844,8 +825,37 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"Af" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dir = 2;
+	dwidth = 5;
+	height = 14;
+	name = "Meta emergency shuttle";
+	width = 25
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Ew" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
 "LY" = (
 /turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Qo" = (
+/obj/machinery/door/airlock/external{
+	name = "Emergency Recovery Airlock"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Vs" = (
 /turf/open/floor/mineral/titanium/white,
@@ -929,7 +939,7 @@ be
 cc
 be
 be
-bf
+Qo
 "}
 (6,1,1) = {"
 ac
@@ -945,7 +955,7 @@ bf
 bT
 be
 be
-bf
+Qo
 "}
 (7,1,1) = {"
 ac
@@ -1028,7 +1038,7 @@ bF
 ac
 "}
 (12,1,1) = {"
-af
+Ew
 LY
 LY
 aE
@@ -1060,7 +1070,7 @@ ad
 ad
 "}
 (14,1,1) = {"
-af
+Ew
 LY
 LY
 aE
@@ -1156,7 +1166,7 @@ bM
 ad
 "}
 (20,1,1) = {"
-ah
+Af
 LY
 LY
 aE
@@ -1188,7 +1198,7 @@ bO
 ac
 "}
 (22,1,1) = {"
-af
+Ew
 LY
 LY
 LY

--- a/_maps/shuttles/emergency_meteor.dmm
+++ b/_maps/shuttles/emergency_meteor.dmm
@@ -26,10 +26,6 @@
 /mob/living/simple_animal/hostile/asteroid/goliath,
 /turf/open/floor/plating/asteroid,
 /area/shuttle/escape/meteor)
-"g" = (
-/obj/structure/mineral_door/iron,
-/turf/open/floor/plating/asteroid,
-/area/shuttle/escape/meteor)
 "h" = (
 /obj/item/pickaxe,
 /turf/open/floor/plating/asteroid,
@@ -61,6 +57,11 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/turf/open/floor/plating/asteroid,
+/area/shuttle/escape/meteor)
+"y" = (
+/obj/structure/mineral_door/iron,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating/asteroid,
 /area/shuttle/escape/meteor)
 "L" = (
@@ -424,8 +425,8 @@ b
 b
 b
 b
-g
-g
+y
+y
 b
 b
 b

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -107,12 +107,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"u" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "x" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -154,6 +148,7 @@
 	name = "Mini emergency shuttle";
 	width = 21
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "D" = (
@@ -252,6 +247,13 @@
 	pixel_y = 3
 	},
 /obj/item/crowbar,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"U" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "W" = (
@@ -455,7 +457,7 @@ b
 b
 b
 b
-u
+U
 b
 b
 n

--- a/_maps/shuttles/emergency_narnar.dmm
+++ b/_maps/shuttles/emergency_narnar.dmm
@@ -125,6 +125,7 @@
 /area/shuttle/escape)
 "x" = (
 /obj/machinery/door/airlock/cult/friendly,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "y" = (
@@ -155,13 +156,6 @@
 /obj/effect/rune/convert,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/cult,
-/area/shuttle/escape)
-"E" = (
-/obj/machinery/door/airlock/cult/friendly,
-/obj/docking_port/mobile/emergency{
-	name = "shuttle 667"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "F" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
@@ -262,6 +256,14 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"X" = (
+/obj/machinery/door/airlock/cult/friendly,
+/obj/docking_port/mobile/emergency{
+	name = "shuttle 667"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 a
@@ -273,7 +275,7 @@ b
 b
 x
 b
-E
+X
 b
 c
 c

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -174,19 +174,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"aq" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/escape)
 "ar" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -267,23 +254,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/escape)
-"ay" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dwidth = 5;
-	name = "Omega emergency shuttle";
-	width = 19
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "az" = (
 /obj/effect/turf_decal/delivery,
@@ -494,18 +464,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
-/area/shuttle/escape)
-"aP" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "aQ" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -856,22 +814,67 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"ga" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"Na" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dwidth = 5;
+	name = "Omega emergency shuttle";
+	width = 19
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"PD" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
 aa
 aa
-aq
+PD
 ac
-ay
+Na
 aa
 ab
 ab
 ab
 aa
-aP
+ga
 ac
-aP
+ga
 aa
 aa
 aZ

--- a/_maps/shuttles/emergency_pod.dmm
+++ b/_maps/shuttles/emergency_pod.dmm
@@ -16,12 +16,6 @@
 "d" = (
 /turf/open/space/basic,
 /area/space)
-"e" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Shuttle Airlock"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "f" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
@@ -50,7 +44,14 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"m" = (
+"s" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"E" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Shuttle Airlock"
 	},
@@ -58,22 +59,23 @@
 	port_direction = 2;
 	preferred_direction = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 
 (1,1,1) = {"
 a
-e
+s
 b
-m
+E
 a
 d
 d
 d
 a
-e
+s
 b
-e
+s
 a
 "}
 (2,1,1) = {"

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -133,12 +133,6 @@
 "ax" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"ay" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "az" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -678,20 +672,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"bL" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dir = 8;
-	dwidth = 27;
-	height = 8;
-	name = "PubbyStation emergency shuttle";
-	port_direction = 4;
-	width = 46
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "bO" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cockpit";
@@ -712,11 +692,33 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"pZ" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dir = 8;
+	dwidth = 27;
+	height = 8;
+	name = "PubbyStation emergency shuttle";
+	port_direction = 4;
+	width = 46
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "xt" = (
 /obj/structure/window/reinforced{
 	dir = 8;
 	layer = 2.9
 	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Tz" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Uu" = (
@@ -1073,17 +1075,17 @@ ab
 ab
 ab
 ab
-ay
+Tz
 ab
-ay
+Tz
 ab
 ab
 aa
 ab
 ab
-bL
+pZ
 ab
-ay
+Tz
 ab
 ac
 ab

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -1054,10 +1054,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"cn" = (
-/obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "co" = (
 /obj/machinery/porta_turret/syndicate/energy/raven{
 	dir = 8
@@ -2068,18 +2064,6 @@
 /obj/structure/shuttle/engine/large,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"eo" = (
-/obj/machinery/door/airlock/external{
-	name = "Emegency Shuttle External Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dwidth = 14;
-	height = 21;
-	name = "CentCom Raven Cruiser";
-	width = 32
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ep" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -2098,6 +2082,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
+"gA" = (
+/obj/machinery/door/airlock/external{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "jq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -2115,6 +2106,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"wn" = (
+/obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "xJ" = (
@@ -2161,6 +2157,19 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"Vj" = (
+/obj/machinery/door/airlock/external{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dwidth = 14;
+	height = 21;
+	name = "CentCom Raven Cruiser";
+	width = 32
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "ZG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/terminal{
@@ -2186,17 +2195,17 @@ aa
 aa
 aO
 ax
-cd
+gA
 co
-eo
+Vj
 ax
 aO
 aa
 aO
 ax
-cd
+gA
 co
-cd
+gA
 ax
 aO
 aa
@@ -2866,17 +2875,17 @@ aa
 aa
 aO
 ax
-cn
+wn
 cw
-cn
+wn
 ax
 aO
 aa
 aO
 ax
-cd
+gA
 cw
-cd
+gA
 ax
 aO
 aa

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -230,13 +230,6 @@
 /mob/living/simple_animal/hostile/bear/fightpit,
 /turf/open/floor/engine,
 /area/shuttle/escape)
-"aO" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "aP" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -273,16 +266,6 @@
 /obj/item/kitchen/fork,
 /mob/living/simple_animal/hostile/bear/fightpit,
 /turf/open/floor/engine,
-/area/shuttle/escape)
-"aW" = (
-/obj/docking_port/mobile/emergency{
-	height = 15;
-	name = "Box emergency shuttle"
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aX" = (
 /obj/structure/extinguisher_cabinet{
@@ -415,12 +398,6 @@
 /obj/item/broken_bottle,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/escape)
-"br" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "bs" = (
 /obj/structure/extinguisher_cabinet{
@@ -587,6 +564,32 @@
 /obj/structure/table/optable,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
+"Ev" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"NW" = (
+/obj/docking_port/mobile/emergency{
+	height = 15;
+	name = "Box emergency shuttle"
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ys" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -596,17 +599,17 @@ aa
 ad
 ab
 ad
-aO
+Ev
 ab
-aW
+NW
 ad
 ac
 ac
 ac
 ad
-br
+Ys
 ad
-br
+Ys
 ad
 aa
 aa

--- a/_maps/shuttles/emergency_scrapheap.dmm
+++ b/_maps/shuttles/emergency_scrapheap.dmm
@@ -101,13 +101,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/escape)
-"as" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "at" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
@@ -169,13 +162,6 @@
 "aB" = (
 /turf/closed/wall/mineral/titanium/interior,
 /area/shuttle/escape)
-"aC" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "aD" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -219,15 +205,6 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"aK" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Scrapheap Challenge"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aL" = (
 /obj/structure/chair/comfy/shuttle{
@@ -304,12 +281,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
-/area/shuttle/escape)
-"aZ" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "ba" = (
 /obj/structure/extinguisher_cabinet{
@@ -426,6 +397,43 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"fH" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"mu" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"rY" = (
+/obj/structure/fans/tiny,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"Bm" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"UW" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Scrapheap Challenge"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -435,17 +443,17 @@ aa
 ab
 ab
 ab
-aC
+fH
 ab
-aK
+UW
 ab
 ac
 ac
 ac
 ab
-aZ
-ab
-aZ
+mu
+rY
+mu
 ab
 ab
 ab
@@ -624,7 +632,7 @@ aa
 aa
 aa
 aa
-as
+Bm
 aw
 aw
 aw

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -97,12 +97,6 @@
 "aw" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
-"aA" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "aB" = (
 /obj/machinery/power/supermatter_crystal/shard/hugbox/fakecrystal,
 /turf/open/floor/plating,
@@ -120,15 +114,6 @@
 "aE" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"aF" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Hyperfractal Gigashuttle"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aI" = (
 /obj/structure/sign/warning/radiation,
@@ -325,6 +310,23 @@
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
+"Hw" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Hyperfractal Gigashuttle"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"NI" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "UA" = (
 /obj/machinery/status_display/evac{
 	pixel_y = -32
@@ -340,9 +342,9 @@ aa
 aa
 aa
 aw
-aA
+NI
 ac
-aF
+Hw
 aw
 aa
 aa
@@ -580,9 +582,9 @@ aa
 aa
 aa
 aw
-aA
+NI
 ac
-aA
+NI
 aw
 aa
 aa

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -161,13 +161,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"ax" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ay" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -198,15 +191,6 @@
 "aC" = (
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"aD" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "NT Lepton Violet"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aF" = (
 /obj/machinery/door/window/eastleft,
@@ -301,12 +285,6 @@
 "aU" = (
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"aV" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aW" = (
 /obj/effect/turf_decal/stripes/line{
@@ -515,6 +493,14 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"co" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "ji" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -530,9 +516,26 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"HF" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "NT Lepton Violet"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "MK" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Qc" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -543,17 +546,17 @@ aa
 ab
 ab
 ab
-ax
+co
 ab
-aD
+HF
 ab
 as
 as
 as
 ab
-aV
+Qc
 ab
-aV
+Qc
 ab
 ab
 ab

--- a/_maps/shuttles/emergency_zeta.dmm
+++ b/_maps/shuttles/emergency_zeta.dmm
@@ -118,6 +118,7 @@
 /obj/docking_port/mobile/emergency{
 	name = "Zeta emergency shuttle"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
 "w" = (
@@ -152,6 +153,7 @@
 /obj/machinery/door/airlock/abductor{
 	name = "Transport Ship Theta"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
 "B" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I put tiny fans under every external door for all arrival and escape shuttles. I also removed the striped tape on the Kilo shuttles to match the station's more cleaner appearance.

## Why It's Good For The Game

Less chances for people to accidentally touch the door and vent the entire shuttle instantly. Of course it is still possible to vent the shuttle using other methods. Arrival shuttles are meant to be the safest place for people, and reducing the odds of them being completely vented, killing people as soon as they join, is good.

## Changelog
:cl: BigFatAnimeTiddies
add: Arrival and Escape shuttles are now less prone to atmospheric ventilation by assistants touching the door controls.
fix: Kilo shuttles have had more of their warning tape removed to reduce headaches among the crew.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
