### PR TITLE
Adds Gas Miners to Atmos on Station Maps

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -25324,10 +25324,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bUV" = (
-/obj/machinery/air_sensor/atmos/nitrous_tank,
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
 "bUW" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -26264,10 +26260,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"bYV" = (
-/obj/machinery/air_sensor/atmos/toxin_tank,
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
 "bYW" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -26876,10 +26868,6 @@
 "ccw" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"ccC" = (
-/obj/machinery/air_sensor/atmos/carbon_tank,
-/turf/open/floor/engine/co2,
-/area/engine/atmos)
 "ccD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -27936,10 +27924,6 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ckU" = (
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "ckV" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
 	dir = 1
@@ -27952,10 +27936,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
-"ckX" = (
-/obj/machinery/air_sensor/atmos/oxygen_tank,
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "ckY" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 1
@@ -27967,10 +27947,6 @@
 	dir = 1
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos)
-"cla" = (
-/obj/machinery/air_sensor/atmos/air_tank,
-/turf/open/floor/engine/air,
 /area/engine/atmos)
 "clb" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
@@ -34049,6 +34025,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"fEA" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/air_sensor/atmos/air_tank,
+/turf/open/floor/engine/air,
+/area/engine/atmos)
 "fES" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -47155,6 +47136,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"ptz" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/air_sensor/atmos/carbon_tank,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "ptM" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood{
@@ -47313,6 +47299,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"pyB" = (
+/obj/machinery/atmospherics/miner/n2o,
+/obj/machinery/air_sensor/atmos/nitrous_tank,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "pyN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47394,6 +47385,11 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"pBv" = (
+/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/air_sensor/atmos/toxin_tank,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "pBY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -50175,11 +50171,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
-"rGK" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/atmos/air,
-/turf/open/floor/engine/air,
-/area/engine/atmos)
 "rHy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -54914,6 +54905,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"vih" = (
+/obj/effect/turf_decal/atmos/air,
+/turf/open/floor/engine/air,
+/area/engine/atmos)
 "viu" = (
 /obj/structure/table,
 /obj/effect/turf_decal/bot,
@@ -55741,6 +55736,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"vNB" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/air_sensor/atmos/oxygen_tank,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
+"vNF" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "vNX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -91704,8 +91709,8 @@ nqT
 old
 aaf
 bQA
-ckU
 pDz
+vNF
 cmU
 bOh
 ccw
@@ -92732,8 +92737,8 @@ jlB
 mnd
 aaf
 bQA
-ckX
 oQb
+vNB
 cmV
 bOh
 cig
@@ -93760,8 +93765,8 @@ uZS
 old
 aaf
 bQA
-cla
-rGK
+vih
+fEA
 cmW
 bOh
 aaa
@@ -95024,19 +95029,19 @@ bzs
 bRK
 bOh
 bPl
-bQB
+uwD
 bRL
 bOh
 bTX
-bUV
+tOZ
 bWd
 bOh
 bXX
-bYV
+moV
 bZL
 bOh
 cbI
-ccC
+tVy
 cdD
 bOh
 cCG
@@ -95281,19 +95286,19 @@ bzs
 bRK
 bOh
 bPk
-uwD
+bQB
 bPm
 bOh
 bTW
-tOZ
+pyB
 bTW
 bOh
 bXW
-moV
+pBv
 bXW
 bOh
 cbH
-tVy
+ptz
 cbH
 bOh
 aaf

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -16350,10 +16350,6 @@
 /obj/effect/turf_decal/atmos/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
-"aXX" = (
-/obj/machinery/air_sensor/atmos/carbon_tank,
-/turf/open/floor/engine/co2,
-/area/engine/atmos)
 "aYg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17507,10 +17503,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bbN" = (
-/obj/machinery/air_sensor/atmos/oxygen_tank,
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "bbO" = (
 /obj/effect/turf_decal/atmos/oxygen,
 /turf/open/floor/engine/o2,
@@ -18355,10 +18347,6 @@
 /area/engine/atmos)
 "bev" = (
 /obj/effect/turf_decal/atmos/plasma,
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
-"bew" = (
-/obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "bey" = (
@@ -19300,10 +19288,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
-"bhv" = (
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2,
 /area/engine/atmos)
 "bhw" = (
 /obj/effect/turf_decal/atmos/nitrogen,
@@ -20428,10 +20412,6 @@
 /area/engine/atmos)
 "bkH" = (
 /obj/effect/turf_decal/atmos/nitrous_oxide,
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
-"bkI" = (
-/obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "bkP" = (
@@ -77231,6 +77211,11 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"eOL" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/air_sensor/atmos/oxygen_tank,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "eOQ" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -87452,6 +87437,11 @@
 	},
 /turf/open/floor/circuit/green,
 /area/engine/atmospherics_engine)
+"imf" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "iml" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmoslock";
@@ -89386,6 +89376,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
+"iSx" = (
+/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/air_sensor/atmos/toxin_tank,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "iST" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -91890,6 +91885,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jHq" = (
+/obj/machinery/atmospherics/miner/n2o,
+/obj/machinery/air_sensor/atmos/nitrous_tank,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "jIc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -126257,6 +126257,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"vJI" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/air_sensor/atmos/carbon_tank,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "vJU" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -154671,19 +154676,19 @@ aFq
 abj
 aRF
 aWu
-aXW
+vJI
 aWt
 aRF
 bcY
-bev
+iSx
 bcX
 aRF
 biU
-bkH
+jHq
 biT
 aRF
 bpO
-kQk
+brU
 btK
 aRF
 qYo
@@ -154928,19 +154933,19 @@ aFr
 aad
 aRF
 aWv
-aXX
+aXW
 aZP
 aRF
 bcZ
-bew
+bev
 bfT
 aRF
 biV
-bkI
+bkH
 bmI
 aRF
 bpP
-brU
+kQk
 btL
 aRF
 qYo
@@ -161865,15 +161870,15 @@ aad
 aad
 aRF
 aTj
-aUZ
+aVa
 aWS
 aRF
 bak
-bbN
+bbO
 bdn
 aRF
 bgf
-bhv
+bhw
 bjn
 aRF
 aMO
@@ -162122,15 +162127,15 @@ aaa
 aad
 aRF
 aTk
-aVa
+aUZ
 aTl
 aRF
 bal
-bbO
+eOL
 bam
 aRF
 bgg
-bhw
+imf
 bgh
 aRF
 aMN

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -77211,11 +77211,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"eOL" = (
-/obj/machinery/atmospherics/miner/oxygen,
-/obj/machinery/air_sensor/atmos/oxygen_tank,
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "eOQ" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -81336,6 +81331,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
+"gic" = (
+/obj/machinery/atmospherics/miner/n2o,
+/obj/machinery/air_sensor/atmos/nitrous_tank,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "gif" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -87437,11 +87437,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/engine/atmospherics_engine)
-"imf" = (
-/obj/machinery/atmospherics/miner/nitrogen,
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "iml" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmoslock";
@@ -89376,11 +89371,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"iSx" = (
-/obj/machinery/atmospherics/miner/toxins,
-/obj/machinery/air_sensor/atmos/toxin_tank,
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
 "iST" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -91885,11 +91875,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"jHq" = (
-/obj/machinery/atmospherics/miner/n2o,
-/obj/machinery/air_sensor/atmos/nitrous_tank,
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
 "jIc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -93245,6 +93230,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"kiH" = (
+/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/air_sensor/atmos/toxin_tank,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "kiI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -106704,6 +106694,11 @@
 	},
 /turf/open/floor/carpet,
 /area/bridge/meeting_room/council)
+"oRT" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "oRV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -112173,6 +112168,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"qLE" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/air_sensor/atmos/carbon_tank,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "qLJ" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 4
@@ -126257,11 +126257,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"vJI" = (
-/obj/machinery/atmospherics/miner/carbon_dioxide,
-/obj/machinery/air_sensor/atmos/carbon_tank,
-/turf/open/floor/engine/co2,
-/area/engine/atmos)
 "vJU" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -129526,6 +129521,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery/room_b)
+"wMj" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/air_sensor/atmos/oxygen_tank,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "wMl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -154676,15 +154676,15 @@ aFq
 abj
 aRF
 aWu
-vJI
+qLE
 aWt
 aRF
 bcY
-iSx
+kiH
 bcX
 aRF
 biU
-jHq
+gic
 biT
 aRF
 bpO
@@ -162131,11 +162131,11 @@ aUZ
 aTl
 aRF
 bal
-eOL
+wMj
 bam
 aRF
 bgg
-imf
+oRT
 bgh
 aRF
 aMN

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -7500,12 +7500,6 @@
 	initial_gas_mix = "n2=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
-"aGV" = (
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2{
-	initial_gas_mix = "n2=1000;TEMP=293.15"
-	},
-/area/engine/atmos)
 "aGW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
 	dir = 4
@@ -7518,12 +7512,6 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 4
 	},
-/turf/open/floor/engine/o2{
-	initial_gas_mix = "o2=1000;TEMP=293.15"
-	},
-/area/engine/atmos)
-"aGY" = (
-/obj/machinery/air_sensor/atmos/oxygen_tank,
 /turf/open/floor/engine/o2{
 	initial_gas_mix = "o2=1000;TEMP=293.15"
 	},
@@ -7560,12 +7548,6 @@
 	initial_gas_mix = "co2=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
-"aHe" = (
-/obj/machinery/air_sensor/atmos/carbon_tank,
-/turf/open/floor/engine/co2{
-	initial_gas_mix = "co2=1000;TEMP=293.15"
-	},
-/area/engine/atmos)
 "aHf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
 	dir = 1
@@ -7582,12 +7564,6 @@
 	initial_gas_mix = "plasma=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
-"aHh" = (
-/obj/machinery/air_sensor/atmos/toxin_tank,
-/turf/open/floor/engine/plasma{
-	initial_gas_mix = "plasma=1000;TEMP=293.15"
-	},
-/area/engine/atmos)
 "aHi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
 	dir = 1
@@ -7600,12 +7576,6 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input{
 	dir = 1
 	},
-/turf/open/floor/engine/n2o{
-	initial_gas_mix = "n2o=1000;TEMP=293.15"
-	},
-/area/engine/atmos)
-"aHk" = (
-/obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o{
 	initial_gas_mix = "n2o=1000;TEMP=293.15"
 	},
@@ -40275,6 +40245,13 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
+"eXT" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/turf/open/floor/engine/n2{
+	initial_gas_mix = "n2=1000;TEMP=293.15"
+	},
+/area/engine/atmos)
 "eYM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -51700,6 +51677,13 @@
 /obj/item/camera,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
+"jiy" = (
+/obj/machinery/atmospherics/miner/n2o,
+/obj/machinery/air_sensor/atmos/nitrous_tank,
+/turf/open/floor/engine/n2o{
+	initial_gas_mix = "n2o=1000;TEMP=293.15"
+	},
+/area/engine/atmos)
 "jjj" = (
 /obj/structure/sign/warning/vacuum/external,
 /obj/effect/spawner/structure/window/reinforced/shutters,
@@ -68997,6 +68981,13 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port/aft)
+"pwm" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/air_sensor/atmos/oxygen_tank,
+/turf/open/floor/engine/o2{
+	initial_gas_mix = "o2=1000;TEMP=293.15"
+	},
+/area/engine/atmos)
 "pwn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -76589,6 +76580,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"snq" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/air_sensor/atmos/carbon_tank,
+/turf/open/floor/engine/co2{
+	initial_gas_mix = "co2=1000;TEMP=293.15"
+	},
+/area/engine/atmos)
 "soo" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -78902,6 +78900,13 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port/fore)
+"tiH" = (
+/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/air_sensor/atmos/toxin_tank,
+/turf/open/floor/engine/plasma{
+	initial_gas_mix = "plasma=1000;TEMP=293.15"
+	},
+/area/engine/atmos)
 "tjj" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer's Office";
@@ -117582,15 +117587,15 @@ bFS
 bFa
 aFM
 aDz
-aDA
+eXT
 aML
 aFM
 aDC
-aDD
+pwm
 aMO
 aFM
 aMY
-dSr
+aHb
 bUQ
 bFP
 cCX
@@ -117839,15 +117844,15 @@ bGG
 bFa
 aFM
 aGU
-aGV
+aDA
 aGW
 aFM
 aGX
-aGY
+aDD
 aGZ
 aFM
 aHa
-aHb
+dSr
 aHc
 jke
 cjm
@@ -120424,8 +120429,8 @@ nyL
 pqO
 nsM
 cBA
-aHe
 aFm
+snq
 aFc
 caK
 acK
@@ -121452,8 +121457,8 @@ nyL
 pqO
 nsM
 cBA
-aHh
 aFn
+tiH
 aFd
 ccT
 acK
@@ -122480,8 +122485,8 @@ vtp
 pqO
 nsM
 cBA
-aHk
 aFo
+jiy
 aFe
 ctr
 acK
@@ -123508,8 +123513,8 @@ xbV
 uqt
 nsM
 cBA
-aHn
 bIw
+aHn
 aFf
 aFM
 aeu

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -24094,10 +24094,6 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bKH" = (
-/obj/machinery/air_sensor/atmos/nitrous_tank,
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
 "bKI" = (
 /obj/effect/turf_decal/atmos/nitrous_oxide,
 /turf/open/floor/engine/n2o,
@@ -25781,10 +25777,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"bQX" = (
-/obj/machinery/air_sensor/atmos/toxin_tank,
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
 "bQY" = (
 /obj/effect/turf_decal/atmos/plasma,
 /turf/open/floor/engine/plasma,
@@ -26918,10 +26910,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bVN" = (
-/obj/machinery/air_sensor/atmos/carbon_tank,
-/turf/open/floor/engine/co2,
-/area/engine/atmos)
 "bVO" = (
 /obj/effect/turf_decal/atmos/carbon_dioxide,
 /turf/open/floor/engine/co2,
@@ -27929,6 +27917,11 @@
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
 /area/medical/medbay/central)
+"bZd" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "bZe" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -30287,10 +30280,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
-"chO" = (
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "chP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
 	dir = 1
@@ -30301,10 +30290,6 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 1
 	},
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
-"chR" = (
-/obj/machinery/air_sensor/atmos/oxygen_tank,
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "chS" = (
@@ -54188,6 +54173,11 @@
 	dir = 5
 	},
 /area/hydroponics)
+"hXl" = (
+/obj/machinery/atmospherics/miner/n2o,
+/obj/machinery/air_sensor/atmos/nitrous_tank,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "hXo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -67581,6 +67571,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
+"oxL" = (
+/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/air_sensor/atmos/toxin_tank,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "oxT" = (
 /obj/structure/chair,
 /obj/machinery/flasher{
@@ -81383,6 +81378,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"vfj" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/air_sensor/atmos/oxygen_tank,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "vfn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -85451,6 +85451,11 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"xfe" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/air_sensor/atmos/carbon_tank,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "xfx" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -129283,8 +129288,8 @@ qtn
 fRk
 aaf
 gJs
-chO
 cjd
+bZd
 ckG
 bAR
 aaf
@@ -130311,8 +130316,8 @@ elb
 uzX
 aaf
 gJs
-chR
 cjg
+vfj
 ckH
 bAR
 aaf
@@ -131339,8 +131344,8 @@ vgE
 uzX
 aaf
 gJs
-chU
 cjj
+chU
 ckJ
 bAR
 aaf
@@ -133117,19 +133122,19 @@ aaa
 aaf
 bAR
 bCB
-bEd
+bpH
 bGa
 bAR
 bJc
-bKH
+bKI
 bMm
 bAR
 bPx
-bQX
+bQY
 bSk
 bAR
 bUI
-bVN
+bVO
 bXr
 bAR
 aaf
@@ -133374,19 +133379,19 @@ aaa
 aaf
 bAR
 bCC
-bpH
+bEd
 bCC
 bAR
 bJd
-bKI
+hXl
 bJd
 bAR
 bPy
-bQY
+oxL
 bPy
 bAR
 bUJ
-bVO
+xfe
 bUJ
 bAR
 aaf

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1460,6 +1460,11 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall,
 /area/security/prison)
+"agB" = (
+/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/air_sensor/atmos/toxin_tank,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "agD" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -26268,10 +26273,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bPZ" = (
-/obj/machinery/air_sensor/atmos/nitrous_tank,
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
 "bQa" = (
 /obj/effect/turf_decal/atmos/nitrous_oxide,
 /turf/open/floor/engine/n2o,
@@ -27194,10 +27195,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
-"bSW" = (
-/obj/machinery/air_sensor/atmos/toxin_tank,
-/turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "bSX" = (
 /obj/effect/turf_decal/atmos/plasma,
@@ -28244,10 +28241,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
 /area/space/nearstation)
-"bWe" = (
-/obj/machinery/air_sensor/atmos/carbon_tank,
-/turf/open/floor/engine/co2,
-/area/engine/atmos)
 "bWf" = (
 /obj/effect/turf_decal/atmos/carbon_dioxide,
 /turf/open/floor/engine/co2,
@@ -29124,10 +29117,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
-"caA" = (
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "caB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
 	dir = 1
@@ -29140,10 +29129,6 @@
 	},
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
-"caD" = (
-/obj/machinery/air_sensor/atmos/oxygen_tank,
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "caE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
 	dir = 1
@@ -29154,10 +29139,6 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
 	dir = 1
 	},
-/turf/open/floor/engine/air,
-/area/engine/atmos)
-"caG" = (
-/obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "caH" = (
@@ -29304,11 +29285,6 @@
 /area/engine/atmos)
 "cbw" = (
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/engine/air,
-/area/engine/atmos)
-"cbx" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/atmos/air,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "cby" = (
@@ -36248,6 +36224,11 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"dWN" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/air_sensor/atmos/carbon_tank,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "dXe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/southleft{
@@ -51857,6 +51838,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
+"oWK" = (
+/obj/effect/turf_decal/atmos/air,
+/turf/open/floor/engine/air,
+/area/engine/atmos)
 "oWN" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -54925,6 +54910,11 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"rAT" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "rBh" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -56209,6 +56199,11 @@
 "suw" = (
 /turf/open/space/basic,
 /area/engine/engineering)
+"svb" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/air_sensor/atmos/air_tank,
+/turf/open/floor/engine/air,
+/area/engine/atmos)
 "svo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
@@ -60060,6 +60055,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"vcr" = (
+/obj/machinery/atmospherics/miner/n2o,
+/obj/machinery/air_sensor/atmos/nitrous_tank,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "vcO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -60890,6 +60890,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"vNF" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/air_sensor/atmos/oxygen_tank,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "vOz" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Chamber Observation";
@@ -100132,8 +100137,8 @@ bXu
 htB
 abI
 bMi
-caA
 cbt
+rAT
 ccm
 bJP
 aaa
@@ -101160,8 +101165,8 @@ bXx
 htB
 abI
 bMi
-caD
 cbv
+vNF
 ccn
 bJP
 aaa
@@ -102188,8 +102193,8 @@ bXB
 crW
 abI
 bMi
-caG
-cbx
+oWK
+svb
 cco
 bJP
 abI
@@ -104483,19 +104488,19 @@ qFy
 abI
 bJP
 bLc
-bMj
+kER
 bNo
 bJP
 bPg
-bPZ
+bQa
 bQP
 bJP
 bSj
-bSW
+bSX
 bTV
 bJP
 bVn
-bWe
+bWf
 bWT
 bJP
 mZE
@@ -104740,19 +104745,19 @@ qFy
 abI
 bJP
 bLd
-kER
+bMj
 bLe
 bJP
 bPh
-bQa
+vcr
 bPh
 bJP
 bSk
-bSX
+agB
 bSk
 bJP
 bVo
-bWf
+dWN
 bVo
 bJP
 aht


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds N2, Oxygen, CO2, Plasma, and N2O gas miners to station maps in atmospherics.

## Why It's Good For The Game

Atmos techs can do atmos things and never run out of gas.

Also a test to see if Monstermos fucks up having miners on station.

## Changelog
:cl:
add: Atmospheric gas collections have been implemented in every station's atmospherics department.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
