### PR TITLE
Communications consoles can now control status of the night shift

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -265,17 +265,17 @@
 					if("auto")
 						SSnightshift.can_fire = TRUE
 						SSnightshift.fire()
-						log_game("[keyname(usr)] has returned the night shift to automatic running.")
+						log_game("[key_name(usr)] has returned the night shift to automatic running.")
 						message_admins("[ADMIN_LOOKUPFLW(usr)] has returned the night shift to automatic running.")
 					if("on")
 						SSnightshift.can_fire = FALSE
 						SSnightshift.update_nightshift(TRUE, TRUE)
-						log_game("[keyname(usr)] has overridden the night shift to be on.")
+						log_game("[key_name(usr)] has overridden the night shift to be on.")
 						message_admins("[ADMIN_LOOKUPFLW(usr)] has overridden the night shift to be on.")
 					if("off")
 						SSnightshift.can_fire = FALSE
 						SSnightshift.update_nightshift(FALSE, TRUE)
-						log_game("[keyname(usr)] has overridden the night shift to be off.")
+						log_game("[key_name(usr)] has overridden the night shift to be off.")
 						message_admins("[ADMIN_LOOKUPFLW(usr)] has overridden the night shift to be off.")
 					else
 						CRASH("Invalid href supplied!")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -26,6 +26,7 @@
 	var/const/STATE_CONFIRM_LEVEL = 9
 	var/const/STATE_TOGGLE_EMERGENCY = 10
 	var/const/STATE_PURCHASE = 11
+	var/const/STATE_NIGHTSHIFT = 12 //Waspstation Edit - Communications Consoles can control Night Shift
 
 	var/stat_msg1
 	var/stat_msg2
@@ -258,6 +259,28 @@
 			message_admins("[ADMIN_LOOKUPFLW(usr)] disabled emergency maintenance access.")
 			deadchat_broadcast(" disabled emergency maintenance access at <span class='name'>[get_area_name(usr, TRUE)]</span>.", "<span class='name'>[usr.real_name]</span>", usr, message_type=DEADCHAT_ANNOUNCEMENT)
 			state = STATE_DEFAULT
+		if("nightshift") // Begin Waspstation Edit - Communications Consoles can control Night Shift
+			if(href_list["setnightshift"])
+				switch(href_list["setnightshift"])
+					if("auto")
+						SSnightshift.can_fire = TRUE
+						SSnightshift.fire()
+						log_game("[keyname(usr)] has returned the night shift to automatic running.")
+						message_admins("[ADMIN_LOOKUPFLW(usr)] has returned the night shift to automatic running.")
+					if("on")
+						SSnightshift.can_fire = FALSE
+						SSnightshift.update_nightshift(TRUE, TRUE)
+						log_game("[keyname(usr)] has overridden the night shift to be on.")
+						message_admins("[ADMIN_LOOKUPFLW(usr)] has overridden the night shift to be on.")
+					if("off")
+						SSnightshift.can_fire = FALSE
+						SSnightshift.update_nightshift(FALSE, TRUE)
+						log_game("[keyname(usr)] has overridden the night shift to be off.")
+						message_admins("[ADMIN_LOOKUPFLW(usr)] has overridden the night shift to be off.")
+					else
+						CRASH("Invalid href supplied!")
+			else
+				state = STATE_NIGHTSHIFT //End Waspstation Edit - Communications Consoles can control Night Shift
 
 		// Status display stuff
 		if("setstat")
@@ -474,6 +497,7 @@
 						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=cancelshuttle'>Cancel Shuttle Call</A> \]"
 
 				dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=status'>Set Status Display</A> \]"
+				dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=nightshift'>Night Shift Subroutine Access</A> \]" //Waspstation Edit - Communications Consoles can control Night Shift
 				if (authenticated==2)
 					dat += "<BR><BR><B>Captain Functions</B>"
 					dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=announce'>Make a Captain's Announcement</A> \]"
@@ -578,6 +602,26 @@
 					if(S.prerequisites)
 						dat += "Prerequisites: [S.prerequisites]<BR>"
 					dat += "<A href='?src=[REF(src)];operation=buyshuttle;chosen_shuttle=[REF(S)]'>(<font color=red><i>Purchase</i></font>)</A><BR><BR>"
+		if(STATE_NIGHTSHIFT) //Begin Waspstation Edit - Communications Consoles can control Night Shift
+			playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
+			dat += "Current Night Shift Subroutine Autonomy: <b>[SSnightshift.can_fire ? "<span style='color:green'>NOMINAL</span>" : "<span style='color:red'>OVERRIDDEN"]</span></b>"
+			dat += "<br>Current Night Shift Subroutine Status: <b>[SSnightshift.nightshift_active ? "ON" : "OFF"]</b>"
+			dat += "<br>"
+			dat += "<br><b>MANUAL OVERRIDE SETTINGS:</b>"
+			dat += "<table>"
+			if(SSnightshift.can_fire) //If it is automatically ticking.
+				dat += "<td>AUTO</td>"
+				dat += "<br><td><A HREF='?src=[REF(src)];operation=nightshift;setnightshift=on'>ON</A></td>"
+				dat += "<br><td><A HREF='?src=[REF(src)];operation=nightshift;setnightshift=off'>OFF</A></td>"
+			else if(!SSnightshift.can_fire && SSnightshift.nightshift_active == FALSE) //If it is manually OFF.
+				dat += "<br><td><A HREF='?src=[REF(src)];operation=nightshift;setnightshift=auto'>AUTO</A></td>"
+				dat += "<br><td><A HREF='?src=[REF(src)];operation=nightshift;setnightshift=on'>ON</A></td>"
+				dat += "<br><td>OFF"
+			else if(!SSnightshift.can_fire && SSnightshift.nightshift_active == TRUE) //If it is manually ON.
+				dat += "<br><td><A HREF='?src=[REF(src)];operation=nightshift;setnightshift=auto'>AUTO</A></td>"
+				dat += "<br><td>ON</td>"
+				dat += "<br><td><A HREF='?src=[REF(src)];operation=nightshift;setnightshift=off'>OFF</A></td>"
+			dat += "</table>" //End Waspstation Edit - Communications Consoles can control Night Shift
 
 	dat += "<BR><BR>\[ [(state != STATE_DEFAULT) ? "<A HREF='?src=[REF(src)];operation=main'>Main Menu</A> | " : ""]<A HREF='?src=[REF(user)];mach_close=communications'>Close</A> \]"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All heads of staff now have the ability to control the status of the Night Shift subsystem through the communications console. The menu will show its autonomy (whether or not it will automatically fire or not) as well as the current night shift level (on or off). The user can pick between setting it to automatic running, overriding it to be on, or overriding it to be off.

In essence, this is a GUI version of the Set Night Shift secret.

## Why It's Good For The Game

I think it's good for the heads of staff to be able to control the night shift status of all APCs from one location. Individual APCs can already have their night shift status changed; this makes it easier to apply it stationwide. Especially during times of emergency or when it's just preferable for there to be more light, I think this will come in handy.

## Changelog
:cl:
add: Heads of staff can now control the Night Shift subroutine via any communications console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
