### PR TITLE
add colt 1911 ammo design disk to cargo ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -1471,7 +1471,8 @@
 	name = "gelatinous floor"
 	},
 /mob/living/simple_animal/hostile/netherworld{
-	name = "Miss Tiggles"
+	name = "Miss Tiggles",
+	loot = list(/obj/item/disk/design_disk/ammo_1911)
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost)

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -1471,8 +1471,8 @@
 	name = "gelatinous floor"
 	},
 /mob/living/simple_animal/hostile/netherworld{
-	name = "Miss Tiggles",
-	loot = list(/obj/item/disk/design_disk/ammo_1911)
+	name = "Miss Tiggles";
+	loot = list(/obj/item/disk/design_disk/ammo_1911);
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3302,6 +3302,7 @@
 #include "waspstation\code\modules\power\antimatter\control.dm"
 #include "waspstation\code\modules\power\antimatter\shielding.dm"
 #include "waspstation\code\modules\projectiles\ammunition\ballistic\smg.dm"
+#include "waspstation\code\modules\projectiles\boxes_magazines\pistol.dm"
 #include "waspstation\code\modules\projectiles\boxes_magazines\external\smg.dm"
 #include "waspstation\code\modules\projectiles\boxes_magazines\internal\_derringer.dm"
 #include "waspstation\code\modules\projectiles\boxes_magazines\internal\shotgun.dm"

--- a/waspstation/code/modules/projectiles/boxes_magazines/pistol.dm
+++ b/waspstation/code/modules/projectiles/boxes_magazines/pistol.dm
@@ -4,7 +4,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_box/magazine/m45
-	category = list("Security")
+	category = list("Imported")
 
 /obj/item/disk/design_disk/ammo_1911
 	name = "Design Disk - 1911 Magazine"

--- a/waspstation/code/modules/projectiles/boxes_magazines/pistol.dm
+++ b/waspstation/code/modules/projectiles/boxes_magazines/pistol.dm
@@ -9,8 +9,8 @@
 /obj/item/disk/design_disk/ammo_1911
 	name = "Design Disk - 1911 Magazine"
 	desc = "A design disk containing the pattern for the classic 1911's seven round .45ACP magazine."
-	var/ammo_design = /datum/design/ammo/colt_1911_magazine
 
 /obj/item/disk/design_disk/ammo_1911/Initialize()
 	. = ..()
-	blueprints[1] = ammo_design
+	var/datum/design/colt_1911_magazine/M = new
+	blueprints[1] = M

--- a/waspstation/code/modules/projectiles/boxes_magazines/pistol.dm
+++ b/waspstation/code/modules/projectiles/boxes_magazines/pistol.dm
@@ -11,6 +11,6 @@
 	desc = "A design disk containing the pattern for the classic 1911's seven round .45ACP magazine."
 	var/ammo_design = /datum/design/ammo/colt_1911_magazine
 
-/obj/item/disk/design_disk/Initialize()
+/obj/item/disk/design_disk/ammo_1911/Initialize()
 	. = ..()
 	blueprints[1] = ammo_design

--- a/waspstation/code/modules/projectiles/boxes_magazines/pistol.dm
+++ b/waspstation/code/modules/projectiles/boxes_magazines/pistol.dm
@@ -1,0 +1,16 @@
+/datum/design/ammo/colt_1911_magazine
+	name = "Colt 1911 Magazine"
+	id = "ammo_1911"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_box/magazine/m45
+	category = list("Security")
+
+/obj/item/disk/design_disk/ammo_1911
+	name = "Design Disk - 1911 Magazine"
+	desc = "A design disk containing the pattern for the classic 1911's seven round .45ACP magazine."
+	var/ammo_design = /datum/design/ammo/colt_1911_magazine
+
+/obj/item/disk/design_disk/Initialize()
+	. = ..()
+	blueprints[1] = ammo_design

--- a/waspstation/code/modules/projectiles/boxes_magazines/pistol.dm
+++ b/waspstation/code/modules/projectiles/boxes_magazines/pistol.dm
@@ -12,5 +12,5 @@
 
 /obj/item/disk/design_disk/ammo_1911/Initialize()
 	. = ..()
-	var/datum/design/colt_1911_magazine/M = new
+	var/datum/design/ammo/colt_1911_magazine/M = new
 	blueprints[1] = M


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Cotributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

After #439 , 1911 Ammo wasn't obtainable by any method available to the player. This alleviates that in a way that makes the ruin where 1911s come from more worthwhile to clear.

## Why It's Good For The Game

Fudd gun needs its bullets

## Changelog
:cl:
add: A 1911 Ammo Disk for use in an autolathe, in the same ruin that 1911s spawn in.
/:cl:

