### PR TITLE
makes regen jelly mixable with omnizine, soft-nerfs the tricord regen jelly recipe

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -147,8 +147,13 @@ WaspStation End */
 	required_reagents = list(/datum/reagent/chlorine = 1, /datum/reagent/fluorine = 1, /datum/reagent/aluminium = 1, /datum/reagent/medicine/potass_iodide = 1, /datum/reagent/fuel/oil = 1)
 
 /datum/chemical_reaction/regen_jelly
-	results = list(/datum/reagent/medicine/regen_jelly = 2)
+	results = list(/datum/reagent/medicine/regen_jelly = 1)
 	required_reagents = list(/datum/reagent/medicine/tricordrazine = 1, /datum/reagent/toxin/slimejelly = 1)
+
+/datum/chemical_reaction/regen_jelly2
+	results = list(/datum/reagent/medicine/regen_jelly = 2)
+	required_reagents = list(/datum/reagent/medicine/omnizine = 1, /datum/reagent/toxin/slimejelly = 1)
+
 /*WaspStation Begin
 /datum/chemical_reaction/higadrite
 	results = list(/datum/reagent/medicine/higadrite = 3)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -148,7 +148,7 @@ WaspStation End */
 
 /datum/chemical_reaction/regen_jelly
 	results = list(/datum/reagent/medicine/regen_jelly = 1)
-	required_reagents = list(/datum/reagent/medicine/tricordrazine = 1, /datum/reagent/toxin/slimejelly = 1)
+	required_reagents = list(/datum/reagent/medicine/tetracordrazine = 1, /datum/reagent/toxin/slimejelly = 1)
 
 /datum/chemical_reaction/regen_jelly2
 	results = list(/datum/reagent/medicine/regen_jelly = 2)


### PR DESCRIPTION
## About The Pull Request

closes #459 
makes omnizine + slime jelly produce regen jelly again
changes the current regen jelly recipe to be tetracord + slime jelly and produces 1 unit instead of 2 

## Why It's Good For The Game

uhh

## Changelog
:cl:
balance: tetracord + slime jelly produces one unit regen jelly instead of two
fix: regen jelly is mixable with omnizine and slime jelly again
/:cl: