### PR TITLE
adds dylovene to vanilla pods

### DIFF
--- a/code/modules/hydroponics/grown/cocoa_vanilla.dm
+++ b/code/modules/hydroponics/grown/cocoa_vanilla.dm
@@ -39,7 +39,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/vanillapod
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/consumable/vanilla = 0.25, /datum/reagent/consumable/nutriment = 0.1)
+	reagents_add = list(/datum/reagent/consumable/vanilla = 0.25, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/medicine/antitoxin = 0.2)
 
 /obj/item/reagent_containers/food/snacks/grown/vanillapod
 	seed = /obj/item/seeds/cocoapod/vanillapod


### PR DESCRIPTION
## About The Pull Request

this adds 20% dylovene production to vanilla .

## Why It's Good For The Game

nwo you can make tricord with plant :)

## Changelog
:cl:
tweak: Dylovene (anti-toxin) can now be found in strains of vanilla plants.
/:cl:

