### PR TITLE
Vote System Rework - Remove Observer/New Player Auto-Transfer Votes

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -348,7 +348,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		return
 	if(SSvote.mode) //Theres already a vote running, default to rotation.
 		maprotate()
-	SSvote.initiate_vote("map", "automatic map rotation")
+	SSvote.initiate_vote("map", "automatic map rotation", TRUE) // WaspStation Edit - Ghost Voting Rework
 
 /datum/controller/subsystem/mapping/proc/changemap(var/datum/map_config/VM)
 	if(!VM.MakeNextMap())

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -198,7 +198,6 @@ SUBSYSTEM_DEF(vote)
 		to_chat(usr, "<span class='warning'>Cannot start vote, server is not done initializing.</span>")
 		return FALSE
 	var/admin = FALSE
-	var/ghost_vote_default_ok = TRUE
 	var/ckey = ckey(initiator_key)
 	if(GLOB.admin_datums[ckey])
 		admin = TRUE
@@ -234,7 +233,6 @@ SUBSYSTEM_DEF(vote)
 				)
 				if(SSshuttle.emergency.mode in ignore_vote)
 					return FALSE
-				ghost_vote_default_ok = FALSE
 				choices.Add("Initiate Crew Transfer","Continue Playing")
 			//WS End
 
@@ -286,7 +284,7 @@ SUBSYSTEM_DEF(vote)
 			var/list/valid_clients = GLOB.clients.Copy()
 			for(var/c in valid_clients)
 				var/client/C = c
-				if(C.mob && (isobserver(C.mob) || isnewplayer(C.mob) || ismouse(C.mob)) && !IsAdminGhost(C.mob))
+				if(C.mob && (isobserver(C.mob) || isnewplayer(C.mob) || ismouse(C.mob)) && !check_rights_for(C, R_ADMIN))
 					valid_clients -= C
 			for(var/c in valid_clients)
 				var/client/C = c

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -284,7 +284,7 @@ SUBSYSTEM_DEF(vote)
 			var/list/valid_clients = GLOB.clients.Copy()
 			for(var/c in valid_clients)
 				var/client/C = c
-				if(C.mob && (isobserver(C.mob) || isnewplayer(C.mob)) && !IsAdminGhost(C.mob))
+				if(C.mob && (isobserver(C.mob) || isnewplayer(C.mob) || ismouse(C.mob)) && !IsAdminGhost(C.mob))
 					valid_clients -= C
 			for(var/c in valid_clients)
 				var/client/C = c

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -267,7 +267,7 @@ SUBSYSTEM_DEF(vote)
 		// WaspStation Begin - Ghost Vote Rework
 		var/vp = CONFIG_GET(number/vote_period)
 		var/vote_message =  "\n<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=[REF(src)]'>here</a> to place your votes.\nYou have [DisplayTimeText(vp)] to vote.</font>"
-		if(observer_vote_allowed || ghost_vote_default_ok)
+		if(observer_vote_allowed)
 			to_chat(world, vote_message)
 			SEND_SOUND(world, sound('sound/misc/notice2.ogg'))
 			time_remaining = round(vp/10)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -271,11 +271,13 @@ SUBSYSTEM_DEF(vote)
 				generated_actions += V
 			return TRUE
 		else
-			var/list/valid_clients = list(GLOB.clients)
-			for(var/C in valid_clients)
+			var/list/valid_clients = GLOB.clients.Copy()
+			for(var/c in valid_clients)
+				var/client/C = c
 				if(C.mob && (isobserver(C.mob) || isnewplayer(C.mob)) && !IsAdminGhost(C.mob))
 					valid_clients -= C
-			for(var/C in valid_clients)
+			for(var/c in valid_clients)
+				var/client/C = c
 				to_chat(C.mob, vote_message)
 				var/datum/action/vote/V = new
 				if(question)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -193,7 +193,7 @@ SUBSYSTEM_DEF(vote)
 				return vote
 	return FALSE
 
-/datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key, ghost_vote_allowed = TRUE)
+/datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key, observer_vote_allowed = TRUE)
 	if(!Master.current_runlevel) //Server is still intializing.
 		to_chat(usr, "<span class='warning'>Cannot start vote, server is not done initializing.</span>")
 		return FALSE
@@ -256,9 +256,9 @@ SUBSYSTEM_DEF(vote)
 		log_vote(text)
 
 		// WaspStation Begin - Ghost Vote Rework
-		var/vote_message =  "\n<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=[REF(src)]'>here</a> to place your votes.\nYou have [DisplayTimeText(vp)] to vote.</font>"
 		var/vp = CONFIG_GET(number/vote_period)
-		if(ghost_vote_allowed)
+		var/vote_message =  "\n<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=[REF(src)]'>here</a> to place your votes.\nYou have [DisplayTimeText(vp)] to vote.</font>"
+		if(observer_vote_allowed)
 			to_chat(world, vote_message)
 			time_remaining = round(vp/10)
 			for(var/c in GLOB.clients)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -273,7 +273,7 @@ SUBSYSTEM_DEF(vote)
 		else
 			var/list/valid_clients = list(GLOB.clients)
 			for(var/C in valid_clients)
-				if(C.mob && (isobserver(C.mob) || isnewplayer(C.mob))
+				if(C.mob && (isobserver(C.mob) || isnewplayer(C.mob)) && !IsAdminGhost(C.mob))
 					valid_clients -= C
 			for(var/C in valid_clients)
 				to_chat(C.mob, vote_message)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -71,7 +71,7 @@ SUBSYSTEM_DEF(vote)
 					choices[GLOB.master_mode] += non_voters.len
 					if(choices[GLOB.master_mode] >= greatest_votes)
 						greatest_votes = choices[GLOB.master_mode]
-						
+
 			//WaspStation Begin - Autotransfer
 			else if(mode == "transfer")
 				var/factor = 1
@@ -87,8 +87,8 @@ SUBSYSTEM_DEF(vote)
 					else
 						factor = 1.4
 				choices["Initiate Crew Transfer"] += round(non_voters.len * factor)
-			//WaspStation End	
-				
+			//WaspStation End
+
 			else if(mode == "map")
 				for (var/non_voter_ckey in non_voters)
 					var/client/C = non_voters[non_voter_ckey]
@@ -193,7 +193,7 @@ SUBSYSTEM_DEF(vote)
 				return vote
 	return FALSE
 
-/datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key)
+/datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key, ghost_vote_allowed = TRUE)
 	if(!Master.current_runlevel) //Server is still intializing.
 		to_chat(usr, "<span class='warning'>Cannot start vote, server is not done initializing.</span>")
 		return FALSE
@@ -254,18 +254,38 @@ SUBSYSTEM_DEF(vote)
 		if(mode == "custom")
 			text += "\n[question]"
 		log_vote(text)
+
+		// WaspStation Begin - Ghost Vote Rework
+		var/vote_message =  "\n<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=[REF(src)]'>here</a> to place your votes.\nYou have [DisplayTimeText(vp)] to vote.</font>"
 		var/vp = CONFIG_GET(number/vote_period)
-		to_chat(world, "\n<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=[REF(src)]'>here</a> to place your votes.\nYou have [DisplayTimeText(vp)] to vote.</font>")
-		time_remaining = round(vp/10)
-		for(var/c in GLOB.clients)
-			var/client/C = c
-			var/datum/action/vote/V = new
-			if(question)
-				V.name = "Vote: [question]"
-			C.player_details.player_actions += V
-			V.Grant(C.mob)
-			generated_actions += V
-		return TRUE
+		if(ghost_vote_allowed)
+			to_chat(world, vote_message)
+			time_remaining = round(vp/10)
+			for(var/c in GLOB.clients)
+				var/client/C = c
+				var/datum/action/vote/V = new
+				if(question)
+					V.name = "Vote: [question]"
+				C.player_details.player_actions += V
+				V.Grant(C.mob)
+				generated_actions += V
+			return TRUE
+		else
+			var/list/valid_clients = list(GLOB.clients)
+			for(var/C in valid_clients)
+				if(C.mob && (isobserver(C.mob) || isnewplayer(C.mob))
+					valid_clients -= C
+			for(var/C in valid_clients)
+				to_chat(C.mob, vote_message)
+				var/datum/action/vote/V = new
+				if(question)
+					V.name = "Vote: [question]"
+				C.player_details.player_actions += V
+				V.Grant(C.mob)
+				generated_actions += V
+			time_remaining = round(vp/10)
+			return TRUE
+		// WaspStation End - Ghost Vote Rework
 	return FALSE
 
 /datum/controller/subsystem/vote/proc/interface(client/C)
@@ -360,16 +380,16 @@ SUBSYSTEM_DEF(vote)
 				CONFIG_SET(flag/allow_vote_map, !CONFIG_GET(flag/allow_vote_map))
 		if("restart")
 			if(CONFIG_GET(flag/allow_vote_restart) || usr.client.holder)
-				initiate_vote("restart",usr.key)
+				initiate_vote("restart",usr.key, TRUE) // WaspStation Edit - Ghost Vote Rework
 		if("gamemode")
 			if(CONFIG_GET(flag/allow_vote_mode) || usr.client.holder)
-				initiate_vote("gamemode",usr.key)
+				initiate_vote("gamemode",usr.key, TRUE) // WaspStation Edit - Ghost Vote Rework
 		if("map")
 			if(CONFIG_GET(flag/allow_vote_map) || usr.client.holder)
-				initiate_vote("map",usr.key)
+				initiate_vote("map",usr.key, TRUE) // WaspStation Edit - Ghost Vote Rework
 		if("custom")
 			if(usr.client.holder)
-				initiate_vote("custom",usr.key)
+				initiate_vote("custom",usr.key, TRUE) // WaspStation Edit - Ghost Vote Rework
 		else
 			submit_vote(round(text2num(href_list["vote"])))
 	usr.vote()

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -224,6 +224,16 @@ SUBSYSTEM_DEF(vote)
 
 			//WS Begin - Autotransfer
 			if("transfer")
+				var/list/ignore_vote = list(
+					SHUTTLE_IGNITING,
+					SHUTTLE_CALL,
+					SHUTTLE_ENDGAME,
+					SHUTTLE_ESCAPE,
+					SHUTTLE_DOCKED,
+					SHUTTLE_PREARRIVAL
+				)
+				if(SSshuttle.emergency.mode in ignore_vote)
+					return FALSE
 				choices.Add("Initiate Crew Transfer","Continue Playing")
 			//WS End
 

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -198,6 +198,7 @@ SUBSYSTEM_DEF(vote)
 		to_chat(usr, "<span class='warning'>Cannot start vote, server is not done initializing.</span>")
 		return FALSE
 	var/admin = FALSE
+	var/ghost_vote_default_ok = TRUE
 	var/ckey = ckey(initiator_key)
 	if(GLOB.admin_datums[ckey])
 		admin = TRUE
@@ -214,7 +215,6 @@ SUBSYSTEM_DEF(vote)
 				to_chat(usr, "<span class='warning'>A vote was initiated recently, you must wait [DisplayTimeText(next_allowed_time-world.time)] before a new vote can be started!</span>")
 				return FALSE
 
-		SEND_SOUND(world, sound('sound/misc/notice2.ogg'))//WS Edit - Autotransfer
 		reset()
 		switch(vote_type)
 			if("restart")
@@ -234,6 +234,7 @@ SUBSYSTEM_DEF(vote)
 				)
 				if(SSshuttle.emergency.mode in ignore_vote)
 					return FALSE
+				ghost_vote_default_ok = FALSE
 				choices.Add("Initiate Crew Transfer","Continue Playing")
 			//WS End
 
@@ -268,8 +269,9 @@ SUBSYSTEM_DEF(vote)
 		// WaspStation Begin - Ghost Vote Rework
 		var/vp = CONFIG_GET(number/vote_period)
 		var/vote_message =  "\n<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=[REF(src)]'>here</a> to place your votes.\nYou have [DisplayTimeText(vp)] to vote.</font>"
-		if(observer_vote_allowed)
+		if(observer_vote_allowed || ghost_vote_default_ok)
 			to_chat(world, vote_message)
+			SEND_SOUND(world, sound('sound/misc/notice2.ogg'))
 			time_remaining = round(vp/10)
 			for(var/c in GLOB.clients)
 				var/client/C = c
@@ -288,6 +290,7 @@ SUBSYSTEM_DEF(vote)
 					valid_clients -= C
 			for(var/c in valid_clients)
 				var/client/C = c
+				SEND_SOUND(C, sound('sound/misc/notice2.ogg'))
 				to_chat(C.mob, vote_message)
 				var/datum/action/vote/V = new
 				if(question)

--- a/waspstation/code/controllers/subsystem/autotransfer.dm
+++ b/waspstation/code/controllers/subsystem/autotransfer.dm
@@ -13,5 +13,5 @@ SUBSYSTEM_DEF(autotransfer)
 
 /datum/controller/subsystem/autotransfer/fire()
 	if (world.time > targettime)
-		SSvote.initiate_vote("transfer",null) //TODO figure out how to not use null as the user
+		SSvote.initiate_vote("transfer",null, FALSE) // WaspStation Edit - Ghost Vote Rework
 		targettime = targettime + CONFIG_GET(number/vote_autotransfer_interval)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a `observer_vote_allowed` parameter to `initiate_vote` so that (specifically) players that are either observing or in the lobby are not allowed to participate in the automatic vote to transfer.

## Why It's Good For The Game

People who are participating in the round are the only ones (besides admins) who should have a say in calling the shuttle.

## Changelog
:cl:
fix: Observers and Lobby Players cannot vote for auto transfer votes.
tweak: Auto-Transfer votes won't trigger if a transfer is already in progress.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
