### PR TITLE
Patched out vulnerability to Syndicate Virus Codename: Hardlock

### DIFF
--- a/waspstation/code/modules/spacepods/spacepod.dm
+++ b/waspstation/code/modules/spacepods/spacepod.dm
@@ -6,6 +6,14 @@
 
 GLOBAL_LIST_INIT(spacepods_list, list())
 
+GLOBAL_LIST_INIT(spacepod_verb_list,  list(
+	/obj/spacepod/verb/exit_pod,
+	/obj/spacepod/verb/lock_pod,
+	/obj/spacepod/verb/toggle_brakes,
+	/obj/spacepod/verb/toggleLights,
+	/obj/spacepod/verb/toggleDoors
+))
+
 /obj/spacepod
 	name = "space pod"
 	desc = "A frame for a spacepod."
@@ -638,6 +646,8 @@ GLOBAL_LIST_INIT(spacepods_list, list())
 		return FALSE
 	M.stop_pulling()
 	M.forceMove(src)
+	if(allow_pilot)
+		add_verb(M, GLOB.spacepod_verb_list)
 	playsound(src, 'sound/machines/windowdoor.ogg', 50, 1)
 	return TRUE
 
@@ -649,6 +659,7 @@ GLOBAL_LIST_INIT(spacepods_list, list())
 		LAZYREMOVE(M.mousemove_intercept_objects, src)
 		if(M.click_intercept == src)
 			M.click_intercept = null
+		remove_verb(M, GLOB.spacepod_verb_list)
 		desired_angle = null // since there's no pilot there's no one aiming it.
 	else if(M in passengers)
 		passengers -= M


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Hardlock Virus is a syndicate developed virus targeting the locking systems of Nanotrasen spacepods. It functions by locking any pilot out of the spacepods controls and bolting the cockpit closed.

The virus prevalence has lead to these spacepods being nicknamed "steel coffins" as pilots have starved to death after failing to disengage the canopy locking systems. NT computer scientists are working to their fullest trying to find the weakness this virus exploits.

Capitalizing on the virus syndicate privateers have had more or less free reign in NT logistics routes as the escort carriers normally tasked with providing protection for these routes are relegated to little more than idly watching as the convoy is destroyed around them.

(Credit to Baldir for the lore)

Appropriately calls `add_verb` and `remove_verb` for pilot within the spacepod.

## Why It's Good For The Game

The crew is expensive to replace.
Minimize expenses.

## Changelog
:cl:
fix: Spacepod verbs are now available again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
