### PR TITLE
Removes the L666 Fuckyouinator from the traitor PDA.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -603,15 +603,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 4
 	surplus = 50
 
-/datum/uplink_item/stealthy_weapons/fuckyouinator
-	name = "L666 FUCKYOUINATOR"
-	desc = "A heavily modified L6 SAW. \
-			This literal WMD has a massive 5000-round magazine of devastating special splitting L666 .50 caliber ammunition. \
-			It has a firerate so high that it is considered unethical even for most syndicate agents, as nobody will survive it."
-	item = /obj/item/gun/ballistic/automatic/l666
-	cost = 1000
-	cant_discount = TRUE
-
 /datum/uplink_item/stealthy_weapons/dehy_carp
 	name = "Dehydrated Space Carp"
 	desc = "Looks like a plush toy carp, but just add water and it becomes a real-life space carp! Activate in \


### PR DESCRIPTION
Do I need need to justify or explain this? Why the fuck is this thing in the PDA, it's not purchasable through any sane legitimate means, and if someone somehow gets it, everything immediately dies. It has no place in the traitor PDA.


🆑
Removal: Removes L666 Fuckyouinator from traitor PDAs.
/🆑