### PR TITLE
Ethereal No-Charge Icon Appears when Charge Reaches Zero

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -127,10 +127,13 @@
 /datum/species/ethereal/proc/handle_charge(mob/living/carbon/human/H)
 	brutemod = 1.25
 	switch(get_charge(H))
-		if(ETHEREAL_CHARGE_NONE)
-			H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 3)
+		// Waspstation Begin - Display Ethereal no charge icon
 		if(ETHEREAL_CHARGE_NONE to ETHEREAL_CHARGE_LOWPOWER)
-			H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 2)
+			if(get_charge(H) == ETHEREAL_CHARGE_NONE)
+				H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 3)
+			else
+				H.throw_alert("ethereal_charge", /obj/screen/alert/etherealcharge, 2)
+			// Waspstation End
 			if(H.health > 10.5)
 				apply_damage(0.2, TOX, null, null, H)
 			brutemod = 1.75


### PR DESCRIPTION
## About The Pull Request

The switch statement had a branch for ETHEREAL_CHARGE_NONE that was never called, because the branch for the range ETHEREAL_CHARGE_NONE to ETHEREAL_CHARGE_LOWPOWER had precedence over it.  So I moved the line for displaying the no charge icon into an if statement inside that branch.

## Why It's Good For The Game

Makes it visually obvious that Ethereal charge has reached zero
I want this one logged as part of #304 

## Changelog
:cl:
fix: Ethereal zero charge icon now displays at zero charge
/:cl:
