### PR TITLE
Add chat markup (Partial port from Aurora)

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -67,6 +67,29 @@
 /proc/adminscrub(t,limit=MAX_MESSAGE_LEN)
 	return copytext((html_encode(strip_html_simple(t))),1,limit)
 
+//Begin Waspstation edit - Chat markup
+//Credit to Aurorastation for the regex and idea for the proc
+//Should be in the form of "tag to be replaced" = list("replacement for beginning", "replacement for end")
+var/global/list/markup_tags = list("_"  = list("<i>", "</i>"),
+								   "**" = list("<b>", "</b>"))
+//Should be in the form of "((\\W|^)@)(\[^@\]*)(@(\\W|$)), "g"", where @ is the appropriate tag from markup_tags
+var/global/regex/markup_italics = new ("((\\W|^)\_)(\[^\_\]*)(\_(\\W|$))", "g")
+var/global/regex/markup_bold = new ("((\\W|^)\\*\\*)(\[^\\*\\*\]*)(\\*\\*(\\W|$))", "g")
+//Should have a key in markup_tags as the key and one of the markup_XXX above as the value.
+var/global/list/markup_regex = list("_"  = markup_italics,
+									"**" = markup_bold)
+
+/proc/process_chat_markup(var/message, var/list/ignore = list())
+	if(!CONFIG_GET(flag/chat_markup) || !message)
+		return message
+
+	var/regex/markup
+	for(var/tag in (markup_tags - ignore))
+		markup = markup_regex[tag]
+		message = markup.Replace_char(message, "$2[markup_tags[tag][1]]$3[markup_tags[tag][2]]$5")
+	
+	return message
+//End Waspstation edit - Chat markup
 
 //Returns null if there is any bad text in the string
 /proc/reject_bad_text(text, max_length = 512, ascii_only = TRUE)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -73,7 +73,7 @@
 var/global/list/markup_tags = list("_"  = list("<i>", "</i>"),
 								   "**" = list("<b>", "</b>"))
 //Should be in the form of "((\\W|^)@)(\[^@\]*)(@(\\W|$)), "g"", where @ is the appropriate tag from markup_tags
-var/global/regex/markup_italics = new ("((\\W|^)\_)(\[^\_\]*)(\_(\\W|$))", "g")
+var/global/regex/markup_italics = new ("((\\W|^)_)(\[^_\]*)(_(\\W|$))", "g")
 var/global/regex/markup_bold = new ("((\\W|^)\\*\\*)(\[^\\*\\*\]*)(\\*\\*(\\W|$))", "g")
 //Should have a key in markup_tags as the key and one of the markup_XXX above as the value.
 var/global/list/markup_regex = list("_"  = markup_italics,

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -70,23 +70,20 @@
 //Begin Waspstation edit - Chat markup
 //Credit to Aurorastation for the regex and idea for the proc
 //Should be in the form of "tag to be replaced" = list("replacement for beginning", "replacement for end")
-var/global/list/markup_tags = list("_"  = list("<i>", "</i>"),
-								   "**" = list("<b>", "</b>"))
+GLOBAL_LIST_INIT(markup_tags, list("/"  = list("<i>", "</i>"),
+								   "**" = list("<b>", "</b>")))
 //Should be in the form of "((\\W|^)@)(\[^@\]*)(@(\\W|$)), "g"", where @ is the appropriate tag from markup_tags
-var/global/regex/markup_italics = new ("((\\W|^)_)(\[^_\]*)(_(\\W|$))", "g")
-var/global/regex/markup_bold = new ("((\\W|^)\\*\\*)(\[^\\*\\*\]*)(\\*\\*(\\W|$))", "g")
-//Should have a key in markup_tags as the key and one of the markup_XXX above as the value.
-var/global/list/markup_regex = list("_"  = markup_italics,
-									"**" = markup_bold)
+GLOBAL_LIST_INIT(markup_regex, list("/"  = new /regex("((\\W|^)_)(\[^_\]*)(_(\\W|$))", "g"),
+									"**" = new /regex("((\\W|^)\\*\\*)(\[^\\*\\*\]*)(\\*\\*(\\W|$))", "g")))
 
 /proc/process_chat_markup(var/message, var/list/ignore = list())
 	if(!CONFIG_GET(flag/chat_markup) || !message)
 		return message
 
 	var/regex/markup
-	for(var/tag in (markup_tags - ignore))
-		markup = markup_regex[tag]
-		message = markup.Replace_char(message, "$2[markup_tags[tag][1]]$3[markup_tags[tag][2]]$5")
+	for(var/tag in (GLOB.markup_tags - ignore))
+		markup = GLOB.markup_regex[tag]
+		message = markup.Replace_char(message, "$2[GLOB.markup_tags[tag][1]]$3[GLOB.markup_tags[tag][2]]$5")
 	
 	return message
 //End Waspstation edit - Chat markup

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -206,6 +206,8 @@
 
 /datum/config_entry/flag/emojis
 
+/datum/config_entry/flag/chat_markup // Waspstation edit - Chat markup
+
 /datum/config_entry/keyed_list/multiplicative_movespeed
 	key_mode = KEY_MODE_TYPE
 	value_mode = VALUE_MODE_NUM

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -26,6 +26,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	spans |= speech_span
 	if(!language)
 		language = get_selected_language()
+	message = process_chat_markup(message) // Waspstation edit - Chat markup
 	send_speech(message, 7, src, , spans, message_language=language)
 
 /atom/movable/proc/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)

--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -45,7 +45,8 @@ GLOBAL_VAR_INIT(normal_looc_colour, "#6699CC")
 			return
 
 	msg = emoji_parse(msg)
-
+	msg = process_chat_markup(msg) // Waspstation edit - Chat markup
+	
 	mob.log_talk(msg,LOG_OOC, tag="(LOOC)")
 
 	var/list/heard = get_hearers_in_view(7, get_top_level_mob(src.mob))

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -55,7 +55,8 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 	mob.log_talk(raw_msg, LOG_OOC)
 	SSredbot.send_discord_message("ooc", "**[key]:** [msg]")
-
+	msg = process_chat_markup(msg) // Waspstation edit - Chat markup
+	
 	var/keyname = key
 	if(prefs.unlock_content)
 		if(prefs.toggles & MEMBER_PUBLIC)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -221,7 +221,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	if(pressure < ONE_ATMOSPHERE*0.4) //Thin air, let's italicise the message
 		spans |= SPAN_ITALICS
-
+	message = process_chat_markup(message) // Waspstation edit - Chat markup
+	
 	send_speech(message, message_range, src, bubble_type, spans, language, message_mode)
 
 	if(succumbed)
@@ -360,6 +361,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	if(cultslurring)
 		message = cultslur(message)
+
+	message = strip_html_simple(message) //Get rid of any markdown that might hurt us
 
 	// check for and apply punctuation. thanks, bee
 	var/end = copytext(message, length(message))

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -33,7 +33,8 @@
 		return
 
 	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
-
+	message = process_chat_markup(message) // Waspstation edit - Chat markup
+	
 	usr.emote("me",1,message,TRUE)
 
 ///Speak as a dead person (ghost etc)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -22,6 +22,10 @@ OOC_DURING_ROUND
 ## Comment this out if you want to disable emojis
 EMOJIS
 
+## CHAT MARKUP (Waspstation edit) ###
+## Comment this out if you do not wish to enable chat markup.
+CHAT_MARKUP
+
 ## MOB MOVEMENT ###
 
 ## We suggest editing these variables ingame to find a good speed for your server.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pull request adds the ability for chat to have markup applied to it. Meaning, certain characters (such as `_` and `**`) when put inside chat messages will be changed into rich text.

Currently, surrounding something in `_underscores_` will italicize it, and surrounding something in `**double asterisks**` will bold it. This feature applies to OOC, LOOC, say, and me verbs.

This is a partial port of Aurora's chat markup system—credit to them for the majority of the regexes used as well as the structure of the proc itself.

This feature is a config setting and requires `CHAT_MARKUP` in game_options.txt.

### Known Issues

Ending a say message with a markup (e.g., `"/Why?/"`) will cause an extra period to appear as a result of the auto-punctuation system. This would require a lot of extra programming to fix and is not something I necessarily plan on doing. For now, just try not to close your messages with markup; leave your punctuation marks outside of the markup.

## Why It's Good For The Game

This allows for people to dynamically style their text where needed, for example being able to say "The captain fucking **sucks**." While yelling and whispering do make the text bold and italic, respectively, they also fundamentally change the way the text is handled, which might not be ideal.

## Changelog
:cl:
add: Added the ability to markup your chat in (L)OOC and IC communication channels. Surrounding a block of text with underscores will italicize it and surrounding it with two asterisks will bold it, similar to traditional markdown. Credit to Aurora for the concept and part of the code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
