### PR TITLE
Cap's Announcement Reports Name on User's ID or Unknown

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -26,10 +26,17 @@
 			else
 				GLOB.news_network.SubmitArticle(title + "<br><br>" + text, "Central Command", "Station Announcements", null)
 
+	// Waspstation Begin - Make cap's announcement use id name
+	var/user_id = "Unknown"
+	var/obj/item/card/id/I = usr.get_idcard(TRUE)
+	if(I && istype(I))
+		user_id = "[I.registered_name] ([I.assignment])"
+	// Waspstation End
+
 	announcement += "<br><span class='alert'>[html_encode(text)]</span><br>"
 	announcement += "<br>"
 	if(user)
-		announcement += "<span class='alert'>-[user.name] ([user.job])</span><br>"
+		announcement += "<span class='alert'>-[user_id]</span><br>"             // Waspstation Edit - Make cap's announcement use id name
 
 	var/s = sound(sound)
 	for(var/mob/M in GLOB.player_list)


### PR DESCRIPTION
## About The Pull Request

New behavior: name_on_id job_on_id
Old behavior: real_name (name_on_id) real_job

This PR is a clarification.  Please put it up for vote.

With the new behavior, a captain's announcement will list the name/job on the id the user is holding, or "Unknown" if there is no id.
With the old behavior, a captain's announcement will always list the real name/job of the user.  This was the intention of PR #44.

I repurposed code from Topic() in communications.dm to get the name and job from the id the user is wearing/holding.

Examples of new behavior:
![image](https://user-images.githubusercontent.com/7697956/93724534-8d5e5c80-fb6d-11ea-89b9-11a2ce7c1433.png)
![image](https://user-images.githubusercontent.com/7697956/93724538-98b18800-fb6d-11ea-9628-0984909a7ccb.png)
![image](https://user-images.githubusercontent.com/7697956/93724549-a5ce7700-fb6d-11ea-8598-9d10642c7c1b.png)
![image](https://user-images.githubusercontent.com/7697956/93724556-aff07580-fb6d-11ea-8ae1-1e49f1fdef4d.png)
![image](https://user-images.githubusercontent.com/7697956/93724565-bf6fbe80-fb6d-11ea-80ee-2cf8ddc09d46.png)

Old behavior documented in Issue #296 comments.

## Why It's Good For The Game

Requested in Issue #296 

## Changelog
:cl:
tweak: Captain's announcement lists name on using id instead of user's real name
/:cl:
