### PR TITLE
cuts the purple people hazmat suits from the everyman's clothing articles and also something else that doesnt really matter too

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -247,6 +247,9 @@
 	new /obj/item/clothing/under/rank/prisoner( src )
 	new /obj/item/clothing/under/rank/prisoner/skirt( src )
 	new /obj/item/clothing/shoes/sneakers/orange( src )
+	new /obj/item/clothing/under/plasmaman/prisoner( src )
+	new /obj/item/clothing/under/plasmaman/prisoner/skirt( src )
+	new /obj/item/clothing/head/helmet/space/plasmaman/prisoner( src )
 
 /obj/structure/closet/secure_closet/courtroom
 	name = "courtroom locker"

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -30,9 +30,6 @@
 					/obj/item/clothing/head/cowboy = 1, //Waspstation - Yee Haw
 					/obj/item/clothing/accessory/waistcoat = 1,
 					/obj/item/clothing/under/suit/black = 1,
-					/obj/item/clothing/under/plasmaman/mime = 1, //WS edit start
-					/obj/item/clothing/under/plasmaman/mime/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/mime = 1, //WS edit end
 					/obj/item/clothing/head/that = 1,
 					/obj/item/clothing/under/costume/kilt = 1,
 					/obj/item/clothing/head/beret = 1,

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -98,9 +98,6 @@
 		            /obj/item/clothing/under/dress/sailor = 1,
 		            /obj/item/clothing/under/dress/redeveninggown = 1,
 		            /obj/item/clothing/under/dress/blacktango = 1,
-					/obj/item/clothing/under/plasmaman = 1, //WS edit start
-					/obj/item/clothing/under/plasmaman/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman = 1, //WS edit end
 		            /obj/item/clothing/suit/ianshirt = 1,
 		            /obj/item/clothing/shoes/laceup = 2,
 		            /obj/item/clothing/shoes/sandal = 2,

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -23,16 +23,6 @@
 					/obj/item/storage/backpack/duffelbag/sec = 3,
 					/obj/item/clothing/under/rank/security/officer = 3,
 					/obj/item/clothing/shoes/jackboots = 3,
-					/obj/item/clothing/under/plasmaman/security = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/head/helmet/space/plasmaman/security = 1,
-					/obj/item/clothing/under/plasmaman/security/warden = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/security/warden = 1,
-					/obj/item/clothing/under/plasmaman/security/secmed = 1,
-					/obj/item/clothing/under/plasmaman/security/secmed/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/security/secmed = 1,
-					/obj/item/clothing/under/plasmaman/prisoner = 1,
-					/obj/item/clothing/under/plasmaman/prisoner/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/prisoner = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/head/beret/sec = 3,
 					/obj/item/clothing/head/soft/sec = 3,
 					/obj/item/clothing/mask/bandana/red = 3,
@@ -75,12 +65,6 @@
 					/obj/item/clothing/under/rank/medical/doctor/green = 4,
 					/obj/item/clothing/under/rank/medical/doctor/purple = 4,
 					/obj/item/clothing/under/rank/medical/doctor = 4,
-					/obj/item/clothing/under/plasmaman/medical = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/medical/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/medical = 1,
-					/obj/item/clothing/under/plasmaman/paramedic = 1,
-					/obj/item/clothing/under/plasmaman/paramedic/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/paramedic = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/suit/toggle/labcoat = 4,
 					/obj/item/clothing/suit/toggle/labcoat/paramedic = 4,
 					/obj/item/clothing/shoes/sneakers/white = 4,
@@ -107,9 +91,6 @@
 					/obj/item/clothing/under/rank/engineering/engineer = 3,
 					/obj/item/clothing/under/rank/engineering/engineer/skirt = 3,
 					/obj/item/clothing/under/rank/engineering/engineer/hazard = 3,
-					/obj/item/clothing/under/plasmaman/engineering = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/engineering/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/engineering = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/head/beret/eng = 3, // Waspstation edit - Berets
 					/obj/item/clothing/head/beret/eng/hazard = 3, //Waspstation edit - Berets
 					/obj/item/clothing/suit/hazardvest = 3,
@@ -137,9 +118,6 @@
 					/obj/item/clothing/suit/hooded/wintercoat/engineering/atmos = 3,
 					/obj/item/clothing/under/rank/engineering/atmospheric_technician = 3,
 					/obj/item/clothing/under/rank/engineering/atmospheric_technician/skirt = 3,
-					/obj/item/clothing/under/plasmaman/atmospherics = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/atmospherics/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/atmospherics = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/shoes/sneakers/black = 3
 					)
 	refill_canister = /obj/item/vending_refill/wardrobe/atmos_wardrobe
@@ -159,9 +137,6 @@
 					/obj/item/clothing/head/beret/cargo = 3,
 					/obj/item/clothing/under/rank/cargo/tech = 3,
 					/obj/item/clothing/under/rank/cargo/tech/skirt = 3,
-					/obj/item/clothing/under/plasmaman/cargo = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/cargo/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/cargo = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/shoes/sneakers/black = 3,
 					/obj/item/clothing/gloves/fingerless = 3,
 					/obj/item/clothing/head/soft = 3,
@@ -181,9 +156,6 @@
 	products = list(/obj/item/clothing/glasses/hud/diagnostic = 2,
 					/obj/item/clothing/under/rank/rnd/roboticist = 2,
 					/obj/item/clothing/under/rank/rnd/roboticist/skirt = 2,
-					/obj/item/clothing/under/plasmaman/robotics = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/robotics/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/robotics = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/suit/toggle/labcoat = 2,
 					/obj/item/clothing/shoes/sneakers/black = 2,
 					/obj/item/clothing/gloves/fingerless = 2,
@@ -211,9 +183,6 @@
 					/obj/item/clothing/suit/hooded/wintercoat/science = 3,
 					/obj/item/clothing/under/rank/rnd/scientist = 3,
 					/obj/item/clothing/under/rank/rnd/scientist/skirt = 3,
-					/obj/item/clothing/under/plasmaman/science = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/science/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/science = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/suit/toggle/labcoat/science = 3,
 					/obj/item/clothing/shoes/sneakers/white = 3,
 					/obj/item/radio/headset/headset_sci = 3,
@@ -239,9 +208,6 @@
 					/obj/item/clothing/suit/apron/waders = 3,
 					/obj/item/clothing/under/rank/civilian/hydroponics = 3,
 					/obj/item/clothing/under/rank/civilian/hydroponics/skirt = 3,
-					/obj/item/clothing/under/plasmaman/botany = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/botany/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/botany = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/mask/bandana = 3,
 					/obj/item/clothing/accessory/armband/hydro = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/hydro_wardrobe
@@ -265,8 +231,6 @@
 					/obj/item/clothing/head/beret/service = 1, //Wasp edit - berets
 					/obj/item/clothing/accessory/pocketprotector = 2,
 					/obj/item/clothing/under/rank/civilian/curator/skirt = 2,
-					/obj/item/clothing/under/plasmaman/curator = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/head/helmet/space/plasmaman/curator = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/under/rank/command/captain/suit/skirt = 2,
 					/obj/item/clothing/under/rank/command/head_of_personnel/suit/skirt = 2,
 					/obj/item/storage/backpack/satchel/explorer = 1,
@@ -291,9 +255,6 @@
 					/obj/item/clothing/under/rank/civilian/bartender = 2,
 					/obj/item/clothing/under/rank/civilian/bartender/purple = 2,
 					/obj/item/clothing/under/rank/civilian/bartender/skirt = 2,
-					/obj/item/clothing/under/plasmaman/enviroslacks = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/enviroslacks/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/white = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/accessory/waistcoat = 2,
 					/obj/item/clothing/suit/apron/purple_bartender = 2,
 					/obj/item/clothing/head/soft/black = 2,
@@ -333,9 +294,6 @@
 					/obj/item/clothing/under/rank/civilian/chef = 1,
 					/obj/item/clothing/under/rank/civilian/chef/skirt = 2,
 					///obj/item/clothing/under/rank/chef = 3,//WaspStation edit - Better security jumpsuit sprites
-					/obj/item/clothing/under/plasmaman/chef = 1,
-					/obj/item/clothing/under/plasmaman/chef/skirt = 1, //WS edit plasmaman customization
-					/obj/item/clothing/head/helmet/space/plasmaman/white = 1,
 					/obj/item/clothing/head/chefhat = 1,
 					/obj/item/clothing/under/rank/civilian/cookjorts = 2,
 					/obj/item/clothing/shoes/cookflops = 2,
@@ -356,9 +314,6 @@
 					/obj/item/cartridge/janitor = 2,
 					/obj/item/clothing/head/beret/service = 2, //Wasp edit - berets
 					/obj/item/clothing/under/rank/civilian/janitor/skirt = 2,
-					/obj/item/clothing/under/plasmaman/janitor = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/janitor/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/janitor = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/gloves/color/black = 2,
 					/obj/item/clothing/head/soft/purple = 2,
 					/obj/item/pushbroom = 2,
@@ -405,9 +360,6 @@
 					/obj/item/clothing/under/rank/civilian/lawyer/red/skirt = 1,
 					/obj/item/clothing/under/rank/civilian/lawyer/black = 1,
 					/obj/item/clothing/under/rank/civilian/lawyer/black/skirt = 1,
-					/obj/item/clothing/under/plasmaman/enviroslacks = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/enviroslacks/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/white = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/shoes/laceup = 2,
 					/obj/item/clothing/neck/tie/red = 6,
 					/obj/item/clothing/neck/tie/black = 6,
@@ -429,9 +381,6 @@
 					/obj/item/clothing/accessory/pocketprotector/cosmetology = 1,
 					/obj/item/clothing/under/rank/civilian/chaplain = 1,
 					/obj/item/clothing/under/rank/civilian/chaplain/skirt = 2,
-					/obj/item/clothing/under/plasmaman/chaplain = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/chaplain/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/chaplain = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/shoes/sneakers/black = 1,
 					/obj/item/clothing/suit/chaplainsuit/nun = 1,
 					/obj/item/clothing/head/nun_hood = 1,
@@ -464,9 +413,6 @@
 	vend_reply = "Thank you for using the ChemDrobe!"
 	products = list(/obj/item/clothing/under/rank/medical/chemist = 2,
 					/obj/item/clothing/under/rank/medical/chemist/skirt = 2,
-					/obj/item/clothing/under/plasmaman/chemist = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/chemist/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/chemist = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/head/beret/chem = 2, // Waspstation edit - Berets
 					/obj/item/clothing/shoes/sneakers/white = 2,
 					/obj/item/clothing/suit/toggle/labcoat/chemist = 2,
@@ -487,9 +433,6 @@
 	vend_reply = "Thank you for using the GeneDrobe!"
 	products = list(/obj/item/clothing/under/rank/medical/geneticist = 2,
 					/obj/item/clothing/under/rank/medical/geneticist/skirt = 2,
-					/obj/item/clothing/under/plasmaman/genetics = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/genetics/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/genetics = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/head/beret/med = 2, //Wasp edit - berets
 					/obj/item/clothing/shoes/sneakers/white = 2,
 					/obj/item/clothing/suit/toggle/labcoat/genetics = 2,
@@ -508,9 +451,6 @@
 	vend_reply = "Thank you for using the ViroDrobe"
 	products = list(/obj/item/clothing/under/rank/medical/virologist = 2,
 					/obj/item/clothing/under/rank/medical/virologist/skirt = 2,
-					/obj/item/clothing/under/plasmaman/viro = 1, //WS edit plasmaman customization begin
-					/obj/item/clothing/under/plasmaman/viro/skirt = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/viro = 1, //WS edit plasmaman customization end
 					/obj/item/clothing/head/beret/viro = 2, //Wasp edit - Berets
 					/obj/item/clothing/shoes/sneakers/white = 2,
 					/obj/item/clothing/suit/toggle/labcoat/virologist = 2,


### PR DESCRIPTION
## About The Pull Request

removes the plasmaman envirosuits and enviroskirts from the various clothing vendors around the station

also adds a pair of them to the permabrig lockers in the event of need arises

## Why It's Good For The Game

the fact that these are even in the common clothing vendors was an antiquated solution to a problem that doesn't exist anymore thanks to [https://github.com/WaspStation/WaspStation-1.0/pull/252](this pull request), and i figure that it wouldn't hurt to finally get around to following mald anus

## Changelog
:cl:
removes: plasmaman envirosuits from the clothing vendors
adds: appropriate plasmaman envirosuits to the jail lockers
/:cl: