### PR TITLE
Bumps default client FPS to 60 FPS

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -263,7 +263,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		GLOB.preferences_datums[ckey] = prefs
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
-	fps = prefs.clientfps == 0 ? 60 : prefs.clientfps
+	fps = prefs.clientfps == 0 ? 60 : prefs.clientfps // WaspStation Edit - Client FPS Tweak
 
 	if(fexists(roundend_report_file()))
 		add_verb(src, /client/proc/show_previous_roundend_report)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -263,7 +263,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		GLOB.preferences_datums[ckey] = prefs
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
-	fps = prefs.clientfps
+	fps = prefs.clientfps == 0 ? 60 : prefs.clientfps
 
 	if(fexists(roundend_report_file()))
 		add_verb(src, /client/proc/show_previous_roundend_report)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/list/ignoring = list()
 
-	var/clientfps = 60
+	var/clientfps = 60 // WaspStation Edit - Client FPS Tweak
 
 	var/parallax
 
@@ -1876,7 +1876,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						preferred_map = maplist[pickedmap]
 
 				if ("clientfps")
-					var/desiredfps = input(user, "Choose your desired fps. (0 = default, 60 FPS))", "Character Preference", clientfps)  as null|num
+					var/desiredfps = input(user, "Choose your desired fps. (0 = default, 60 FPS))", "Character Preference", clientfps)  as null|num // WaspStation Edit - Client FPS Tweak -
 					if (!isnull(desiredfps))
 						clientfps = desiredfps
 						parent.fps = desiredfps

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/list/ignoring = list()
 
-	var/clientfps = 0
+	var/clientfps = 60
 
 	var/parallax
 
@@ -1876,7 +1876,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						preferred_map = maplist[pickedmap]
 
 				if ("clientfps")
-					var/desiredfps = input(user, "Choose your desired fps. (0 = synced with server tick rate (currently:[world.fps]))", "Character Preference", clientfps)  as null|num
+					var/desiredfps = input(user, "Choose your desired fps. (0 = default, 60 FPS))", "Character Preference", clientfps)  as null|num
 					if (!isnull(desiredfps))
 						clientfps = desiredfps
 						parent.fps = desiredfps

--- a/config/dbconfig.txt
+++ b/config/dbconfig.txt
@@ -3,7 +3,7 @@
 ## administration, and the in game library.
 
 ## Should SQL be enabled? Uncomment to enable
-SQL_ENABLED
+#SQL_ENABLED
 
 ## Server the MySQL database can be found at.
 ## Examples: localhost, 200.135.5.43, www.mysqldb.com, etc.

--- a/config/dbconfig.txt
+++ b/config/dbconfig.txt
@@ -3,7 +3,7 @@
 ## administration, and the in game library.
 
 ## Should SQL be enabled? Uncomment to enable
-#SQL_ENABLED
+SQL_ENABLED
 
 ## Server the MySQL database can be found at.
 ## Examples: localhost, 200.135.5.43, www.mysqldb.com, etc.


### PR DESCRIPTION
## About The Pull Request

Interestingly enough, server "FPS" is the tickrate, and has nothing to do with graphical rendering. Playing with this value has weird side-effects that don't necessarily make sense when that value is treated as equivalent to FPS.

On the other hand, bumping the client FPS to 60 produces incredibly smooth and great looking animations for movement, pickups, attacks, other animations that are not necessarily tied to the tickrate.

To achieve this, when the client FPS is set to 0, which currently ties it to the server tickrate, the default value swaps to 60. Any non-zero value will still be respected, so people who want to retain the 20FPS jank can revert the change without affecting others.

## Why It's Good For The Game

It's a night and day change in quality, making the game feel like it's running distinctly faster.

## Changelog
:cl:
tweak: Weakly decoupled client FPS from server FPS in a way that improves client animation speed, while not affecting the server.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
