### PR TITLE
Sane Shotgun Rebalance

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -37,7 +37,7 @@
 		impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser/wall
 
 /obj/projectile/beam/weak
-	damage = 15
+	damage = 6
 
 /obj/projectile/beam/weak/penetrator
 	armour_penetration = 50

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -37,7 +37,7 @@
 		impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser/wall
 
 /obj/projectile/beam/weak
-	damage = 6
+	damage = 6		// Wasp Edit - Shotgun Nerf
 
 /obj/projectile/beam/weak/penetrator
 	armour_penetration = 50

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,7 +1,7 @@
 /obj/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 30
-	armour_penetration = 10
+	damage = 30		// Wasp Edit - Shotgun Nerf
+	armour_penetration = 10		// Wasp Edit - Shotgun Nerf
 
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,11 +1,12 @@
 /obj/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 60
+	damage = 30
+	armour_penetration = 10
 
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
 	damage = 5
-	stamina = 55
+	stamina = 50
 
 /obj/projectile/bullet/incendiary/shotgun
 	name = "incendiary slug"
@@ -18,10 +19,11 @@
 /obj/projectile/bullet/shotgun_stunslug
 	name = "stunslug"
 	damage = 5
-	paralyze = 100
+	stamina = 40
+	knockdown = 10
 	stutter = 5
 	jitter = 20
-	range = 7
+	range = 4
 	icon_state = "spark"
 	color = "#FFFF00"
 
@@ -29,7 +31,7 @@
 	name = "meteorslug"
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "dust"
-	damage = 30
+	damage = 25
 	paralyze = 15
 	knockdown = 80
 	hitsound = 'sound/effects/meteorimpact.ogg'
@@ -56,17 +58,17 @@
 	return BULLET_ACT_HIT
 
 /obj/projectile/bullet/pellet
-	var/tile_dropoff = 0.75
-	var/tile_dropoff_s = 0.5
+	var/tile_dropoff = 0.8
+	var/tile_dropoff_s = 0.6
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 12.5
+	damage = 8
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
-	damage = 3
-	stamina = 11
+	damage = 1
+	stamina = 8
 
 /obj/projectile/bullet/pellet/shotgun_incapacitate
 	name = "incapacitating pellet"
@@ -83,7 +85,6 @@
 		qdel(src)
 
 /obj/projectile/bullet/pellet/shotgun_improvised
-	tile_dropoff = 0.55		//Come on it does 6 damage don't be like that.
 	damage = 6
 
 /obj/projectile/bullet/pellet/shotgun_improvised/Initialize()

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -6,7 +6,7 @@
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
 	damage = 5
-	stamina = 50
+	stamina = 50		// Wasp Edit - Shotgun Nerf
 
 /obj/projectile/bullet/incendiary/shotgun
 	name = "incendiary slug"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -63,7 +63,7 @@
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 8
+	damage = 8		// Wasp Edit - Shotgun Nerf
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -23,7 +23,7 @@
 	knockdown = 10
 	stutter = 5
 	jitter = 20
-	range = 4
+	range = 4		// Wasp Edit - Shotgun Nerf
 	icon_state = "spark"
 	color = "#FFFF00"
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -67,8 +67,8 @@
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
-	damage = 1
-	stamina = 8
+	damage = 1		// Wasp Edit - Shotgun Nerf
+	stamina = 8		// Wasp Edit - Shotgun Nerf
 
 /obj/projectile/bullet/pellet/shotgun_incapacitate
 	name = "incapacitating pellet"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -19,8 +19,8 @@
 /obj/projectile/bullet/shotgun_stunslug
 	name = "stunslug"
 	damage = 5
-	stamina = 40
-	knockdown = 10
+	stamina = 40		// Wasp Edit - Shotgun Nerf
+	knockdown = 10		// Wasp Edit - Shotgun Nerf
 	stutter = 5
 	jitter = 20
 	range = 4		// Wasp Edit - Shotgun Nerf

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -58,8 +58,8 @@
 	return BULLET_ACT_HIT
 
 /obj/projectile/bullet/pellet
-	var/tile_dropoff = 0.8
-	var/tile_dropoff_s = 0.6
+	var/tile_dropoff = 0.8		// Wasp Edit - Shotgun Nerf
+	var/tile_dropoff_s = 0.6		// Wasp Edit - Shotgun Nerf
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -31,7 +31,7 @@
 	name = "meteorslug"
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "dust"
-	damage = 25
+	damage = 25		// Wasp Edit - Shotgun Nerf
 	paralyze = 15
 	knockdown = 80
 	hitsound = 'sound/effects/meteorimpact.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
An edit of #426 that keeps non-lethal rounds a bit higher up. Meaning:

- Beanbag slugs go from 55 -> 50 stamina damage.

- Buckshot pellets from 12.5 -> 8, totaling 48 damage point-blank

- Stamina damage falloff goes from 0.5 -> 0.6

All other changes match the original PR
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Most of sparrows changes were good, but nerfing non-lethals seems redundant.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: shotguns are generally worse.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
