### PR TITLE
Borg Converter Conveyor Fix

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -46,6 +46,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(.)
 		operating = TRUE
 		update_icon()
+		begin_processing()                                              // Waspstation Edit - Auto Conveyor Fix (Issue #331)
 
 // create a conveyor
 /obj/machinery/conveyor/Initialize(mapload, newdir, newid)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The borg converter (/obj/machinery/transformer) uses auto conveyors instead of the normal switch-operated ones.  The auto conveyors were missing a call to begin_processing, which has been added to conveyor2.dm.  I have confirmed they still stop moving items/players when unpowered.

## Why It's Good For The Game

Bug fix: Issue #331 

## Changelog
:cl:
fix: Borg converter conveyors work again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
