### PR TITLE
Me and subtler are no longer multiline inputs

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -436,7 +436,7 @@
 		to_chat(user, "<span class='boldwarning'>You cannot send IC messages (muted).</span>")
 		return FALSE
 	else if(!params)
-		var/custom_emote = copytext(sanitize(input("Choose an emote to display.") as message|null), 1, MAX_MESSAGE_LEN) //WASP CHANGE - expands emote textbox
+		var/custom_emote = copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
 		if(custom_emote && !check_invalid(user, custom_emote))
 			var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable")
 			switch(type)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -1,7 +1,7 @@
 //Speech verbs.
 
 ///Say verb
-/mob/verb/say_verb(message as text)
+/mob/verb/say_verb(message as text|null) // Waspstation edit - add null to speech verbs
 	set name = "Say"
 	set category = "IC"
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
@@ -11,7 +11,7 @@
 		say(message)
 
 ///Whisper verb
-/mob/verb/whisper_verb(message as text)
+/mob/verb/whisper_verb(message as text|null) // Waspstation edit - add null to speech verbs
 	set name = "Whisper"
 	set category = "IC"
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
@@ -24,7 +24,7 @@
 	say(message, language) //only living mobs actually whisper, everything else just talks
 
 ///The me emote verb
-/mob/verb/me_verb(message as message) // WASP CHANGE - makes me command input box bigger
+/mob/verb/me_verb(message as text|null) // Waspstation edit - add null to speech verbs
 	set name = "Me"
 	set category = "IC"
 

--- a/waspstation/code/modules/mob/say_vr.dm
+++ b/waspstation/code/modules/mob/say_vr.dm
@@ -68,7 +68,7 @@ SUBTLER  //WaspStation - Subtle emotes
 		to_chat(user, "You cannot send IC messages (muted).")
 		return FALSE
 	else if(!params)
-		var/subtle_emote = stripped_multiline_input(user, "Choose an emote to display.", "Subtler" , null, MAX_MESSAGE_LEN)
+		var/subtle_emote = input(user, "Choose an emote to display.", "Subtler")
 		if(subtle_emote && !check_invalid(user, subtle_emote))
 			var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable")
 			switch(type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so the input boxes for the `me` and `subtler` verbs are no longer multiline. This lets you send them using the Enter key.

This also makes inputs `text|null`, which doesn't really do anything since they're verb inputs anyway, but makes it a bit clearer to understand IMO.

This can be considered a partial revert of https://github.com/WaspStation/WaspStation-1.0/pull/378.

## Why It's Good For The Game

While I can understand why the boxes allow for multiple lines, since they are meant to be descriptive, it also makes it very difficult to actually send a message. Compared to the `say` verb, having to mouse over and click the send button takes up a lot of time compared to simply hitting the enter key. And from what I have seen, no one uses line breaks when using these verbs anyway.

## Changelog
:cl:
tweak: The "me" and "subtler" verbs are now single line input boxes again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
