### PR TITLE
Hygiene Bot Construction Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -470,9 +470,8 @@
 					build_step++
 					return
 
+		// WaspStation Start -- hygienebot construction fix (Issue #301)
 		if(ASSEMBLY_SECOND_STEP)
-			if(!can_finish_build(I, user))
-				return
 			if(istype(I, /obj/item/stack/ducts))
 				var/obj/item/stack/ducts/D = I
 				if(D.get_amount() < 1)
@@ -484,9 +483,8 @@
 						D.use(1)
 						to_chat(user, "<span class='notice'>You pipe up [src].</span>")
 						build_step++
-					else
-						return
-				var/mob/living/simple_animal/bot/hygienebot/H = new(drop_location())
-				H.name = created_name
-				qdel(src)
-				return TRUE
+						var/mob/living/simple_animal/bot/hygienebot/H = new(drop_location())
+						H.name = created_name
+						qdel(src)
+						return TRUE
+		// WaspStation end


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moved hygiene bot creation inside if block preventing early/free completion
Removed in-backpack check that was eating any item used on the hygiene bot in state ASSEMBLY_SECOND_STEP.

## Why It's Good For The Game

Bug fix: Issue #301 

## Changelog
:cl:
fix: Hygiene bot construction no longer eats items or finishes early
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
