### PR TITLE
Null Drone Prompt Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -13,6 +13,7 @@
 
 /obj/effect/mob_spawn/drone
 	name = "drone shell"
+	mob_name = "drone"                                                                              // Waspstation Edit - Adding missing var
 	desc = "A shell of a maintenance drone, an expendable robot built to perform station repairs."
 	icon = 'icons/mob/drone.dmi'
 	icon_state = "drone_maint_hat" //yes reuse the _hat state.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added mob_name to drone in drones_as_items.dm, so the prompt to become a drone no longer uses an empty string

Before:
![image](https://user-images.githubusercontent.com/7697956/91359551-686b0980-e7ba-11ea-8adb-d74fbae188f1.png)
 
After: 
![image](https://user-images.githubusercontent.com/7697956/91359622-89cbf580-e7ba-11ea-8be2-7ab42cc6b097.png)

## Why It's Good For The Game

Bug fix: Issue #330 

## Changelog
:cl:
fix: "Become drone?" is prompted when selecting to play as a drone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
