### PR TITLE
Makes Pubby whiteship gooderer

### DIFF
--- a/_maps/shuttles/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship_pubby.dmm
@@ -1,80 +1,291 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ao" = (
-/obj/effect/turf_decal/caution,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+"ab" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"au" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/cargo)
-"aV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+"aK" = (
+/obj/structure/table/reinforced,
+/obj/item/gps{
+	gpstag = "NTREC1";
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/off{
+	pixel_x = 6;
+	pixel_y = 14
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/cargo)
-"bg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/bridge)
 "bn" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/engine)
-"cF" = (
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
+"bo" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/suit_storage_unit/mining/eva,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"cI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"dy" = (
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/cargo)
-"dN" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/bridge)
-"er" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/bridge)
-"eT" = (
+"dn" = (
+/obj/effect/turf_decal/caution,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"du" = (
 /obj/structure/spacepoddoor{
 	dir = 4
 	},
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"ep" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/cargo)
+"eG" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"eJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"eL" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/engine)
+"ge" = (
+/obj/machinery/power/smes{
+	charge = 1e+006
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"gr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"gN" = (
+/obj/effect/turf_decal/box/corners,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"gP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/hivebot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/cargo)
+"hi" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/hyper,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"hq" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"hw" = (
 /obj/machinery/door/poddoor{
+	id = "whiteship_bridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/bridge)
+"hX" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/box,
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/storage/firstaid,
+/obj/item/storage/firstaid,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"ir" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_bridge"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned/bridge)
+"iz" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"jr" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"jJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/strong,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"jO" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/electrical,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"jV" = (
+/obj/structure/spacepoddoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/multi_tile/four_tile_hor{
 	id = "pubbywspodsw"
 	},
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
-"fm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"kw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
+	dir = 8;
+	view_range = 14;
+	x_offset = -4;
+	y_offset = -8
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"kW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"gB" = (
-/obj/effect/turf_decal/box/corners,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"gH" = (
+"kZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"la" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"lp" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"mh" = (
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"na" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"nr" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate,
@@ -84,79 +295,150 @@
 /obj/item/storage/belt/mining,
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/cargo)
-"gU" = (
-/obj/structure/chair{
+"nG" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/box,
+/obj/machinery/mineral/equipment_vendor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"nS" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"hT" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/hyper,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"ih" = (
+"oj" = (
 /obj/structure/spacepoddoor{
 	dir = 4
 	},
-/obj/machinery/door/poddoor{
-	id = "pubbywspodne"
+/obj/machinery/door/poddoor/multi_tile/four_tile_hor{
+	id = "pubbywspodse"
 	},
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
-"in" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"ow" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/box,
+/obj/machinery/airalarm/directional/east{
+	pixel_x = 24
 	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"iS" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/bridge)
-"jH" = (
-/obj/machinery/button/door{
-	id = "pubbywspodne";
-	name = "Pod Door Control";
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"jK" = (
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"jQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"kJ" = (
+/obj/structure/closet/crate,
+/obj/item/spacepod_equipment/weaponry/plasma_cutter,
+/obj/item/spacepod_equipment/cargo/large/ore,
+/obj/item/pod_parts/armor/industrial,
+/obj/item/circuitboard/mecha/pod,
+/obj/item/pod_parts/core,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"pF" = (
+/obj/spacepod,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
-"ml" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+"qi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/light,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"mr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/cargo)
-"mt" = (
+"qx" = (
+/turf/template_noop,
+/area/template_noop)
+"qy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "whiteship_windows";
+	name = "Windows Blast Door Control";
+	pixel_x = -5;
+	pixel_y = 26
+	},
+/obj/machinery/button/door{
+	id = "whiteship_bridge";
+	name = "Bridge Blast Door Control";
+	pixel_x = 5;
+	pixel_y = 26
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -4
+	},
+/obj/item/folder/blue{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/folder/white,
+/obj/item/pen{
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"rX" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"sr" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"sv" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"sx" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate,
+/obj/item/pickaxe/drill,
+/obj/item/pickaxe/drill,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"sX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -166,57 +448,97 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/cargo)
-"mL" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"nv" = (
-/obj/effect/turf_decal/stripes/line{
+"tq" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"nS" = (
+"tE" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/mineral/ore_redemption,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/cargo)
+"tM" = (
+/obj/structure/ore_box,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"tX" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"uf" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"ui" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/shuttle/white_ship{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"vQ" = (
+/obj/machinery/button/door{
+	id = "pubbywspodse";
+	name = "Pod Door Control";
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"wl" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"wB" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/engine)
+"wT" = (
 /obj/effect/turf_decal/caution,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"od" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"ol" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/box,
-/obj/structure/table/reinforced,
-/obj/item/multitool,
-/obj/item/multitool,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"on" = (
+"xe" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/button/door{
@@ -228,269 +550,104 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
-"oH" = (
-/obj/structure/shuttle/engine/propulsion/left{
+"xM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
-	},
-/turf/template_noop,
-/area/shuttle/abandoned/engine)
-"oT" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/engine)
-"pt" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"pA" = (
-/obj/machinery/door/airlock/titanium,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/engine)
-"pU" = (
-/obj/structure/spacepoddoor{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
-	id = "pubbywspodse"
-	},
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"pY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"qx" = (
-/turf/template_noop,
-/area/template_noop)
-"re" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/bridge)
-"sh" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/cargo)
-"ss" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"tp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"tN" = (
-/obj/structure/chair{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/bridge)
-"uf" = (
+"xV" = (
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"wy" = (
-/obj/machinery/door/window/westleft,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/cargo)
-"wG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
-/obj/item/gps{
-	gpstag = "NTREC1";
-	pixel_x = -9;
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/bridge)
-"xG" = (
-/obj/spacepod,
-/obj/effect/turf_decal/box/corners{
+"yt" = (
+/obj/structure/shuttle/engine/propulsion/left{
 	dir = 8
 	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/engine)
+"yu" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
-"yR" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
+"yy" = (
+/obj/structure/window/reinforced,
 /obj/effect/turf_decal/box,
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/cargo)
-"zv" = (
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned/cargo)
-"Al" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"AO" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/cargo)
-"BB" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/box,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/closet/crate/secure/weapon,
-/obj/item/gun/energy/laser/retro,
-/obj/item/gun/energy/laser/retro,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"BR" = (
+"yC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"Cd" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"Do" = (
-/obj/machinery/door/window/westright,
+"yH" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/cargo)
-"Ea" = (
+"zk" = (
 /obj/structure/spacepoddoor{
 	dir = 4
 	},
-/obj/machinery/door/poddoor{
-	id = "pubbywspodnw"
+/obj/machinery/door/poddoor/multi_tile/four_tile_hor{
+	id = "pubbywspodne"
 	},
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
-"Ei" = (
-/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
-	dir = 8;
-	view_range = 14;
-	x_offset = -4;
-	y_offset = -8
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/bridge)
-"Eq" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/box,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/suit_storage_unit/mining/eva,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"Er" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "pubbywspodnw";
-	name = "Pod Door Control";
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"Fa" = (
+"zo" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
 	},
 /obj/effect/turf_decal/box,
-/obj/structure/closet/crate,
-/obj/item/pickaxe/drill,
-/obj/item/pickaxe/drill,
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/item/gun/energy/kinetic_accelerator,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"Fu" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"FG" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/box,
-/obj/machinery/mineral/equipment_vendor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/cargo)
-"FH" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 8
+"Al" = (
+/obj/machinery/light{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
-"Gm" = (
+"BA" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/docking_port/mobile{
@@ -506,216 +663,46 @@
 	preferred_direction = 4;
 	width = 24
 	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/cargo)
-"Ha" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/box,
-/obj/structure/table/reinforced,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"Hh" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/box,
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/storage/firstaid,
-/obj/item/storage/firstaid,
-/obj/item/storage/firstaid,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"If" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/bridge)
-"Ih" = (
+"BD" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"BJ" = (
 /obj/machinery/button/door{
-	id = "pubbywspodse";
+	id = "pubbywspodne";
 	name = "Pod Door Control";
 	pixel_x = 24;
 	pixel_y = 0
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
-"Is" = (
+"BN" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/box,
 /obj/structure/table/reinforced,
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/cargo)
-"IE" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/bridge)
-"JN" = (
-/obj/structure/table/reinforced,
-/obj/item/laser_pointer,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/bridge)
-"JV" = (
-/obj/structure/ore_box,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"KO" = (
-/obj/machinery/power/smes{
-	charge = 1e+006
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"Lu" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
-/obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"MY" = (
-/obj/machinery/door/airlock/titanium/glass,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/bridge)
-"NK" = (
-/obj/machinery/door/window/eastleft,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/cargo)
-"NT" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/cargo)
-"Or" = (
-/obj/structure/table/reinforced,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/machinery/recharger,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/bridge)
-"Ov" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/mineral/ore_redemption,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/cargo)
-"OI" = (
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"Pg" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"Pu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"QO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"QU" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"RC" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"RW" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"RZ" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/table/reinforced,
-/obj/machinery/microwave,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"Sg" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/tank_dispenser,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"Si" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/box,
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
-/obj/structure/closet/crate,
-/obj/item/spacepod_equipment/weaponry/plasma_cutter,
-/obj/item/spacepod_equipment/cargo/large/ore,
-/obj/item/pod_parts/armor/industrial,
-/obj/item/circuitboard/mecha/pod,
-/obj/item/pod_parts/core,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"TU" = (
-/obj/machinery/door/window/eastright,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/cargo)
-"TZ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"Uf" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/shuttle/abandoned/cargo)
-"Uk" = (
+"Cq" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
@@ -723,58 +710,351 @@
 /obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/suit_storage_unit/mining/eva,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/cargo)
-"Uy" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
+"DL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"UD" = (
-/obj/machinery/computer/shuttle/white_ship{
-	dir = 8
+"DT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/cargo)
+"Es" = (
+/obj/machinery/door/window/eastright,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/cargo)
+"Fp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/bridge)
-"UP" = (
-/obj/machinery/power/terminal{
-	dir = 4
+"FQ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/hivebot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"Gf" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"US" = (
-/obj/structure/grille,
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"Vv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"VO" = (
-/obj/machinery/light,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"Wg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"Gh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/cargo)
+"Gn" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"Hr" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"Hx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/cargo)
+"If" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/bridge)
+"Ix" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/box,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/gun/energy/laser/retro,
+/obj/item/gun/energy/laser/retro,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"Ku" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"La" = (
+/obj/machinery/door/window/eastleft,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/cargo)
+"Ld" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/box,
+/obj/structure/table/reinforced,
+/obj/item/multitool,
+/obj/item/multitool,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"Lg" = (
+/obj/machinery/door/window/westright,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/cargo)
+"Ls" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_windows"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"LU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"Mp" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"My" = (
+/obj/machinery/door/airlock/titanium,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/engine)
+"No" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"Oq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"Ow" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"Pa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/station_alert{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"PS" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/cargo)
+"Qe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"Rd" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/cargo)
+"Rj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"Sg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"Sj" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_bridge"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned/bridge)
+"TA" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_windows"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned/cargo)
+"TC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/table/reinforced,
+/obj/item/laser_pointer,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
+"TG" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_bridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned/bridge)
+"Uo" = (
+/obj/structure/spacepoddoor{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/multi_tile/four_tile_hor{
+	id = "pubbywspodnw"
+	},
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"Us" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"VN" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/tank_dispenser,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"Wb" = (
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"WG" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "pubbywspodnw";
+	name = "Pod Door Control";
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"WN" = (
+/obj/machinery/door/window/westleft,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/cargo)
 "WW" = (
@@ -783,344 +1063,400 @@
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/engine)
+"Xc" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "whiteship_bridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned/bridge)
 "Xl" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/bridge)
-"XO" = (
-/obj/machinery/atmospherics/components/unary/tank/air,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"Yz" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
-"ZA" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
+"Yu" = (
+/obj/machinery/airalarm/directional/east{
+	pixel_x = 24
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"Yw" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"YC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"YF" = (
+/obj/effect/turf_decal/box/corners,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/shuttle/abandoned/cargo)
+"YK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
+"Zm" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"Zz" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/cargo)
 
 (1,1,1) = {"
 qx
 bn
-US
-US
+Ls
+Ls
 bn
 qx
 qx
 bn
-US
-US
+Ls
+Ls
 bn
 qx
 "}
 (2,1,1) = {"
 qx
-bn
-RW
-jK
-bn
-Uy
-Uy
-bn
-JV
-jK
-bn
+eL
+uf
+kW
+eL
+nS
+nS
+eL
+tM
+DL
+eL
 qx
 "}
 (3,1,1) = {"
 qx
-bn
-Cd
-jK
-bn
-Pu
-in
-bn
-hT
-jK
-bn
+eL
+la
+kW
+eL
+yC
+ab
+eL
+hi
+kW
+eL
 qx
 "}
 (4,1,1) = {"
 qx
-bn
-JV
-VO
-bn
-pY
-ml
-bn
-UP
-jK
-bn
+eL
+tM
+Gn
+eL
+Sg
+cI
+eL
+lp
+kW
+eL
 qx
 "}
 (5,1,1) = {"
 qx
+eL
+tM
+kW
 bn
-JV
-jK
+tq
+eG
 bn
-pt
-Pg
-bn
-KO
-jK
-bn
+ge
+kW
+eL
 qx
 "}
 (6,1,1) = {"
 qx
-bn
-TZ
-Fu
-nS
-BR
-nv
-ao
-fm
-jK
-bn
+eL
+Yw
+FQ
+dn
+YC
+Oq
+wT
+YK
+kW
+eL
 qx
 "}
 (7,1,1) = {"
-oH
-bn
-XO
-Al
-cF
-Vv
-tp
-Lu
-gU
-uf
-bn
-oH
+yt
+eL
+rX
+kZ
+Yu
+Ow
+Us
+Wb
+BD
+xV
+eL
+yt
 "}
 (8,1,1) = {"
 WW
+eL
+Ls
+Ls
 bn
-Yz
-Yz
+My
+wB
 bn
-pA
-oT
-bn
-Yz
-Yz
-bn
+Ls
+Ls
+eL
 WW
 "}
 (9,1,1) = {"
-Ea
-Er
-OI
-OI
-RZ
-Wg
-dy
-ol
-OI
-OI
-on
-eT
+Uo
+WG
+Rj
+Rj
+zo
+Gh
+Hx
+Ld
+Rj
+Rj
+xe
+jV
 "}
 (10,1,1) = {"
-Ea
-QO
-QU
-FH
-yR
-Wg
-dy
-Ha
-QU
-FH
-RC
-eT
+du
+Ku
+jr
+Zz
+Zm
+Gh
+Hx
+yy
+sv
+hq
+tX
+du
 "}
 (11,1,1) = {"
-Ea
-QO
-ZA
-gB
-od
-Wg
-dy
-Is
-ZA
-gB
-RC
-eT
+du
+Ku
+iz
+YF
+Mp
+Gh
+Hx
+BN
+iz
+YF
+tX
+du
 "}
 (12,1,1) = {"
-Ea
-ss
-OI
-bg
-mL
-sh
-mr
-Hh
-jQ
-OI
-Uf
-eT
+du
+No
+Rj
+LU
+jO
+Rd
+DT
+hX
+Qe
+Rj
+yu
+du
 "}
 (13,1,1) = {"
-au
-au
-au
-Do
-dy
-Wg
-dy
-dy
-wy
-au
-au
-au
+TA
+TA
+TA
+Lg
+Hx
+Gh
+Hx
+Hx
+WN
+TA
+TA
+TA
 "}
 (14,1,1) = {"
-Gm
-dy
-AO
-dy
-dy
-Ov
-aV
-dy
-dy
-NT
-dy
-AO
+BA
+Hx
+ep
+Hx
+Hx
+tE
+qi
+Hx
+Hx
+yH
+Hx
+ep
 "}
 (15,1,1) = {"
-au
-au
-au
-NK
-dy
-Wg
-dy
-dy
-TU
-au
-au
-au
+TA
+TA
+TA
+La
+Hx
+Gh
+Hx
+Hx
+Es
+TA
+TA
+TA
 "}
 (16,1,1) = {"
-ih
-ss
-OI
-bg
-Uk
-sh
-mr
-Eq
-jQ
-OI
-Uf
-pU
+zk
+No
+Rj
+LU
+Cq
+Rd
+gP
+bo
+Qe
+Rj
+yu
+oj
 "}
 (17,1,1) = {"
-ih
-QO
-QU
-xG
-Fa
-Wg
-dy
-gH
-QU
-FH
-RC
-pU
+du
+Ku
+sv
+pF
+sx
+Gh
+Hx
+nr
+sv
+Zz
+tX
+du
 "}
 (18,1,1) = {"
-ih
-QO
-ZA
-gB
-Sg
-Wg
-dy
-FG
-ZA
-gB
-RC
-pU
+du
+Ku
+iz
+YF
+VN
+Gh
+Hx
+nG
+iz
+gN
+tX
+du
 "}
 (19,1,1) = {"
-ih
-ss
-jH
-kJ
-BB
-mt
-dy
-Si
-kJ
-Ih
-Uf
-pU
+du
+No
+BJ
+Al
+Ix
+sX
+Hx
+ow
+Al
+vQ
+yu
+du
 "}
 (20,1,1) = {"
-zv
-au
-zv
-zv
-zv
-dN
-MY
-zv
-zv
-zv
-au
-zv
+PS
+PS
+PS
+PS
+PS
+sr
+wl
+PS
+PS
+PS
+PS
+PS
 "}
 (21,1,1) = {"
-qx
-qx
 Xl
+If
+If
+Hr
+eJ
+xM
+gr
+Gf
+aK
+If
+If
 Xl
-JN
-er
-IE
-re
-Xl
-Xl
-qx
-qx
 "}
 (22,1,1) = {"
 qx
-qx
-qx
 Xl
-Or
-tN
-IE
-wG
+If
+qy
+na
+jJ
+Fp
+na
+TC
+If
 Xl
-qx
-qx
 qx
 "}
 (23,1,1) = {"
 qx
 qx
-qx
-Xl
-If
-Ei
-UD
-If
-Xl
-qx
+Xc
+Sj
+mh
+ui
+kw
+Pa
+Sj
+ir
 qx
 qx
 "}
@@ -1128,12 +1464,12 @@ qx
 qx
 qx
 qx
-qx
-Xl
-iS
-iS
-Xl
-qx
+Xc
+TG
+TG
+hw
+hw
+ir
 qx
 qx
 qx


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Monstermos compliance 
- DIRT! It's an abandoned shuttle and needs to be D I R T Y
- Hostile mobs added, just put some hivebots in there as a "not too deadly" solution for free gamer loot
- Changed the bridge layout. I absolutely hated looking at how smole the bridge looked and it was weird looking in with how the tiles smoothed 
- Changed the pod doors to the fancy four tile wide doors

![image](https://user-images.githubusercontent.com/6519623/94239572-03e9ba00-fee0-11ea-85c8-19ffb7031d5b.png)


## Why It's Good For The Game

Haha, Traitor got SUCCED, and I wasn't aware this wasn't made monstermos compliant.

## Changelog
:cl:
tweak: Pubby whiteship updated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
