### PR TITLE
Allow all players to see how many are ready at roundstart.

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -60,8 +60,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 		. += "Time To Start: SOON"
 
 	. += "Players: [SSticker.totalPlayers]"
-	if(client.holder)
-		. += "Players Ready: [SSticker.totalPlayersReady]"
+	. += "Players Ready: [SSticker.totalPlayersReady]"
 
 /mob/dead/proc/server_hop()
 	set category = "OOC"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title.

## Why It's Good For The Game

It probably isn't but it's worth seeing if it improves/degrades player counts at roundstart, if at all.

## Changelog
:cl:
tweak: All players can now see how many players are readied at roundstart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
