### PR TITLE
Finally, a variable for the text from dry firing! (blowpipe text and sound tweak too)

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -23,7 +23,7 @@
 	var/vary_fire_sound = TRUE
 	var/fire_sound_volume = 50
 	var/dry_fire_sound = 'sound/weapons/gun/general/dry_fire.ogg'
-	var/dry_fire_text = "click"				//change this on non-gun things
+	var/dry_fire_text = "click"				//change this on non-gun things		Wasp Edit - Dry firing
 	var/suppressed = null					//whether or not a message is displayed when fired
 	var/can_suppress = FALSE
 	var/suppressed_sound = 'sound/weapons/gun/general/heavy_shot_suppressed.ogg'

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -147,7 +147,7 @@
 	return TRUE
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
-	to_chat(user, "<span class='danger'>*[dry_fire_text]*</span>")
+	to_chat(user, "<span class='danger'>*[dry_fire_text]*</span>")		// Wasp Edit - Dry firing
 	playsound(src, dry_fire_sound, 30, TRUE)
 
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -23,6 +23,7 @@
 	var/vary_fire_sound = TRUE
 	var/fire_sound_volume = 50
 	var/dry_fire_sound = 'sound/weapons/gun/general/dry_fire.ogg'
+	var/dry_fire_text = "click"				//change this on non-gun things
 	var/suppressed = null					//whether or not a message is displayed when fired
 	var/can_suppress = FALSE
 	var/suppressed_sound = 'sound/weapons/gun/general/heavy_shot_suppressed.ogg'
@@ -146,7 +147,7 @@
 	return TRUE
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
-	to_chat(user, "<span class='danger'>*click*</span>")
+	to_chat(user, "<span class='danger'>*[dry_fire_text]*</span>")
 	playsound(src, dry_fire_sound, 30, TRUE)
 
 

--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -116,6 +116,8 @@
 	icon_state = "blowgun"
 	item_state = "blowgun"
 	fire_sound = 'sound/items/syringeproj.ogg'
+	dry_fire_sound = null //dont got a trigger, no dry fire sound
+	dry_fire_text = "pshoo" //heehee pshoo
 
 /obj/item/gun/syringe/blowgun/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	visible_message("<span class='danger'>[user] starts aiming with a blowgun!</span>")

--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -116,8 +116,8 @@
 	icon_state = "blowgun"
 	item_state = "blowgun"
 	fire_sound = 'sound/items/syringeproj.ogg'
-	dry_fire_sound = null //dont got a trigger, no dry fire sound
-	dry_fire_text = "pshoo" //heehee pshoo
+	dry_fire_sound = null //dont got a trigger, no dry fire sound	Wasp Edit - Dry firing
+	dry_fire_text = "pshoo" //heehee pshoo		Wasp Edit - Dry firing
 
 /obj/item/gun/syringe/blowgun/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	visible_message("<span class='danger'>[user] starts aiming with a blowgun!</span>")


### PR DESCRIPTION

## About The Pull Request
makes it so you have a cool custom variable for the text displayed for dry firing, and makes the blowgun not make a gun-clicking noise and go *click*. Instead its silent and goes *pshoo*


## Why It's Good For The Game
now the blowgun is less stupid. also now anything you want can have any custom dry firing text. good for adding non-trigger projectile weapons.


## Changelog
:cl:
tweak: blowpipe no longer makes a phantom trigger click sound when empty
refactor: custom dry fire text given to the masses
/:cl:

