### PR TITLE
makes bolted safety airlocks unboltable

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -89,10 +89,14 @@
 		spark_system = null
 	return ..()
 
-/obj/machinery/door/proc/try_safety_unlock(mob/user)
-	if(safety_mode && !hasPower() && density)
-		to_chat(user, "<span class='notice'>You begin unlocking the airlock safety mechanism...</span>")
-		if(do_after(user, 15 SECONDS, target = src))
+/obj/machinery/door/proc/try_safety_unlock(mob/user, closing = FALSE)
+	if(safety_mode && !hasPower() && (closing || density))
+		if(locked)
+			to_chat(user, "<span class='notice'>You begin to lift [src]'s bolt with the safety mechanism...</span>")
+			if(do_after(user, 20 SECONDS, target = src)) //unbolting takes 20 seconds
+				unlock()
+		to_chat(user, "<span class='notice'>You begin [density ? "opening" : "closing"] [src] with the safety mechanism...</span>")
+		if((!density && do_after(user, 5 SECONDS, target = src)) || do_after(user, 15 SECONDS, target = src)) //closing takes 5 seconds, opening takes 15
 			try_to_crowbar(null, user)
 			return TRUE
 	return FALSE
@@ -171,7 +175,7 @@
 	. = ..()
 	if(.)
 		return
-	if(try_safety_unlock(user))
+	if(try_safety_unlock(user, TRUE))
 		return
 	return try_to_activate_door(user)
 


### PR DESCRIPTION
## Changelog
:cl:
tweak: Safety airlocks (the airlocks in both arrivals and departures) can now be unbolted and then opened without any tools.
tweak: Safety airlocks can now be closed when depowered, so that you don't get flung into space when the arrivals shuttle leaves.
/:cl: