### PR TITLE
Only natural-ish haircolors are generated randomly

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(markup_regex, list("/"  = new /regex("((\\W|^)_)(\[^_\]*)(_(\\W
 	for(var/tag in (GLOB.markup_tags - ignore))
 		markup = GLOB.markup_regex[tag]
 		message = markup.Replace_char(message, "$2[GLOB.markup_tags[tag][1]]$3[GLOB.markup_tags[tag][2]]$5")
-	
+
 	return message
 //End Waspstation edit - Chat markup
 
@@ -357,6 +357,12 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 
 /proc/random_color()
 	return random_string(6, GLOB.hex_characters)
+
+/proc/random_short_color_natural()	//For use in natural haircolors.
+	var red = num2text(rand(0,255), 1, 16)
+	var green = num2text(rand(0,128), 1, 16)	//Conversion to hex
+	var blue = "00"
+	return red + green + blue
 
 //merges non-null characters (3rd argument) from "from" into "into". Returns result
 //e.g. into = "Hello World"

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -19,7 +19,7 @@
 	H.skin_tone = random_skin_tone()
 	H.hairstyle = random_hairstyle(H.gender)
 	H.facial_hairstyle = random_facial_hairstyle(H.gender)
-	H.hair_color = random_short_color()
+	H.hair_color = random_short_color_natural()
 	H.facial_hair_color = H.hair_color
 	H.eye_color = random_eye_color()
 	H.dna.blood_type = random_blood_type()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simply adds a new proc that returns a RGB value between 0x00 0x00 0x00 and 0xFF 0x80 0x00
Applies this proc to the create_mob proc, which is used for ghost role spawners and generally spawned humans.
This does not alter nonhuman species or character creation in the creation panel at all.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less terrible hodge-podge skin-hair combinations that are horrible to look at from ghost roles and random spawns.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Randomly generated characters now have less neon colored hairs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
