### PR TITLE
Fixed Add Filtered Frequency Button on Telecomms Tgui

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -120,9 +120,9 @@
 					. = TRUE
 		if("tempfreq")
 			if(params["value"])
-				tempfreq = text2num(params["value"]) * 10
+				tempfreq = sanitize_frequency(text2num(params["value"]) * 10, TRUE) // Waspstation Edit - add frequency filter fix
 		if("freq")
-			var/newfreq = tempfreq * 10
+			var/newfreq = tempfreq                                                  // Waspstation Edit - add frequency filter fix
 			if(newfreq == FREQ_SYNDICATE)
 				to_chat(operator, "<span class='warning'>Error: Interference preventing filtering frequency: \"[newfreq / 10] GHz\"</span>")
 				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)


### PR DESCRIPTION
## About The Pull Request

The add filtered frequency button in the telecomms tgui wouldn't respond when clicked.  This was caused by a second times-ten operation that would make the frequency value always be above the allowed cap, causing the function to exit.  Once I fixed this, I realized the frequency you added wasn't being validated/sanitized, so you could enter weird values like 145.1099999998.  I fixed this by adding a call to sanitize_frequency() from __HELPERS/radio.dm.

Example of added filtered frequencies:
![image](https://user-images.githubusercontent.com/7697956/92363711-8ccabe00-f0b7-11ea-9d1b-f8c6d99485c7.png)

## Why It's Good For The Game

Bug fix.  Without this fix you can't restore any filtered frequency cleared from tcomms machinery, which makes it impossible to restore tcomms to the round start setup.

## Changelog
:cl:
fix: Tcomms machines now accept additional filtered frequencies.
/:cl:
