### PR TITLE
Selected Character Name Added to Job Selection Window

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -424,7 +424,12 @@
 */
 
 /mob/dead/new_player/proc/LateChoices()
-	var/dat = "<div class='notice'>Round Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]</div>"
+	// Waspstation Start - Added selected character name to job selection window
+	var/name = client.prefs.real_name
+
+	var/dat = "<div class='notice'>Welcome, [name].</div>"
+	dat += "<div class='notice'>Round Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]</div>"
+	// Waspstation End
 
 	if(SSshuttle.emergency)
 		switch(SSshuttle.emergency.mode)


### PR DESCRIPTION
## About The Pull Request

Selected character name added to the top of the job selection window via LateChoices() in new_player.dm.
![image](https://user-images.githubusercontent.com/7697956/92196974-1bc8a380-ee36-11ea-8b58-0e7a451edaa7.png)

Corner case analysis: If you open the job select and setup character windows at the same time, you can change your character without updating the name in the job select window.  Because the point of this PR is to remind you who you're playing as, I don't feel the need to force the job selection window to update if you change characters after you've already seen the reminder.

## Why It's Good For The Game

The point of this addition is to make it less likely to forget which character you have selected and sign them up as the wrong job.  
I.E. When I accidentally sign my miner or botanist up as an atmos tech.

## Changelog
:cl:
add: Your selected character's name has been added to the job selection window
/:cl:
