### PR TITLE
Fixed displayed vendor prices on contraband items

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -717,7 +717,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		var/list/data = list(
 			path = replacetext(replacetext("[R.product_path]", "/obj/item/", ""), "/", "-"),
 			name = R.name,
-			price = R.custom_price || default_price,
+			price = R.custom_premium_price || extra_price,                                            // WaspStation Edit - vendor incorrect premium price fix
 			max_amount = R.max_amount,
 			ref = REF(R),
 			premium = TRUE

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -717,7 +717,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		var/list/data = list(
 			path = replacetext(replacetext("[R.product_path]", "/obj/item/", ""), "/", "-"),
 			name = R.name,
-			price = R.custom_premium_price || extra_price,                                            // WaspStation Edit - vendor incorrect premium price fix
+			price = R.custom_premium_price || extra_price,                                            // WaspStation Edit - vendor incorrect contraband price fix
 			max_amount = R.max_amount,
 			ref = REF(R),
 			premium = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed copy/paste error in _vending.dm that was loading contraband prices the same way as standard items in the vendor UI

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fix: Issue #318 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Vendors display correct prices on contraband items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->