### PR TITLE
Caltrops no longer paralyze people with light step

### DIFF
--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -49,21 +49,27 @@
 			return
 
 		var/damage = rand(min_damage, max_damage)
-		if(HAS_TRAIT(H, TRAIT_LIGHT_STEP))
+		var/haslightstep = HAS_TRAIT(H, TRAIT_LIGHT_STEP) //Begin Waspstation edit - caltrops don't paralyze people with light step
+		if(haslightstep && !H.incapacitated(ignore_restraints = TRUE))
 			damage *= 0.75
 
 		if(cooldown < world.time - 10) //cooldown to avoid message spam.
 			//var/atom/A = parent		Wasp edit
 			if(!H.incapacitated(ignore_restraints = TRUE))
-				H.visible_message("<span class='danger'>[H] steps on [A].</span>", \
-						"<span class='userdanger'>You step on [A]!</span>")
+				if(haslightstep)
+					H.visible_message("<span class='danger'>[H] carefully steps on [A].</span>",
+									  "<span class='danger'>You carefully step on [A], but it still hurts!</span>")
+				else 
+					H.visible_message("<span class='danger'>[H] steps on [A].</span>", \
+									  "<span class='userdanger'>You step on [A]!</span>")
 			else
 				H.visible_message("<span class='danger'>[H] slides on [A]!</span>", \
 						"<span class='userdanger'>You slide on [A]!</span>")
 
 			cooldown = world.time
 		H.apply_damage(damage, BRUTE, picked_def_zone)
-		H.Paralyze(60)
+		if(!haslightstep)
+			H.Paralyze(60) //End Waspstation edit - caltrops don't paralyze people with light step
 		if(H.pulledby)								// Waspstation Edit Begin - Being pulled over caltrops is logged
 			log_combat(H.pulledby, H, "pulled", A)
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Objects marked as caltrops (such as glass shards) will no longer paralyze mobs that have the Light Step quirk. In addition, having the Light Step quirk will no longer reduce damage if you are incapacitated and move over caltrops (since you wouldn't be able to carefully step over them).

## Why It's Good For The Game

Since digitigrade species don't have shoes for themselves, this is a good way to prevent an unfair combat advantage.

## Changelog
:cl:
tweak: Caltrops (like glass shards) will no longer paralyze you if you have the Light Step trait.
tweak: You will now take full damage if you move over caltrops if you are incapacitated, even if you have the Light Step trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
