### PR TITLE
Added Ethereal Charge to Status Tab

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -76,6 +76,17 @@
 				stat(null, "Chemical Storage: [changeling.chem_charges]/[changeling.chem_storage]")
 				stat(null, "Absorbed DNA: [changeling.absorbedcount]")
 
+		// WaspStation Begin - Display Ethereal Charge
+		var/mob/living/carbon/human/H = usr
+
+		if(istype(H))
+			var/datum/species/ethereal/eth_species = H.dna?.species
+			if(istype(eth_species))
+				var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+				if(istype(stomach))
+					stat(null, "Crystal Charge: [round(stomach.crystal_charge, 0.1)]")
+		// WaspStation End
+
 	//NINJACODE
 	if(istype(wear_suit, /obj/item/clothing/suit/space/space_ninja)) //Only display if actually a ninja.
 		var/obj/item/clothing/suit/space/space_ninja/SN = wear_suit


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/7697956/92294339-e1700c80-eef0-11ea-9281-f38cb92974dc.png)

I wrapped the crystal charge value from stomach.dm inside the ethereal checks from lighting.dm, and moved them inside Stat() in human.dm.

## Why It's Good For The Game

This makes it easier for Ethereal players to manage their charge.  Specifically, it makes it easier to avoid overcharging while using a borg recharger.  Requested in Issue #304 

## Changelog
:cl:
add: Ethereals' charge is now listed in the status tab
/:cl:
