### PR TITLE
AI Channel Fix and Borer Channel Change

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -43,8 +43,8 @@
 
 //Wasp begin - Borers
 #define MODE_BORER "borer"
-#define MODE_KEY_BORER "o"
-#define MODE_TOKEN_BORER ":o"
+#define MODE_KEY_BORER "j"
+#define MODE_TOKEN_BORER ":j"
 //Wasp end
 
 #define MODE_VOCALCORDS "cords"

--- a/waspstation/code/modules/antagonists/borer/borer.dm
+++ b/waspstation/code/modules/antagonists/borer/borer.dm
@@ -1219,7 +1219,7 @@ GLOBAL_VAR_INIT(total_borer_hosts_needed, 3)
 	to_chat(owner.current, "<span class='notice'>You are the [name].</span>")
 	to_chat(owner.current, "You are a brain slug that worms its way into the head of its victim. Use stealth, persuasion and your powers of mind control to keep you, your host and your eventual spawn safe and warm.")
 	to_chat(owner.current, "Sugar nullifies your abilities, avoid it at all costs!")
-	to_chat(owner.current, "You can speak to your fellow borers by prefixing your messages with '.o'. Check out your Borer tab to see your abilities. To reproduce, you must have 200 chemicals and be controlling a host.")
+	to_chat(owner.current, "You can speak to your fellow borers by prefixing your messages with '.j'. Check out your Borer tab to see your abilities. To reproduce, you must have 200 chemicals and be controlling a host.")
 	return ..()
 
 //Objective


### PR DESCRIPTION
## About The Pull Request

The AI Private Channel token :o had stopped working, because the Borer Channel token was also set to :o and it took precedence over the AI Private Channel.  I resolved this issue by changing the Borer Channel to :j.

There doesn't appear to be a single list with all the tokens in it.  At the time of writing, it appears that :f, :j, :q, :w, and :z are still available.  I believe :1 - :9 and :0 are also still available.  It seems that the way to tell is to try to send a message on the channel, and if it returns the token, it's free.  The example being if you say "test" using ":z", it'll say ":z test" back to you.

It also occurs to me that this can easily break if upstream decides to use :j for something else and we don't notice.

Channel output examples:
Headset using :o test
![image](https://user-images.githubusercontent.com/7697956/95000563-a8769680-0587-11eb-905e-85342a4e154e.png)
AI using :o test
![image](https://user-images.githubusercontent.com/7697956/95000567-b3312b80-0587-11eb-9111-cf132a9bce63.png)
Borer using :j test
![image](https://user-images.githubusercontent.com/7697956/95000572-bcba9380-0587-11eb-8000-d86bfc9224e7.png)


## Why It's Good For The Game

Bug fix: Issue #466 

## Changelog
:cl:
fix: AI channel :o works again
tweak: Borer channel changed from :o to :j
/:cl:
