### PR TITLE
Wack BSMs with the nerf bat.

### DIFF
--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -53,7 +53,7 @@
 		if(SM.rating > 3)
 			minable_ores |= tier4_ores
 	for(var/obj/item/stock_parts/micro_laser/ML in component_parts)
-		mining_rate = 10 ** (ML.rating)
+		mining_rate = 10 ** (ML.rating > 3 ? ML.rating - 2 : sqrt(ML.rating))
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		M_C += 12 * sqrt(M.rating) + 8
 	mining_chance = M_C

--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -53,7 +53,7 @@
 		if(SM.rating > 3)
 			minable_ores |= tier4_ores
 	for(var/obj/item/stock_parts/micro_laser/ML in component_parts)
-		mining_rate = 10 ** (ML.rating > 3 ? ML.rating - 2 : sqrt(ML.rating))
+		mining_rate = 10 ** sqrt(ML.rating)
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		M_C += 12 * sqrt(M.rating) + 8
 	mining_chance = M_C

--- a/waspstation/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/waspstation/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -33,7 +33,7 @@
 		/obj/item/stock_parts/micro_laser = 1,
 		/obj/item/stock_parts/manipulator = 3,
 		/obj/item/stock_parts/scanning_module = 1,
-		/obj/item/stack/ore/bluespace_crystal = 3)
+		/obj/item/stack/ore/bluespace_crystal = 5)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/sleeper

--- a/waspstation/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/waspstation/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -29,11 +29,11 @@
 	name = "Bluespace Miner (Machine Board)"
 	build_path = /obj/machinery/power/bluespace_miner
 	req_components = list(
-		/obj/item/stock_parts/matter_bin = 10,
-		/obj/item/stock_parts/micro_laser = 5,
-		/obj/item/stock_parts/manipulator = 10,
-		/obj/item/stock_parts/scanning_module = 3,
-		/obj/item/stack/ore/bluespace_crystal = 5)
+		/obj/item/stock_parts/matter_bin = 3,
+		/obj/item/stock_parts/micro_laser = 1,
+		/obj/item/stock_parts/manipulator = 3,
+		/obj/item/stock_parts/scanning_module = 1,
+		/obj/item/stack/ore/bluespace_crystal = 3)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/sleeper

--- a/waspstation/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/waspstation/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -29,11 +29,11 @@
 	name = "Bluespace Miner (Machine Board)"
 	build_path = /obj/machinery/power/bluespace_miner
 	req_components = list(
-		/obj/item/stock_parts/matter_bin = 3,
-		/obj/item/stock_parts/micro_laser = 1,
-		/obj/item/stock_parts/manipulator = 3,
-		/obj/item/stock_parts/scanning_module = 1,
-		/obj/item/stack/ore/bluespace_crystal = 3)
+		/obj/item/stock_parts/matter_bin = 10,
+		/obj/item/stock_parts/micro_laser = 5,
+		/obj/item/stock_parts/manipulator = 10,
+		/obj/item/stock_parts/scanning_module = 3,
+		/obj/item/stack/ore/bluespace_crystal = 5)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/sleeper


### PR DESCRIPTION
## About The Pull Request

Reduces BSM Mining rate to the following values based on laser rating:
```
Tier 1: 10 ^ 1
Tier 2: 10 ^ sqrt(2)
Tier 3: 10 ^ sqrt(3)
Tier 4: 10 ^ 2
```
Also adjusts the parts required for BSM construction as follows:
```
Bluespace Crystal 3 -> 5
```

## Why It's Good For The Game

Makes the curve of BSM material production less aggressively high to offset the way mining chance scales with manipulators.

Couple this with the increase in parts requirements and it should make it harder to hit the material production levels seen with current T4 BSMs (3x T4s will make all the material a station will ever need right now)

I don't really want to do this but it's really just more numerical nerfbats until #320 is finished (👀 @AsciiSquid )

## Changelog
:cl:
balance:  Adjust BSM material generation rates
balance:  Increase bluespace crystal requirements for BSMs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
