### PR TITLE
Atmos Analyzer Format Fix

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -461,6 +461,12 @@ GENE SCANNER
 		var/co2_concentration = environment.get_moles(/datum/gas/carbon_dioxide)/total_moles
 		var/plasma_concentration = environment.get_moles(/datum/gas/plasma)/total_moles
 
+		// WaspStation Start -- Atmos Analyzer Reformat (Issue #419)
+		to_chat(user, "<span class='boldnotice'>Results of analysis.</span>")
+		to_chat(user, "<span class='info'>Pressure: [round(pressure,0.01)] kPa</span>")
+		to_chat(user, "<span class='info'>Temperature: [round(environment.return_temperature()-T0C, 0.01)] &deg;C ([round(environment.return_temperature(), 0.01)] K)</span>")
+		// WaspStation End
+
 		if(abs(n2_concentration - N2STANDARD) < 20)
 			to_chat(user, "<span class='info'>Nitrogen: [round(n2_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/nitrogen), 0.01)] mol)</span>")
 		else
@@ -486,7 +492,6 @@ GENE SCANNER
 				continue
 			var/gas_concentration = environment.get_moles(id)/total_moles
 			to_chat(user, "<span class='alert'>[GLOB.meta_gas_info[id][META_GAS_NAME]]: [round(gas_concentration*100, 0.01)] % ([round(environment.get_moles(id), 0.01)] mol)</span>")
-		to_chat(user, "<span class='info'>Temperature: [round(environment.return_temperature()-T0C, 0.01)] &deg;C ([round(environment.return_temperature(), 0.01)] K)</span>")
 
 /obj/item/analyzer/AltClick(mob/user) //Barometer output for measuring when the next storm happens
 	..()
@@ -574,14 +579,16 @@ GENE SCANNER
 		var/cached_scan_results = air_contents.analyzer_results
 
 		if(total_moles > 0)
+			// WaspStation Start -- Atmos Analyzer Reformat (Issue #419)
 			render_list += "<span class='notice'>Moles: [round(total_moles, 0.01)] mol</span>\
-						 \n<span class='notice'>Volume: [volume] L</span>\
-						 \n<span class='notice'>Pressure: [round(pressure,0.01)] kPa</span>"
+							\n<span class='notice'>Volume: [volume] L</span>\
+							\n<span class='notice'>Pressure: [round(pressure,0.01)] kPa</span>\
+							\n<span class='notice'>Temperature: [round(temperature - T0C,0.01)] &deg;C ([round(temperature, 0.01)] K)</span>"
+			// WaspStation End
 
 			for(var/id in air_contents.get_gases())
 				var/gas_concentration = air_contents.get_moles(id)/total_moles
-				to_chat(user, "<span class='notice'>[GLOB.meta_gas_info[id][META_GAS_NAME]]: [round(gas_concentration*100, 0.01)] % ([round(air_contents.get_moles(id), 0.01)] mol)</span>")
-			to_chat(user, "<span class='notice'>Temperature: [round(temperature - T0C,0.01)] &deg;C ([round(temperature, 0.01)] K)</span>")
+				render_list += "<span class='notice'>[GLOB.meta_gas_info[id][META_GAS_NAME]]: [round(gas_concentration*100, 0.01)] % ([round(air_contents.get_moles(id), 0.01)] mol)</span>"  // WaspStation Edit -- Atmos Analyzer Reformat (Issue #419)
 
 		else
 			render_list += airs.len > 1 ? "<span class='notice'>This node is empty!</span>" : "<span class='notice'>[target] is empty!</span>"


### PR DESCRIPTION
## About The Pull Request

All changes in scanners.dm

In attack_self() I added the line from atmosanalyzer_scan() that displays the pressure.  Then I grouped the temperature and pressure together before the individul gas quantities to match the format I used in atmosanalyzer_scan().

In atmosanalyzer_scan() I moved the temperature next to the moles, volume, and pressure.  The individual gas quantities were being printed before these values because they called to_chat() directly instead of using render_list to print everything at once.  Switching to this prevents them from printing early.

2 Fixes:
1. Atmos analyzer displays room pressure and has a header for the analysis.
![image](https://user-images.githubusercontent.com/7697956/92065452-5f071180-ed65-11ea-8eda-09f2dfe96cd4.png)

2. Atmos analyzer output is reordered to group headers together, gas characteristics together, and individual gas quantities together.
![image](https://user-images.githubusercontent.com/7697956/92065487-6f1ef100-ed65-11ea-8fd2-f0d5652d3943.png)

## Why It's Good For The Game

Bug fix: Issue #419 

## Changelog
:cl:
fix: Atmos analyzer displays room pressure
tweak: Atmos analyzer output is easier to read when used multiple times
/:cl:
