### PR TITLE
Fix vape clouds making reagents out of nothing

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -943,15 +943,19 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	//open flame removed because vapes are a closed system, they wont light anything on fire
 
 	if(super && vapetime > 3)//Time to start puffing those fat vapes, yo.
-		var/datum/effect_system/smoke_spread/chem/smoke_machine/s = new
-		s.set_up(reagents, 1, 24, loc)
+		var/datum/effect_system/smoke_spread/chem/smoke_machine/s = new //Begin Waspstation edit - Fix vape clouds
+		var/datum/reagents/smokereagents = new
+		reagents.trans_to(smokereagents, reagents.total_volume / 10, 0.65)
+		s.set_up(smokereagents, 1, 24, loc)
 		s.start()
 		vapetime = 0
 
 	if((obj_flags & EMAGGED) && vapetime > 3)
 		var/datum/effect_system/smoke_spread/chem/smoke_machine/s = new
-		s.set_up(reagents, 4, 24, loc)
-		s.start()
+		var/datum/reagents/smokereagents = new
+		reagents.trans_to(smokereagents, reagents.total_volume / 5, 0.75)
+		s.set_up(smokereagents, 4, 24, loc)
+		s.start() //End Waspstation edit - Fix vape clouds
 		vapetime = 0
 		if(prob(5))//small chance for the vape to break and deal damage if it's emagged
 			playsound(get_turf(src), 'sound/effects/pop_expl.ogg', 50, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Vape clouds, currently, are given the full reagents of the originating vape...without actually removing any reagents from the vape itself. This leads to duplication of the vape's reagents en masse, which can lead to literally thousands of reagents being consumed by a mob in a short span of time. Obviously not ideal.

This PR makes the following changes:

- When a vape is set to the medium voltage setting, vape clouds will consume one tenth (1/10) of the vape's current total reagents. 65% of this will be sent to the actual vape cloud (since this is not a 100% efficient process) where it can be inhaled.

- When a vape is emagged and set to the high voltage setting, vape clouds will consume one fifth (1/5) of the vape's current total reagents. 75% of this will be sent to the actual vape cloud where it can be inhaled.

This PR is made independent of https://github.com/WaspStation/WaspStation-1.0/pull/479 since it covers a much different scope and I don't want https://github.com/WaspStation/WaspStation-1.0/pull/479 to become a victim of feature creep.

## Why It's Good For The Game

This fixes a bug while also adding in a reasonable limit on how vape clouds can function.

## Changelog
:cl:
fix: Vape clouds (from medium/high-voltage vapes) no longer create reagents out of thin air. They are also no longer 100% efficient in atomizing the reagents in the cartridge.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
