### PR TITLE
Ethereal Color Change via Multitool

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -40,6 +40,7 @@
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		default_color = "#" + H.dna.features["ethcolor"]
+		// WaspStation Removal -- Multitool Color Change
 		spec_updatehealth(H)
 		RegisterSignal(C, COMSIG_ATOM_EMAG_ACT, .proc/on_emag_act)
 		RegisterSignal(C, COMSIG_ATOM_EMP_ACT, .proc/on_emp_act)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -1,4 +1,4 @@
-#define ETHEREAL_COLORS list("#00ffff", "#ffc0cb", "#9400D3", "#4B0082", "#0000FF", "#00FF00", "#FFFF00", "#FF7F00", "#FF0000")
+#define ETHEREAL_EMAG_COLORS list("#00ffff", "#ffc0cb", "#9400D3", "#4B0082", "#0000FF", "#00FF00", "#FFFF00", "#FF7F00", "#FF0000")        // WaspStation Edit -- Multitool Color Change
 
 /datum/species/ethereal
 	name = "Ethereal"
@@ -29,14 +29,15 @@
 	hair_alpha = 140
 	var/current_color
 	var/EMPeffect = FALSE
-	var/emageffect = FALSE
-	var/r1
-	var/g1
-	var/b1
-	var/static/r2 = 237
-	var/static/g2 = 164
-	var/static/b2 = 149
-	//this is shit but how do i fix it? no clue.
+	// WaspStation Start -- Multitool Color Change
+	var/emag_effect = FALSE
+	var/default_color_red_part
+	var/default_color_green_part
+	var/default_color_blue_part
+	var/static/unhealthy_color_red_part = 237
+	var/static/unhealthy_color_green_part = 164
+	var/static/unhealthy_color_blue_part = 149
+	// WaspStation End
 	loreblurb = "Ethereals are organic humanoid beings with a blood that has strange luminiscent and electrical properties. \
 				Ethereals are barred from most authority roles on Nanotrasen stations and are not protected by the AI's default Asimov laws."
 	var/drain_time = 0 //used to keep ethereals from spam draining power sources
@@ -46,9 +47,7 @@
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		default_color = "#" + H.dna.features["ethcolor"]
-		r1 = GetRedPart(default_color)
-		g1 = GetGreenPart(default_color)
-		b1 = GetBluePart(default_color)
+		set_default_color_parts()                    // WaspStation Edit -- Multitool Color Change
 		spec_updatehealth(H)
 		RegisterSignal(C, COMSIG_ATOM_EMAG_ACT, .proc/on_emag_act)
 		RegisterSignal(C, COMSIG_ATOM_EMP_ACT, .proc/on_emp_act)
@@ -70,15 +69,30 @@
 /datum/species/ethereal/spec_updatehealth(mob/living/carbon/human/H)
 	.=..()
 	if(H.stat != DEAD && !EMPeffect)
-		var/healthpercent = max(H.health, 0) / 100
-		if(!emageffect)
-			current_color = rgb(r2 + ((r1-r2)*healthpercent), g2 + ((g1-g2)*healthpercent), b2 + ((b1-b2)*healthpercent))
-		H.set_light(1 + (2 * healthpercent), 1 + (1 * healthpercent), current_color)
+		// WaspStation Start -- Multitool Color Change
+		var/health_percent = max(H.health, 0) / 100
+		if(!emag_effect)
+			current_color = health_adjusted_color(H, health_percent)
+		H.set_light(1 + (2 * health_percent), 1 + (1 * health_percent), current_color)
 		fixed_mut_color = copytext_char(current_color, 2)
+		// WaspStation End
 	else
 		H.set_light(0)
 		fixed_mut_color = rgb(128,128,128)
 	H.update_body()
+
+// WaspStation Start -- Multitool Color Change
+/datum/species/ethereal/proc/set_default_color_parts()
+	default_color_red_part   = GetRedPart(default_color)
+	default_color_green_part = GetGreenPart(default_color)
+	default_color_blue_part  = GetBluePart(default_color)
+
+/datum/species/ethereal/proc/health_adjusted_color(mob/living/carbon/human/H, health_percent)
+	var/result = rgb(unhealthy_color_red_part   + ((default_color_red_part   - unhealthy_color_red_part)   * health_percent),
+	                 unhealthy_color_green_part + ((default_color_green_part - unhealthy_color_green_part) * health_percent),
+	                 unhealthy_color_blue_part  + ((default_color_blue_part  - unhealthy_color_blue_part)  * health_percent))
+	return result
+// WaspStation End
 
 /datum/species/ethereal/proc/on_emp_act(mob/living/carbon/human/H, severity)
 	EMPeffect = TRUE
@@ -91,9 +105,9 @@
 			addtimer(CALLBACK(src, .proc/stop_emp, H), 20 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE) //We're out for 20 seconds
 
 /datum/species/ethereal/proc/on_emag_act(mob/living/carbon/human/H, mob/user)
-	if(emageffect)
+	if(emag_effect)                              // WaspStation Edit -- Multitool Color Change
 		return
-	emageffect = TRUE
+	emag_effect = TRUE                           // WaspStation Edit -- Multitool Color Change
 	if(user)
 		to_chat(user, "<span class='notice'>You tap [H] on the back with your card.</span>")
 	H.visible_message("<span class='danger'>[H] starts flickering in an array of colors!</span>")
@@ -113,14 +127,14 @@
 
 
 /datum/species/ethereal/proc/handle_emag(mob/living/carbon/human/H)
-	if(!emageffect)
+	if(!emag_effect)                              // WaspStation Edit -- Multitool Color Change
 		return
-	current_color = pick(ETHEREAL_COLORS)
+	current_color = pick(ETHEREAL_EMAG_COLORS)    // WaspStation Edit -- Multitool Color Change
 	spec_updatehealth(H)
 	addtimer(CALLBACK(src, .proc/handle_emag, H), 5) //Call ourselves every 0.5 seconds to change color
 
 /datum/species/ethereal/proc/stop_emag(mob/living/carbon/human/H)
-	emageffect = FALSE
+	emag_effect = FALSE                           // WaspStation Edit -- Multitool Color Change
 	spec_updatehealth(H)
 	H.visible_message("<span class='danger'>[H] stops flickering and goes back to their normal state!</span>")
 
@@ -178,3 +192,33 @@
 	if(istype(stomach))
 		return stomach.crystal_charge
 	return ETHEREAL_CHARGE_NONE
+
+// WaspStation Start -- Multitool Color Change
+/datum/species/ethereal/spec_attacked_by(obj/item/I, mob/living/user, obj/item/bodypart/affecting, intent, mob/living/carbon/human/H)
+	if(istype(I, /obj/item/multitool))
+		if(user.a_intent == INTENT_HARM)
+			. = ..() // multitool beatdown
+			return
+
+		if (emag_effect == TRUE)
+			to_chat(user, "<span class='danger'>The multitool can't get a lock on [H]'s EM frequency</span>")
+			return
+
+		if(user != H)
+			// random color change
+			default_color = GLOB.color_list_ethereal[pick(GLOB.color_list_ethereal)]
+			current_color = default_color
+			set_default_color_parts()
+			spec_updatehealth(H)
+			H.visible_message("<span class='danger'>[H]'s EM frequency is scrambled to a random color.</span>")
+		else
+			// select new color
+			var/new_etherealcolor = input(user, "Choose your ethereal color", "Character Preference") as null|anything in GLOB.color_list_ethereal
+			if(new_etherealcolor)
+				default_color = "#" + GLOB.color_list_ethereal[new_etherealcolor]
+				set_default_color_parts()
+				spec_updatehealth(H)
+				H.visible_message("<span class='notice'>[H] modulates \his EM frequency to [new_etherealcolor].</span>")
+	else
+		. = ..()
+// WaspStation End

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -1,4 +1,4 @@
-#define ETHEREAL_EMAG_COLORS list("#00ffff", "#ffc0cb", "#9400D3", "#4B0082", "#0000FF", "#00FF00", "#FFFF00", "#FF7F00", "#FF0000")        // WaspStation Edit -- Multitool Color Change
+#define ETHEREAL_EMAG_COLORS list("#00ffff", "#ffc0cb", "#9400D3", "#4B0082", "#0000FF", "#00FF00", "#FFFF00", "#FF7F00", "#FF0000") // WaspStation Edit -- Multitool Color Change
 
 /datum/species/ethereal
 	name = "Ethereal"
@@ -29,8 +29,8 @@
 	hair_alpha = 140
 	var/current_color
 	var/EMPeffect = FALSE
-	var/emag_effect = FALSE // WaspStation Edit -- Multitool Color Change
-	// WaspStation Removal -- Multitool Color Change
+	var/emag_effect = FALSE                          // WaspStation Edit -- Multitool Color Change
+	var/static/unhealthy_color = rgb(237, 164, 149)  // WaspStation Edit -- Multitool Color Change
 	loreblurb = "Ethereals are organic humanoid beings with a blood that has strange luminiscent and electrical properties. \
 				Ethereals are barred from most authority roles on Nanotrasen stations and are not protected by the AI's default Asimov laws."
 	var/drain_time = 0 //used to keep ethereals from spam draining power sources
@@ -63,10 +63,9 @@
 	.=..()
 	if(H.stat != DEAD && !EMPeffect)
 		// WaspStation Start -- Multitool Color Change
-		var/health_percent = max(H.health, 0) / 100
 		if(!emag_effect)
-			current_color = health_adjusted_color(H, health_percent, default_color)
-		H.set_light(1 + (2 * health_percent), 1 + (1 * health_percent), current_color)
+			current_color = health_adjusted_color(H, default_color)
+		set_ethereal_light(H, current_color)
 		fixed_mut_color = copytext_char(current_color, 2)
 		// WaspStation End
 	else
@@ -75,8 +74,9 @@
 	H.update_body()
 
 // WaspStation Start -- Multitool Color Change
-/datum/species/ethereal/proc/health_adjusted_color(mob/living/carbon/human/H, health_percent, default_color)
-	var/static/unhealthy_color = rgb(237,164,149)
+/datum/species/ethereal/proc/health_adjusted_color(mob/living/carbon/human/H, default_color)
+	var/health_percent = max(H.health, 0) / 100
+
 	var/static/unhealthy_color_red_part   = GetRedPart(unhealthy_color)
 	var/static/unhealthy_color_green_part = GetGreenPart(unhealthy_color)
 	var/static/unhealthy_color_blue_part  = GetBluePart(unhealthy_color)
@@ -89,6 +89,14 @@
 	                 unhealthy_color_green_part + ((default_color_green_part - unhealthy_color_green_part) * health_percent),
 	                 unhealthy_color_blue_part  + ((default_color_blue_part  - unhealthy_color_blue_part)  * health_percent))
 	return result
+
+/datum/species/ethereal/proc/set_ethereal_light(mob/living/carbon/human/H, current_color)
+	var/health_percent = max(H.health, 0) / 100
+
+	var/light_range = 1 + (2 * health_percent)
+	var/light_power = 1 + (1 * health_percent)
+
+	H.set_light(light_range, light_power, current_color)
 // WaspStation End
 
 /datum/species/ethereal/proc/on_emp_act(mob/living/carbon/human/H, severity)
@@ -201,11 +209,10 @@
 			to_chat(user, "<span class='danger'>The multitool can't get a lock on [H]'s EM frequency</span>")
 			return
 
-		var/health_percent = max(H.health, 0) / 100
 		if(user != H)
 			// random color change
-			default_color = GLOB.color_list_ethereal[pick(GLOB.color_list_ethereal)]
-			current_color = health_adjusted_color(H, health_percent, default_color)
+			default_color = "#" + GLOB.color_list_ethereal[pick(GLOB.color_list_ethereal)]
+			current_color = health_adjusted_color(H, default_color)
 			spec_updatehealth(H)
 			H.visible_message("<span class='danger'>[H]'s EM frequency is scrambled to a random color.</span>")
 		else
@@ -213,7 +220,7 @@
 			var/new_etherealcolor = input(user, "Choose your ethereal color", "Character Preference") as null|anything in GLOB.color_list_ethereal
 			if(new_etherealcolor)
 				default_color = "#" + GLOB.color_list_ethereal[new_etherealcolor]
-				current_color = health_adjusted_color(H, health_percent, default_color)
+				current_color = health_adjusted_color(H, default_color)
 				spec_updatehealth(H)
 				H.visible_message("<span class='notice'>[H] modulates \his EM frequency to [new_etherealcolor].</span>")
 	else

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -74,6 +74,7 @@
 		fixed_mut_color = rgb(128,128,128)
 	H.update_body()
 
+// WaspStation Start -- Multitool Color Change
 /datum/species/ethereal/proc/health_adjusted_color(mob/living/carbon/human/H, health_percent, default_color)
 	var/static/unhealthy_color = rgb(237,164,149)
 	var/static/unhealthy_color_red_part   = GetRedPart(unhealthy_color)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -29,15 +29,8 @@
 	hair_alpha = 140
 	var/current_color
 	var/EMPeffect = FALSE
-	// WaspStation Start -- Multitool Color Change
-	var/emag_effect = FALSE
-	var/default_color_red_part
-	var/default_color_green_part
-	var/default_color_blue_part
-	var/static/unhealthy_color_red_part = 237
-	var/static/unhealthy_color_green_part = 164
-	var/static/unhealthy_color_blue_part = 149
-	// WaspStation End
+	var/emag_effect = FALSE // WaspStation Edit -- Multitool Color Change
+	// WaspStation Removal -- Multitool Color Change
 	loreblurb = "Ethereals are organic humanoid beings with a blood that has strange luminiscent and electrical properties. \
 				Ethereals are barred from most authority roles on Nanotrasen stations and are not protected by the AI's default Asimov laws."
 	var/drain_time = 0 //used to keep ethereals from spam draining power sources
@@ -47,7 +40,6 @@
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		default_color = "#" + H.dna.features["ethcolor"]
-		set_default_color_parts()                    // WaspStation Edit -- Multitool Color Change
 		spec_updatehealth(H)
 		RegisterSignal(C, COMSIG_ATOM_EMAG_ACT, .proc/on_emag_act)
 		RegisterSignal(C, COMSIG_ATOM_EMP_ACT, .proc/on_emp_act)
@@ -72,7 +64,7 @@
 		// WaspStation Start -- Multitool Color Change
 		var/health_percent = max(H.health, 0) / 100
 		if(!emag_effect)
-			current_color = health_adjusted_color(H, health_percent)
+			current_color = health_adjusted_color(H, health_percent, default_color)
 		H.set_light(1 + (2 * health_percent), 1 + (1 * health_percent), current_color)
 		fixed_mut_color = copytext_char(current_color, 2)
 		// WaspStation End
@@ -81,13 +73,16 @@
 		fixed_mut_color = rgb(128,128,128)
 	H.update_body()
 
-// WaspStation Start -- Multitool Color Change
-/datum/species/ethereal/proc/set_default_color_parts()
-	default_color_red_part   = GetRedPart(default_color)
-	default_color_green_part = GetGreenPart(default_color)
-	default_color_blue_part  = GetBluePart(default_color)
+/datum/species/ethereal/proc/health_adjusted_color(mob/living/carbon/human/H, health_percent, default_color)
+	var/static/unhealthy_color = rgb(237,164,149)
+	var/static/unhealthy_color_red_part   = GetRedPart(unhealthy_color)
+	var/static/unhealthy_color_green_part = GetGreenPart(unhealthy_color)
+	var/static/unhealthy_color_blue_part  = GetBluePart(unhealthy_color)
 
-/datum/species/ethereal/proc/health_adjusted_color(mob/living/carbon/human/H, health_percent)
+	var/default_color_red_part   = GetRedPart(default_color)
+	var/default_color_green_part = GetGreenPart(default_color)
+	var/default_color_blue_part  = GetBluePart(default_color)
+
 	var/result = rgb(unhealthy_color_red_part   + ((default_color_red_part   - unhealthy_color_red_part)   * health_percent),
 	                 unhealthy_color_green_part + ((default_color_green_part - unhealthy_color_green_part) * health_percent),
 	                 unhealthy_color_blue_part  + ((default_color_blue_part  - unhealthy_color_blue_part)  * health_percent))
@@ -204,11 +199,11 @@
 			to_chat(user, "<span class='danger'>The multitool can't get a lock on [H]'s EM frequency</span>")
 			return
 
+		var/health_percent = max(H.health, 0) / 100
 		if(user != H)
 			// random color change
 			default_color = GLOB.color_list_ethereal[pick(GLOB.color_list_ethereal)]
-			current_color = default_color
-			set_default_color_parts()
+			current_color = health_adjusted_color(H, health_percent, default_color)
 			spec_updatehealth(H)
 			H.visible_message("<span class='danger'>[H]'s EM frequency is scrambled to a random color.</span>")
 		else
@@ -216,7 +211,7 @@
 			var/new_etherealcolor = input(user, "Choose your ethereal color", "Character Preference") as null|anything in GLOB.color_list_ethereal
 			if(new_etherealcolor)
 				default_color = "#" + GLOB.color_list_ethereal[new_etherealcolor]
-				set_default_color_parts()
+				current_color = health_adjusted_color(H, health_percent, default_color)
 				spec_updatehealth(H)
 				H.visible_message("<span class='notice'>[H] modulates \his EM frequency to [new_etherealcolor].</span>")
 	else


### PR DESCRIPTION
## About The Pull Request

An Ethereal can use a multitool to select their color the same way they would on the preferences screen.
Another player can use a multitool on an Ethereal to randomize their color.
Color changes will not be applied while an Ethereal is emagged.

This one was surprisingly tricky.  I included some refactoring to help maintain my sanity.

Rename Variable:
ETHEREAL_COLORS -> ETHEREAL_EMAG_COLORS
emageffect -> emag_effect
r1 -> default_color_red_part
g1 -> default_color_green_part
b1 -> default_color_blue_part
r2 -> unhealthy_color_red_part
g2 -> unhealthy_color_green_part
b2 -> unhealthy_color_blue_part
healthpercent -> health_percent

Extract Function: 
health_adjusted_color()
set_ethereal_light()

Known Issue:
While working on this, I found an existing bug.  When Ethereals change colors, their hair color only sometimes refreshes.  I have found no pattern for when it does or does not refresh.  It can be force refreshed by equipping or removing something from the head slot.
![image](https://user-images.githubusercontent.com/7697956/97514726-70cbf600-195d-11eb-8c20-d5bd5fd2d299.png)

I confirmed this was pre-existing by going on the live server, changing my color to white in character setup, and beating myself with a crowbar.  My body color turned red, but not my hair color.  I plan to address this separately in the future.
![image](https://user-images.githubusercontent.com/7697956/97513763-1cc01200-195b-11eb-8607-2befaabd1924.png)

## Why It's Good For The Game

Requested in Issue #304 

## Changelog
:cl:
add: Ethereals can select their colors with a multitool
add: Anyone can randomize an Ethereal's color with a multitool
/:cl:
