### PR TITLE
No more free ammo

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -417,11 +417,21 @@
 	hacked = state
 	for(var/id in SSresearch.techweb_designs)
 		var/datum/design/D = SSresearch.techweb_design_by_id(id)
-		if((D.build_type & AUTOLATHE) && ("hacked" in D.category))
-			if(hacked)
+		if(D.build_type & AUTOLATHE)
+			if("hacked" in D.category)
+				if(hacked || obj_flags & EMAGGED) // Waspstation - Emag the lathe
+					stored_research.add_design(D)
+				else
+					stored_research.remove_design(D)
+			if(("emagged" in D.category) && (obj_flags & EMAGGED))
 				stored_research.add_design(D)
-			else
-				stored_research.remove_design(D)
+
+/obj/machinery/autolathe/emag_act(mob/user) // Waspstation - Emag the lathe
+	if(obj_flags & EMAGGED)
+		return
+	obj_flags |= EMAGGED
+	adjust_hacked(TRUE) // im in
+	to_chat(user, "<span class='warning'>You load the [src] with a series of specialized designs.</span>")
 
 /obj/machinery/autolathe/hacked/Initialize()
 	. = ..()

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -763,6 +763,7 @@
 	category = list("initial", "Misc")
 
 //hacked autolathe recipes
+// Waspstation - emagged recipies
 /datum/design/flamethrower
 	name = "Flamethrower"
 	id = "flamethrower"
@@ -809,7 +810,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/shotgun
-	category = list("hacked", "Security")
+	category = list("emagged", "Security")
 
 /datum/design/buckshot_shell
 	name = "Buckshot Shell"
@@ -817,7 +818,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/buckshot
-	category = list("hacked", "Security")
+	category = list("emagged", "Security")
 
 /datum/design/shotgun_dart
 	name = "Shotgun Dart"
@@ -825,7 +826,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/dart
-	category = list("hacked", "Security")
+	category = list("emagged", "Security")
 
 /datum/design/incendiary_slug
 	name = "Incendiary Slug"
@@ -833,7 +834,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/incendiary
-	category = list("hacked", "Security")
+	category = list("emagged", "Security")
 
 /datum/design/riot_dart
 	name = "Foam Riot Dart"
@@ -857,7 +858,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/a357
-	category = list("hacked", "Security")
+	category = list("emagged", "Security")
 
 /datum/design/c10mm
 	name = "Ammo Box (10mm)"
@@ -865,7 +866,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 30000)
 	build_path = /obj/item/ammo_box/c10mm
-	category = list("hacked", "Security")
+	category = list("emagged", "Security")
 
 /datum/design/c45
 	name = "Ammo Box (.45)"
@@ -873,7 +874,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 30000)
 	build_path = /obj/item/ammo_box/c45
-	category = list("hacked", "Security")
+	category = list("emagged", "Security")
 
 /datum/design/c9mm
 	name = "Ammo Box (9mm)"
@@ -881,7 +882,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 30000)
 	build_path = /obj/item/ammo_box/c9mm
-	category = list("hacked", "Security")
+	category = list("emagged", "Security")
 
 /datum/design/cleaver
 	name = "Butcher's Cleaver"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Autolathes will no longer contain designs for any lethal rounds unless emagged. Putting a few ammunition types behind a TC investment again.

This also means autolathes now have the feature of containing both hacked and emagged contents, as opposed to just the hacked state before.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As an example: The .357 Speed Loader is considered a 4 TC item that contains 6 rounds. A hacked autolathe prints .357 rounds for 4000 iron each. So with only an autolathe and a pair of wirecutters you can get a **4TC value** for only **12 sheets of iron**.
Items with a TC cost shouldn't be available in a machine that any department can build the board for and hacked with minimal effort.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added "emagged" category to autolathe designes
balance: All lethal munitions in the lathe are moved to the "emagged" category
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
