### PR TITLE
Revenants can now hear again

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -72,7 +72,7 @@
 
 /mob/living/simple_animal/revenant/Initialize(mapload)
 	. = ..()
-	flags_1 = RAD_NO_CONTAMINATE_1
+	flags_1 |= RAD_NO_CONTAMINATE_1                                                       // Waspstation Edit - Deaf Revenant Fix
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	ADD_TRAIT(src, TRAIT_SIXTHSENSE, INNATE_TRAIT)
 	AddSpell(new /obj/effect/proc_holder/spell/targeted/night_vision/revenant(null))


### PR DESCRIPTION
## About The Pull Request

Credit to Timberpoes from https://github.com/tgstation/tgstation/pull/52354
flags_1 was being overwritten instead of appended to.

Confirmation of Revenant being able to hear, and flags_1 containing HEAR_1:
![image](https://user-images.githubusercontent.com/7697956/94984586-1df44f80-0513-11eb-9bc6-b072af236bd2.png)

## Why It's Good For The Game

Bug fix: Issue #408

## Changelog
:cl:
fix: Revenants are no longer deaf.
/:cl:
