### PR TITLE
Webedit Spritercode Time: Bag rebalancing, Welding protection fits in your toolbelt

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -18,7 +18,7 @@
 //  Generic non-item
 /obj/item/storage/bag
 	slot_flags = ITEM_SLOT_BELT
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/storage/bag/ComponentInitialize()
 	. = ..()
@@ -104,7 +104,6 @@
 	icon_state = "minebag"
 	//WaspStation end
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
-	w_class = WEIGHT_CLASS_NORMAL
 	component_type = /datum/component/storage/concrete/stack
 	var/spam_protection = FALSE //If this is TRUE, the holder won't receive any messages when they fail to pick up ore through crossing it
 	var/mob/listeningTo
@@ -377,7 +376,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_combined_w_class = 200
-	STR.max_items = 50
+	STR.max_items = 25
 	STR.insert_preposition = "in"
 	STR.set_holdable(list(
 		/obj/item/reagent_containers/pill,
@@ -407,7 +406,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_combined_w_class = 200
-	STR.max_items = 25
+	STR.max_items = 20
 	STR.insert_preposition = "in"
 	STR.set_holdable(list(
 		/obj/item/slime_extract,

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -192,7 +192,7 @@
 	//WaspStation Begin - Better bag sprites
 	icon = 'waspstation/icons/obj/bags.dmi'
 	icon_state = "plantbag"
-	w_class = WEIGHT_CLASS_TINY
+	w_class = WEIGHT_CLASS_NORMAL
 	//WaspStation end
 	resistance_flags = FLAMMABLE
 
@@ -200,7 +200,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.max_combined_w_class = 100
+	STR.max_combined_w_class = 50
 	STR.max_items = 100
 	STR.set_holdable(list(
 		/obj/item/reagent_containers/food/snacks/grown,

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -376,7 +376,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_combined_w_class = 200
-	STR.max_items = 25
+	STR.max_items = 30
 	STR.insert_preposition = "in"
 	STR.set_holdable(list(
 		/obj/item/reagent_containers/pill,

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -193,13 +193,13 @@
 	//WaspStation Begin - Better bag sprites
 	icon = 'waspstation/icons/obj/bags.dmi'
 	icon_state = "plantbag"
-	w_class = WEIGHT_CLASS_NORMAL
 	//WaspStation end
 	resistance_flags = FLAMMABLE
 
 /obj/item/storage/bag/plants/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = 50
 	STR.max_items = 100
 	STR.set_holdable(list(

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -34,6 +34,7 @@
 /obj/item/storage/bag/trash
 	name = "trash bag"
 	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!"
+	w_class = WEIGHT_CLASS_BULKY
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "trashbag"
 	item_state = "trashbag"

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -200,7 +200,6 @@
 /obj/item/storage/bag/plants/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = 50
 	STR.max_items = 100
 	STR.set_holdable(list(

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -64,7 +64,10 @@
 		/obj/item/construction/rcd,
 		/obj/item/pipe_dispenser,
 		/obj/item/inducer,
-		/obj/item/plunger
+		/obj/item/plunger,
+		/obj/item/clothing/glasses/welding, //wasp edit: ok mald sure I'll add the welding stuff to the. ok. 
+		/obj/item/clothing/mask/gas/welding,
+		/obj/item/clothing/head/welding //wasp end
 		))
 
 /obj/item/storage/belt/utility/chief

--- a/waspstation/code/game/objects/items/storage/bags.dm
+++ b/waspstation/code/game/objects/items/storage/bags.dm
@@ -3,18 +3,19 @@
 	icon = 'waspstation/icons/obj/bags.dmi'
 	icon_state = "medbag"
 	desc = "A bag for storing syringes, sutures, ointments, and pills."
-	w_class = WEIGHT_CLASS_TINY
+	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FLAMMABLE
 
 /obj/item/storage/bag/medical/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_combined_w_class = 200
-	STR.max_items = 20
+	STR.max_items = 15
 	STR.insert_preposition = "in"
 	STR.set_holdable(list(
 		/obj/item/reagent_containers/pill,
 		/obj/item/reagent_containers/medigel,
 		/obj/item/reagent_containers/syringe,
-		/obj/item/stack/medical
+		/obj/item/stack/medical,
+		/obj/item/reagent_containers/chem_pack //IV bags of blood and such. I don't know why you're carrying them around, but you never know!
 		))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

in short, this makes Most bags normal sized rather than bulky/tiny/whatever size they were, while bonking the holding capacity on certain bags, namely the chemistry, bio, plant and medicine bags. All numbers are negotiable.

## Why It's Good For The Game

While I have since warmed up to the initial bag nerf on TG because some of the things you could do were frankly ridiculous, I do believe some bags were caught in the crossfire that did not deserve to. For instance, the construction bag could *only* fit on your belt, meaning you had to deal with it and put your toolbelt in your bag while you carried around 40-something tesla coil boards in your construction bag.

On the flipside, some bags remained too powerful due to us partially reverting the nerf. For instance, the medicine bag could hold *three medkits* worth of medicine inside of it, and was tiny sized. 

at the end of the day i just want to be able to put construction bags inside of my satchel again

## Changelog
:cl:
balance: specialist bags are normal sized again
/:cl:
