### PR TITLE
Cap's Announcement Reports Name on Logged-In ID or Unknown

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -1,4 +1,4 @@
-/proc/priority_announce(text, title = "", sound = 'sound/ai/attention.ogg', type, sender_override, mob/living/user)
+/proc/priority_announce(text, title = "", sound = 'sound/ai/attention.ogg', type, sender_override, auth_id)            // Waspstation Edit - Make cap's announcement use logged-in name
 	if(!text)
 		return
 
@@ -28,8 +28,8 @@
 
 	announcement += "<br><span class='alert'>[html_encode(text)]</span><br>"
 	announcement += "<br>"
-	if(user)
-		announcement += "<span class='alert'>-[user.name] ([user.job])</span><br>"
+	if(auth_id)                                                                                                       // Waspstation Edit - Make cap's announcement use logged-in name
+		announcement += "<span class='alert'>-[auth_id]</span><br>"                                                   // Waspstation Edit - Make cap's announcement use logged-in name
 
 	var/s = sound(sound)
 	for(var/mob/M in GLOB.player_list)

--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -16,14 +16,14 @@ SUBSYSTEM_DEF(communications)
 	else
 		. = TRUE
 
-/datum/controller/subsystem/communications/proc/make_announcement(mob/living/user, is_silicon, input)
+/datum/controller/subsystem/communications/proc/make_announcement(mob/living/user, is_silicon, input, auth_id)     // Waspstation Edit - Make cap's announcement use logged-in name
 	if(!can_announce(user, is_silicon))
 		return FALSE
 	if(is_silicon)
 		minor_announce(html_decode(input),"[user.name] Announces:")
 		silicon_message_cooldown = world.time + COMMUNICATION_COOLDOWN_AI
 	else
-		priority_announce(html_decode(user.treat_message(input)), null, 'sound/misc/announce.ogg', "Captain", user = user) //WaspStation Edit - Name on announcements
+		priority_announce(html_decode(user.treat_message(input)), null, 'sound/misc/announce.ogg', "Captain", null, auth_id) //WaspStation Edit - Name on announcements & Make cap's announcement use logged-in name
 		nonsilicon_message_cooldown = world.time + COMMUNICATION_COOLDOWN
 	user.log_talk(input, LOG_SAY, tag="priority announcement")
 	message_admins("[ADMIN_LOOKUPFLW(user)] has made a priority announcement.")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -717,7 +717,7 @@
 		to_chat(user, "<span class='warning'>You find yourself unable to speak.</span>")
 	else
 		input = user.treat_message(input) //Adds slurs and so on. Someone should make this use languages too.
-	SScommunications.make_announcement(user, is_silicon, input)
+	SScommunications.make_announcement(user, is_silicon, input, auth_id)                                                // Waspstation Edit - Make cap's announcement use logged-in name
 	deadchat_broadcast(" made a priority announcement from <span class='name'>[get_area_name(usr, TRUE)]</span>.", "<span class='name'>[user.real_name]</span>", user, message_type=DEADCHAT_ANNOUNCEMENT)
 
 /obj/machinery/computer/communications/proc/post_status(command, data1, data2)


### PR DESCRIPTION
## About The Pull Request

New behavior: name_on_loggedin_id job_on_loggedin_id or "Unknown"
Old behavior: real_name (name_on_id) real_job

I passed auth_id down the function calls to the code that sends the Captain's announcement.  Because of this, the sender will be listed as "Unknown" if the console is emagged.

Examples:
![image](https://user-images.githubusercontent.com/7697956/94979534-e4a6ea00-04e8-11eb-8c1e-e63fc7b11aa0.png)
![image](https://user-images.githubusercontent.com/7697956/94979598-3fd8dc80-04e9-11eb-82ea-f70408153ff5.png)

## Why It's Good For The Game

Requested in Issue #296, clarified in PR #468 comments

## Changelog
:cl:
tweak: Captain's announcement lists name on logged-in id instead of user's real name
/:cl:
