### PR TITLE
Ethereal Facial Hair

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -14,7 +14,7 @@
 	brutemod = 1.25 //They're weak to punches
 	attack_type = BURN //burn bish
 	damage_overlay_type = "" //We are too cool for regular damage overlays
-	species_traits = list(DYNCOLORS, AGENDER, NO_UNDERWEAR, HAIR)
+	species_traits = list(DYNCOLORS, AGENDER, NO_UNDERWEAR, HAIR, FACEHAIR)    // Waspstation Edit - Gave Ethereals Beards
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/ethereal
 	inherent_traits = list(TRAIT_NOHUNGER)


### PR DESCRIPTION
## About The Pull Request

Allows Ethereals to have facial hair.

While this was reported as a bug, I think "no facial hair" may have been intentional.  Ethereals don't have genders, and facial hair is considered to be male-only.  That said, if they can have hair, I would figure they can have facial hair.  Maybe have a lore guy look over this first.

![image](https://user-images.githubusercontent.com/7697956/92311734-6efa3d80-ef7f-11ea-9558-bd650d9e2abc.png)
![image](https://user-images.githubusercontent.com/7697956/92311738-77eb0f00-ef7f-11ea-9a80-61105aa882bd.png)

## Why It's Good For The Game

Allows for more visual distinction between Ethereals of the same color.  Requested in Issue #304.

## Changelog
:cl:
tweak: Ethereals can have facial hair
/:cl:
