### PR TITLE
Shotgun screwery.

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -88,7 +88,7 @@
 	icon_state = "improvshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_improvised
 	custom_materials = list(/datum/material/iron=250)
-	pellets = 10
+	pellets = 6
 	variance = 25
 
 /obj/item/ammo_casing/shotgun/ion

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -88,7 +88,7 @@
 	icon_state = "improvshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_improvised
 	custom_materials = list(/datum/material/iron=250)
-	pellets = 6
+	pellets = 6		// Wasp Edit - Shotgun Nerf
 	variance = 25
 
 /obj/item/ammo_casing/shotgun/ion

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -37,7 +37,7 @@
 		impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser/wall
 
 /obj/projectile/beam/weak
-	damage = 5.5
+	damage = 5.5		// Wasp Edit - Shotgun Nerf
 
 /obj/projectile/beam/weak/penetrator
 	armour_penetration = 50

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -37,7 +37,7 @@
 		impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser/wall
 
 /obj/projectile/beam/weak
-	damage = 15
+	damage = 5.5
 
 /obj/projectile/beam/weak/penetrator
 	armour_penetration = 50

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,7 +1,7 @@
 /obj/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 30
-	armour_penetration = 10
+	damage = 30		// Wasp Edit - Shotgun Nerf
+	armour_penetration = 10		// Wasp Edit - Shotgun Nerf
 
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -63,7 +63,7 @@
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 7
+	damage = 7		// Wasp Edit - Shotgun Nerf
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -58,8 +58,8 @@
 	return BULLET_ACT_HIT
 
 /obj/projectile/bullet/pellet
-	var/tile_dropoff = 0.8
-	var/tile_dropoff_s = 0.8
+	var/tile_dropoff = 0.8		// Wasp Edit - Shotgun Nerf
+	var/tile_dropoff_s = 0.8		// Wasp Edit - Shotgun Nerf
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,27 +1,28 @@
 /obj/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 60
+	damage = 30
 
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
 	damage = 5
-	stamina = 55
+	stamina = 30
 
 /obj/projectile/bullet/incendiary/shotgun
 	name = "incendiary slug"
-	damage = 20
+	damage = 15
 
 /obj/projectile/bullet/incendiary/shotgun/dragonsbreath
 	name = "dragonsbreath pellet"
-	damage = 5
+	damage = 3
 
 /obj/projectile/bullet/shotgun_stunslug
 	name = "stunslug"
 	damage = 5
-	paralyze = 100
+	stamina = 40
+	knockdown = 10
 	stutter = 5
 	jitter = 20
-	range = 7
+	range = 3
 	icon_state = "spark"
 	color = "#FFFF00"
 
@@ -29,7 +30,7 @@
 	name = "meteorslug"
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "dust"
-	damage = 30
+	damage = 25
 	paralyze = 15
 	knockdown = 80
 	hitsound = 'sound/effects/meteorimpact.ogg'
@@ -56,17 +57,17 @@
 	return BULLET_ACT_HIT
 
 /obj/projectile/bullet/pellet
-	var/tile_dropoff = 0.75
-	var/tile_dropoff_s = 0.5
+	var/tile_dropoff = 0.8
+	var/tile_dropoff_s = 0.8
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 12.5
+	damage = 7
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
-	damage = 3
-	stamina = 11
+	damage = 1
+	stamina = 7
 
 /obj/projectile/bullet/pellet/shotgun_incapacitate
 	name = "incapacitating pellet"
@@ -83,7 +84,6 @@
 		qdel(src)
 
 /obj/projectile/bullet/pellet/shotgun_improvised
-	tile_dropoff = 0.55		//Come on it does 6 damage don't be like that.
 	damage = 6
 
 /obj/projectile/bullet/pellet/shotgun_improvised/Initialize()

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,6 +1,7 @@
 /obj/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
 	damage = 30
+	armour_penetration = 10
 
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
@@ -9,11 +10,11 @@
 
 /obj/projectile/bullet/incendiary/shotgun
 	name = "incendiary slug"
-	damage = 15
+	damage = 20
 
 /obj/projectile/bullet/incendiary/shotgun/dragonsbreath
 	name = "dragonsbreath pellet"
-	damage = 3
+	damage = 5
 
 /obj/projectile/bullet/shotgun_stunslug
 	name = "stunslug"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -4,7 +4,7 @@
 
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
-	damage = 5
+	damage = 1
 	stamina = 30
 
 /obj/projectile/bullet/incendiary/shotgun

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -19,8 +19,8 @@
 /obj/projectile/bullet/shotgun_stunslug
 	name = "stunslug"
 	damage = 5
-	stamina = 40
-	knockdown = 10
+	stamina = 40		// Wasp Edit - Shotgun Nerf
+	knockdown = 10		// Wasp Edit - Shotgun Nerf
 	stutter = 5
 	jitter = 20
 	range = 3

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -31,7 +31,7 @@
 	name = "meteorslug"
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "dust"
-	damage = 25
+	damage = 25		// Wasp Edit - Shotgun Nerf
 	paralyze = 15
 	knockdown = 80
 	hitsound = 'sound/effects/meteorimpact.ogg'

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -67,8 +67,8 @@
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
-	damage = 1
-	stamina = 7
+	damage = 1		// Wasp Edit - Shotgun Nerf
+	stamina = 7		// Wasp Edit - Shotgun Nerf
 
 /obj/projectile/bullet/pellet/shotgun_incapacitate
 	name = "incapacitating pellet"

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -260,7 +260,7 @@
 					/obj/item/clothing/head/soft/black = 2,
 					/obj/item/clothing/shoes/sneakers/black = 2,
 					/obj/item/reagent_containers/glass/rag = 2,
-					/obj/item/storage/box/beanbag = 1,
+					/obj/item/storage/box/rubbershot = 1,
 					/obj/item/clothing/suit/armor/vest/alt = 1,
 					/obj/item/circuitboard/machine/dish_drive = 1,
 					/obj/item/clothing/glasses/sunglasses/reagent = 1,

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -260,7 +260,7 @@
 					/obj/item/clothing/head/soft/black = 2,
 					/obj/item/clothing/shoes/sneakers/black = 2,
 					/obj/item/reagent_containers/glass/rag = 2,
-					/obj/item/storage/box/rubbershot = 1,
+					/obj/item/storage/box/rubbershot = 1,		// Wasp Edit - Shotgun Nerf
 					/obj/item/clothing/suit/armor/vest/alt = 1,
 					/obj/item/circuitboard/machine/dish_drive = 1,
 					/obj/item/clothing/glasses/sunglasses/reagent = 1,


### PR DESCRIPTION
Title says it all. An overdue shotgun nerf. I really want to rebalance more weapons, but I think I'll start with this. I could go into the details, but basically this PR just massively reduces the damage of all shotgun ammo. I touched all the shotgun types, but I'll list the main two here.

- Slugs deal 30 damage and 10 AP, leading to 4 hits to crit, 2 to slowdown. I know, same number as the stechkin and .45, but one of those is a traitor gun and the other barely exists. The change was necessary to differentiate hits to crit, which in our current state of balance, the slug shotgun crits in the same number of shots as the buckshot does. This makes it so the slug isn't always the superior choice for those with decent aim.

- Buckshot deals 42 damage, leading to 3 hits to kill at close range, one to slowdown. Damage falloff was raised by 0.05, making it 0.8 damage lost per tile. The buckshot shotgun should still be a force to be reckoned with at close range, but making it a little more fair to fight against.

*edit* Papa squid said I should mention all the changes, so I will now.

- Non lethal variants of buckshot and slugs also were nerfed, with the same HtK.

- Meteor slug was nerfed to 25 dmg, from 30, so it wasn't just a better slug.

- Laser ammo nerfed to 5.5 dmg per shot.

- removed the different falloff value from makeshift ammo.

I know, nerfs aren't popular things, but this is long overdue. The only weapon that can even compete with these things in terms of sheer damage is the deagle/traitor revolver, and those things are insanely expensive and rare, while shotguns are, quite literally, laying all over the place (it's hilarious how many shotguns the ship has, and how much damage they dish out). All in all, this should make these more balanced weapons.

