### PR TITLE
Scale Up Ethereal Charge

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -194,13 +194,16 @@
 #define NUTRITION_LEVEL_ALMOST_FULL 535
 
 //Charge levels for Ethereals
-#define ETHEREAL_CHARGE_NONE 0
-#define ETHEREAL_CHARGE_LOWPOWER 20
-#define ETHEREAL_CHARGE_NORMAL 50
-#define ETHEREAL_CHARGE_ALMOSTFULL 75
-#define ETHEREAL_CHARGE_FULL 100
-#define ETHEREAL_CHARGE_OVERLOAD 125
-#define ETHEREAL_CHARGE_DANGEROUS 150
+// Waspstation Begin -- Ethereal Charge Scaling
+#define ETHEREAL_CHARGE_SCALING_MULTIPLIER 20
+#define ETHEREAL_CHARGE_NONE       (  0 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+#define ETHEREAL_CHARGE_LOWPOWER   ( 20 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+#define ETHEREAL_CHARGE_NORMAL     ( 50 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+#define ETHEREAL_CHARGE_ALMOSTFULL ( 75 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+#define ETHEREAL_CHARGE_FULL       (100 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+#define ETHEREAL_CHARGE_OVERLOAD   (125 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+#define ETHEREAL_CHARGE_DANGEROUS  (150 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+// Waspstation End
 
 //Slime evolution threshold. Controls how fast slimes can split/grow
 #define SLIME_EVOLUTION_THRESHOLD 10
@@ -305,7 +308,7 @@
 #define DOOR_CRUSH_DAMAGE	15	//the amount of damage that airlocks deal when they crush you
 
 #define	HUNGER_FACTOR		0.1	//factor at which mob nutrition decreases
-#define	ETHEREAL_CHARGE_FACTOR	0.05 //factor at which ethereal's charge decreases
+#define	ETHEREAL_CHARGE_FACTOR (0.05 * ETHEREAL_CHARGE_SCALING_MULTIPLIER) //factor at which ethereal's charge decreases   // Waspstation Edit -- Ethereal Charge Scaling
 #define	REAGENTS_METABOLISM 0.4	//How many units of reagent are consumed per tick, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4)	// By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -88,7 +88,7 @@
 			if(istype(eth_species))
 				var/obj/item/organ/stomach/ethereal/stomach = src.getorganslot(ORGAN_SLOT_STOMACH)
 				if(istype(stomach))
-					. += "Crystal Charge: [round(stomach.crystal_charge, 0.1)]"
+					. += "Crystal Charge: [round((stomach.crystal_charge / ETHEREAL_CHARGE_SCALING_MULTIPLIER), 0.1)]%"
 		// WaspStation End
 
 	//NINJACODE

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -196,9 +196,9 @@
 		var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 		playsound(H, 'sound/magic/lightningshock.ogg', 100, TRUE, extrarange = 5)
 		H.cut_overlay(overcharge)
-		tesla_zap(H, 2, stomach.crystal_charge*50, ZAP_OBJ_DAMAGE | ZAP_ALLOW_DUPLICATES)
+		tesla_zap(H, 2, (stomach.crystal_charge / ETHEREAL_CHARGE_SCALING_MULTIPLIER) * 50, ZAP_OBJ_DAMAGE | ZAP_ALLOW_DUPLICATES)       // Waspstation Edit -- Ethereal Charge Scaling
 		if(istype(stomach))
-			stomach.adjust_charge(100 - stomach.crystal_charge)
+			stomach.adjust_charge(ETHEREAL_CHARGE_FULL - stomach.crystal_charge)     // Waspstation Edit -- Ethereal Charge Scaling
 		to_chat(H, "<span class='warning'>You violently discharge energy!</span>")
 		H.visible_message("<span class='danger'>[H] violently discharges energy!</span>")
 		if(prob(10)) //chance of developing heart disease to dissuade overcharging oneself

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -38,6 +38,11 @@
 #define APC_CHARGING 1
 #define APC_FULLY_CHARGED 2
 
+// Waspstation Begin -- Ethereal Charge Scaling
+#define APC_DRAIN_TIME 75
+#define APC_POWER_GAIN (10 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+// Waspstation End
+
 // the Area Power Controller (APC), formerly Power Distribution Unit (PDU)
 // one per area, needs wire connection to power network through a terminal
 
@@ -810,51 +815,54 @@
 	if(.)
 		return
 
+	// Waspstation Begin -- Ethereal Charge Scaling
 	if(isethereal(user))
 		var/mob/living/carbon/human/H = user
 		var/datum/species/ethereal/E = H.dna.species
+		var/charge_limit = ETHEREAL_CHARGE_DANGEROUS - APC_POWER_GAIN
 		if((H.a_intent == INTENT_HARM) && (E.drain_time < world.time))
-			if(cell.charge <= (cell.maxcharge / 2)) // if charge is under 50% you shouldnt drain it
-				to_chat(H, "<span class='warning'>The APC doesn't have much power, you probably shouldn't drain any.</span>")
+			if(cell.charge <= (cell.maxcharge / 2)) // ethereals can't drain APCs under half charge, this is so that they are forced to look to alternative power sources if the station is running low
+				to_chat(H, "<span class='warning'>The APC's syphon safeties prevent you from draining power!</span>")
 				return
 			var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
-			if(stomach.crystal_charge > 145)
+			if(stomach.crystal_charge > charge_limit)
 				to_chat(H, "<span class='warning'>Your charge is full!</span>")
 				return
-			E.drain_time = world.time + 75
+			E.drain_time = world.time + APC_DRAIN_TIME
 			to_chat(H, "<span class='notice'>You start channeling some power through the APC into your body.</span>")
-			while(do_after(user, 75, target = src)) //Wasp edit
-				E.drain_time = world.time + 75 //Wasp edit
-				if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > 145))
+			while(do_after(user, APC_DRAIN_TIME, target = src)) //Wasp edit
+				E.drain_time = world.time + APC_DRAIN_TIME //Wasp edit
+				if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > charge_limit))
 					return
 				if(istype(stomach))
 					to_chat(H, "<span class='notice'>You receive some charge from the APC.</span>")
-					stomach.adjust_charge(10)
-					cell.charge -= 10
+					stomach.adjust_charge(APC_POWER_GAIN)
+					cell.charge -= APC_POWER_GAIN
 				else
 					to_chat(H, "<span class='warning'>You can't receive charge from the APC!</span>")
 			return
 		if((H.a_intent == INTENT_GRAB) && (E.drain_time < world.time))
-			if(cell.charge == cell.maxcharge)
+			if(cell.charge >= cell.maxcharge - APC_POWER_GAIN)
 				to_chat(H, "<span class='warning'>The APC is full!</span>")
 				return
 			var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
-			if(stomach.crystal_charge < 10)
+			if(stomach.crystal_charge < APC_POWER_GAIN)
 				to_chat(H, "<span class='warning'>Your charge is too low!</span>")
 				return
-			E.drain_time = world.time + 75
+			E.drain_time = world.time + APC_DRAIN_TIME
 			to_chat(H, "<span class='notice'>You start channeling power through your body into the APC.</span>")
-			while(do_after(user, 75, target = src)) //Wasp edit
-				E.drain_time = world.time + 75 //Wasp edit
-				if(cell.charge == cell.maxcharge || (stomach.crystal_charge < 10))
+			while(do_after(user, APC_DRAIN_TIME, target = src)) //Wasp edit
+				E.drain_time = world.time + APC_DRAIN_TIME //Wasp edit
+				if(cell.charge >= (cell.maxcharge - APC_POWER_GAIN) || (stomach.crystal_charge < APC_POWER_GAIN))
 					return
 				if(istype(stomach))
 					to_chat(H, "<span class='notice'>You transfer some power to the APC.</span>")
-					stomach.adjust_charge(-10)
-					cell.charge += 10
+					stomach.adjust_charge(-APC_POWER_GAIN)
+					cell.charge += APC_POWER_GAIN
 				else
 					to_chat(H, "<span class='warning'>You can't transfer power to the APC!</span>")
 			return
+	// Waspstation End
 
 	if(opened && (!issilicon(user)))
 		if(cell)
@@ -1529,6 +1537,11 @@
 #undef APC_NOT_CHARGING
 #undef APC_CHARGING
 #undef APC_FULLY_CHARGED
+
+// Waspstation Begin -- Ethereal Charge Scaling
+#undef APC_DRAIN_TIME
+#undef APC_POWER_GAIN
+// Waspstation End
 
 //update_overlay
 #undef APC_UPOVERLAY_CHARGEING0

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -1,3 +1,9 @@
+// Waspstation Begin -- Ethereal Charge Scaling
+#define CELL_DRAIN_TIME 35
+#define CELL_POWER_GAIN  (3    * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+#define CELL_POWER_DRAIN (37.5 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+// Waspstation End
+
 /obj/item/stock_parts/cell
 	name = "power cell"
 	desc = "A rechargeable electrochemical power cell."
@@ -148,32 +154,34 @@
 				if(prob(25))
 					corrupt()
 
+// Waspstation Begin -- Ethereal Charge Scaling
 /obj/item/stock_parts/cell/attack_self(mob/user)
 	if(isethereal(user))
 		var/mob/living/carbon/human/H = user
 		var/datum/species/ethereal/E = H.dna.species
+		var/charge_limit = ETHEREAL_CHARGE_DANGEROUS - CELL_POWER_GAIN
 		if(E.drain_time > world.time)
 			return
-		if(charge < 100)
-			to_chat(H, "<span class='warning'>The [src] doesn't have enough power!</span>")
+		if(charge < CELL_POWER_DRAIN)
+			to_chat(H, "<span class='warning'>[src] doesn't have enough power!</span>")
 			return
 		var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
-		if(stomach.crystal_charge > 146)
+		if(stomach.crystal_charge > charge_limit)
 			to_chat(H, "<span class='warning'>Your charge is full!</span>")
 			return
-		to_chat(H, "<span class='notice'>You clumsily channel power through the [src] and into your body, wasting some in the process.</span>")
-		E.drain_time = world.time + 20
-		if(do_after(user, 20, target = src))
-			if((charge < 100) || (stomach.crystal_charge > 146))
+		to_chat(H, "<span class='notice'>You begin clumsily channeling power from [src] into your body.</span>")
+		E.drain_time = world.time + CELL_DRAIN_TIME
+		if(do_after(user, CELL_DRAIN_TIME, target = src))
+			if((charge < CELL_POWER_DRAIN) || (stomach.crystal_charge > charge_limit))
 				return
 			if(istype(stomach))
-				to_chat(H, "<span class='notice'>You receive some charge from the [src].</span>")
-				stomach.adjust_charge(3)
-				charge -= 100 //you waste way more than you receive, so that ethereals cant just steal one cell and forget about hunger
+				to_chat(H, "<span class='notice'>You receive some charge from [src], wasting some in the process.</span>")
+				stomach.adjust_charge(CELL_POWER_GAIN)
+				charge -= CELL_POWER_DRAIN //you waste way more than you receive, so that ethereals cant just steal one cell and forget about hunger
 			else
-				to_chat(H, "<span class='warning'>You can't receive charge from the [src]!</span>")
+				to_chat(H, "<span class='warning'>You can't receive charge from [src]!</span>")
 		return
-
+// Waspstation End
 
 /obj/item/stock_parts/cell/blob_act(obj/structure/blob/B)
 	SSexplosions.highobj += src
@@ -401,3 +409,9 @@
 	var/area/A = get_area(src)
 	if(!A.lightswitch || !A.light_power)
 		charge = 0 //For naturally depowered areas, we start with no power
+
+// Waspstation Begin -- Ethereal Charge Scaling
+#undef CELL_DRAIN_TIME
+#undef CELL_POWER_GAIN
+#undef CELL_POWER_DRAIN
+// Waspstation End

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -12,6 +12,9 @@
 #define BROKEN_SPARKS_MIN (3 MINUTES)
 #define BROKEN_SPARKS_MAX (9 MINUTES)
 
+#define LIGHT_DRAIN_TIME 25                                             // Waspstation Edit -- Ethereal Charge Scaling
+#define LIGHT_POWER_GAIN (1.75 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)    // Waspstation Edit -- Ethereal Charge Scaling
+
 /obj/item/wallframe/light_fixture
 	name = "light fixture frame"
 	desc = "Used for building lights."
@@ -681,13 +684,13 @@
 				if(E.drain_time > world.time)
 					return
 				to_chat(H, "<span class='notice'>You start channeling some power through the [fitting] into your body.</span>")
-				E.drain_time = world.time + 30
-				while(do_after(user, 30, target = src)) //Wasp edit
-					E.drain_time = world.time + 30 //Wasp edit
+				E.drain_time = world.time + LIGHT_DRAIN_TIME          // Waspstation Edit -- Ethereal Charge Scaling
+				while(do_after(user, LIGHT_DRAIN_TIME, target = src)) //Wasp edit
+					E.drain_time = world.time + LIGHT_DRAIN_TIME //Wasp edit
 					var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 					if(istype(stomach))
 						to_chat(H, "<span class='notice'>You receive some charge from the [fitting].</span>")
-						stomach.adjust_charge(2)
+						stomach.adjust_charge(LIGHT_POWER_GAIN)       // Waspstation Edit -- Ethereal Charge Scaling
 					else
 						to_chat(H, "<span class='warning'>You can't receive charge from the [fitting]!</span>")
 				return
@@ -931,3 +934,6 @@
 	layer = 2.5
 	light_type = /obj/item/light/bulb
 	fitting = "bulb"
+
+#undef LIGHT_DRAIN_TIME  // Waspstation Edit -- Ethereal Charge Scaling
+#undef LIGHT_POWER_GAIN  // Waspstation Edit -- Ethereal Charge Scaling

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -725,7 +725,7 @@
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
-			stomach.adjust_charge(reac_volume * REM)
+			stomach.adjust_charge(reac_volume * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)      // Waspstation Edit -- Ethereal Charge Scaling
 
 /datum/reagent/consumable/liquidelectricity/on_mob_life(mob/living/carbon/M)
 	if(prob(25) && !isethereal(M))

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -151,7 +151,7 @@
 	var/did_we_charge = FALSE
 	var/obj/item/organ/stomach/ethereal/eth_stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 	if(istype(eth_stomach))
-		eth_stomach.adjust_charge(3)
+		eth_stomach.adjust_charge(3 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)    // Waspstation Edit -- Ethereal Charge Scaling
 		did_we_charge = TRUE
 
 	//if we're not targetting a robot part we stop early

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -118,7 +118,7 @@
 	..()
 
 /obj/item/organ/stomach/ethereal/proc/charge(datum/source, amount, repairs)
-	adjust_charge(amount / 70)
+	adjust_charge((amount * ETHEREAL_CHARGE_SCALING_MULTIPLIER) / 70 )      // Waspstation Edit -- Ethereal Charge Scaling
 
 /obj/item/organ/stomach/ethereal/proc/on_electrocute(datum/source, shock_damage, siemens_coeff = 1, flags = NONE)
 	if(flags & SHOCK_ILLUSION)


### PR DESCRIPTION
Co-authored-by: s <wesoda24@gmail.com>

## About The Pull Request

Porting https://github.com/tgstation/tgstation/pull/53924 and https://github.com/tgstation/tgstation/pull/53984, adding a constant, and fixing a related bug.

PR 53984:
Scales up the amount of charge Ethereals store and use, so they have a greater impact on APC charge.  One charge cycle now gives/takes about 8% as compared to the previous <1%.  This should be otherwise unnoticeable, aside from a couple things listed below.

Cells hold less charge in relation to an Ethereal's max charge, so the amount wasted by cell charging has been reduced to compensate.  Cell charge time has also raised slightly.

The amount of time to charge from lights and the amount of charge gained from lights has been slightly reduced.  See 53984 for rationale.

My refactors on PR 53984:
I wasn't convinced that 20 was the correct scale factor for Ethereal charge, so I created a easily-changed constant for it.  I replaced the multiplication by 20, with this value: ETHEREAL_CHARGE_SCALING_MULTIPLIER.

Changed the charge displayed in the stat tab to be a percentage, so people don't wonder what 2000 charge means...

My bugfix on PR 53984:
Chain-charging an APC that wasn't charging via external power, would let you continuously charge an APC that was at 99%.  This was because of a missing check inside the charge loop.  I added this.

PR 53924:
Replaces literals with constants: APC_DRAIN_TIME, APC_POWER_GAIN, CELL_DRAIN_TIME, CELL_POWER_GAIN, CELL_POWER_DRAIN, LIGHT_DRAIN_TIME, and LIGHT_POWER_GAIN.

Extract Variable: charge_limit.

Fixes some grammar mistakes.

Testing:
I've confirmed that the discharge rate is the same percentage per unit time.  I have also confirmed the other changed interactions (aside from those listed above) result in the same change in charge percentage as before this change.

## Why It's Good For The Game

Requested in Issue #304 

## Changelog
:cl: untrius & wesoda24
tweak: Ethereals can be the inducers they were born to be
fix: Fixed charge cap on almost full APCs
balance: Ethereals charging from power cells waste less power and charge slightly slower
balance: Ethereals charging from lights gain slightly less power and charge slightly faster
/:cl:
