### PR TITLE
Fix "cancel" button deleting all flavor text

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1560,7 +1560,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("flavor_text")
 					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", features["flavor_text"], 4096, TRUE)
-					if(!isnull(msg))
+					if(msg)
 						features["flavor_text"] = html_decode(msg)
 
 				if("hair")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1560,7 +1560,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("flavor_text")
 					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", features["flavor_text"], 4096, TRUE)
-					if(msg)
+					if(msg) //Waspstation edit - "Cancel" does not clear flavor text
 						features["flavor_text"] = html_decode(msg)
 
 				if("hair")

--- a/waspstation/code/modules/mob/say_vr.dm
+++ b/waspstation/code/modules/mob/say_vr.dm
@@ -10,7 +10,7 @@
 		usr << "No."
 	var/msg = input(usr,"Set the flavor text in your 'examine' verb. Can also be used for OOC notes about your character.","Flavor Text",html_decode(flavor_text)) as message|null
 
-	if(msg != null)
+	if(msg)
 		msg = copytext(msg, 1, MAX_MESSAGE_LEN)
 		msg = html_encode(msg)
 

--- a/waspstation/code/modules/mob/say_vr.dm
+++ b/waspstation/code/modules/mob/say_vr.dm
@@ -10,7 +10,7 @@
 		usr << "No."
 	var/msg = input(usr,"Set the flavor text in your 'examine' verb. Can also be used for OOC notes about your character.","Flavor Text",html_decode(flavor_text)) as message|null
 
-	if(msg)
+	if(msg) //Waspstation edit - "Cancel" does not clear flavor text
 		msg = copytext(msg, 1, MAX_MESSAGE_LEN)
 		msg = html_encode(msg)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This optimizes the null/false checking on the returned string when changing one's flavor text. As a result, clicking the Cancel button will not longer reset a character's flavor text to nothing.

## Why It's Good For The Game

An unwary player might not be aware of this issue and click cancel, thus deleting what might have been a large chunk of information. This exact scenario happened to me and is why I made this PR.

## Changelog
:cl:
fix: Clicking the "cancel" button will no longer reset your flavor text to nothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
