### PR TITLE
[s] Fixes BS bodybag dplication glitch

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -8,6 +8,8 @@
 	var/unfoldedbag_path = /obj/structure/closet/body_bag
 
 /obj/item/bodybag/attack_self(mob/user)
+	if(user in contents)
+		return
 	deploy_bodybag(user, user.loc)
 
 /obj/item/bodybag/afterattack(atom/target, mob/user, proximity)
@@ -15,6 +17,12 @@
 	if(proximity)
 		if(isopenturf(target))
 			deploy_bodybag(user, target)
+
+/obj/item/bodybag/attack_hand(mob/user)
+	if(user in contents)
+		to_chat(user, "<span class='warning'>You cannot use [src] from the inside!</span>")
+		return
+	return ..()
 
 /obj/item/bodybag/proc/deploy_bodybag(mob/user, atom/location)
 	var/obj/structure/closet/body_bag/R = new unfoldedbag_path(location)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes: #463 

## Why It's Good For The Game
Duplication bad

## Changelog
:cl:
fix: You can no longer duplicate bluespace bodybags.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
