### PR TITLE
Ninja Buttons Fix

### DIFF
--- a/code/modules/ninja/suit/suit_initialisation.dm
+++ b/code/modules/ninja/suit/suit_initialisation.dm
@@ -37,8 +37,10 @@ GLOBAL_LIST_INIT(ninja_deinitialize_messages, list(
 	s_busy = TRUE
 	if(s_initialized)
 		deinitialize()
+		STOP_PROCESSING(SSobj, src)                   // Waspstation Edit - Ninja Buttons Fix (Issue #339)
 	else
 		ninitialize()
+		START_PROCESSING(SSobj, src)                  // Waspstation Edit - Ninja Buttons Fix (Issue #339)
 
 /**
   * Initializes the ninja suit


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Multiple ninja buttons (smoke bomb, adrenaline boost, throwing stars, recall blade, etc.) share a cooldown value.  This cooldown is decremented by process(), which was never being called.  I queued this function up by adding calls to START_PROCESSING and STOP_PROCESSING in the suit toggle function in suit_initialisation.dm.

## Why It's Good For The Game

Bug fix: Issue #339 

## Changelog
:cl:
fix: SpiderOS has been patched.  All fear the clan!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
