### PR TITLE
Added Recipient to PDA Message Input Box Title

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -630,8 +630,18 @@ GLOBAL_LIST_EMPTY(PDAs)
 			H.sec_hud_set_ID()
 
 
-/obj/item/pda/proc/msg_input(mob/living/U = usr)
-	var/t = stripped_input(U, "Please enter message", name, null, MAX_MESSAGE_LEN)
+// WaspStation Start -- Added recipient to PDA messages
+/obj/item/pda/proc/msg_input(mob/living/U = usr, list/obj/item/pda/targets)
+	var/title = name
+	if(targets)
+		if(length(targets) == 1)
+			title = "[name] -> [targets[1]]"
+		else if(length(targets) > 1)
+			title = "[name] -> Multiple PDAs"
+		else
+			CRASH("msg_input(): Length of list/obj/item/pda/targets is non-positive")
+	var/t = stripped_input(U, "Please enter message", title, null, MAX_MESSAGE_LEN)
+	// WaspStation End
 	if(!t || toff)
 		return
 	if(!in_range(src, U) && loc != U)
@@ -641,7 +651,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	return t
 
 /obj/item/pda/proc/send_message(mob/living/user, list/obj/item/pda/targets, everyone)
-	var/message = msg_input(user)
+	var/message = msg_input(user, targets)                  // WaspStation Edit -- Added recipient to PDA messages
 	if(!message || !targets.len)
 		return
 	if((last_text && world.time < last_text + 10) || (everyone && last_everyone && world.time < last_everyone + PDA_SPAM_DELAY))


### PR DESCRIPTION
## About The Pull Request

I passed the PDA list to msg_input() to pass the target's name to the title in stripped_input().  If there's more than one recipient in the target list, "Multiple PDAs" is displayed as the recipient.  If both names together are too long, the title gets cut off.  I'm ignoring this, since you can see enough to tell who you're messaging, assuming the sender hasn't decided to make their name/job combo excessively long.

One recipient example:
![image](https://user-images.githubusercontent.com/7697956/95516990-c7a96580-0985-11eb-8acb-289dc970ad6a.png)

Multiple recipients example:
![image](https://user-images.githubusercontent.com/7697956/95517014-ced07380-0985-11eb-8a12-989f119980e7.png)

Title is too long example:
![image](https://user-images.githubusercontent.com/7697956/95517027-d728ae80-0985-11eb-83e3-9c1916feb1ba.png)

## Why It's Good For The Game

Makes it less likely for your messages about mutiny against the captain, to get sent to the captain.

## Changelog
:cl:
tweak: PDA send-message box says who the message is being sent to
/:cl:
