### PR TITLE
firefighter helmets are back, mining hardhat receives buffs

### DIFF
--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -69,8 +69,8 @@
 
 /obj/item/clothing/head/hardhat/red
 	name = "firefighter helmet"
-	icon_state "hardhat_red"
-	item_state "hardhat_red"
+	icon_state = "hardhat_red"
+	item_state = "hardhat_red"
 	clothing_flags = STOPSPRESSUREDAMAGE
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
@@ -198,4 +198,3 @@
 /obj/item/clothing/head/hardhat/weldhat/dblue
 	icon_state = "hardhat_dblue"
 	item_state = "hardhat_dblue"
-

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -63,10 +63,14 @@
 	set_light_on(FALSE)
 
 /obj/item/clothing/head/hardhat/orange
-	name = "firefighter helmet"
-	icon_state = "hardhat_red"
-	item_state = "hardhat_red"
+	icon_state = "hardhat_orange"
+	item_state = "hardhat_orange"
 	dog_fashion = null
+
+/obj/item/clothing/head/hardhat/red
+	name = "firefighter helmet"
+	icon_state "hardhat_red"
+	item_state "hardhat_red"
 	clothing_flags = STOPSPRESSUREDAMAGE
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
@@ -127,8 +131,11 @@
 	icon_state = "hardhat_mining"
 	item_state = "hardhat_mining"
 	dog_fashion = null
-
-	armor = list("melee" = 15, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 0)
+	heat_protection = HEAD
+	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
+	cold_protection = HEAD
+	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
+	armor = list("melee" = 30, "bullet" = 10, "laser" = 10, "energy" = 20, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0) //some of the wacky resistances the miner hood has have been reduced or removed
 
 /obj/item/clothing/head/hardhat/weldhat
 	name = "welding hard hat"


### PR DESCRIPTION
which one of you fuckers accidentally deleted the red hardhat from hardhat.dm

## About The Pull Request

this readds the firefighter helmet, which should fix the bug of all of the fire safety closets coming with regular hardhats (which do not provide heat or pressure protection)

this also buffs the mining helmet, which is now fireproof (but not pressureproof!) and has had its resistances buffed from 
`armor = list("melee" = 15, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 0)`
to
`armor = list("melee" = 30, "bullet" = 10, "laser" = 10, "energy" = 20, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)`

This should make it a usable alternative to the explorer's hood, trading off some of its miscellaneous resistances for the light. 

## Why It's Good For The Game

i like my fire safety closets actually being equipped to provide safety against fires kthx

## Changelog
:cl:
balance: mining hardhats have received an armor buff to protect against fires and be usable as an alternative to wearing your explorer suit's hoodie
fix: fire safety closets come with actual firefighter helmets now
/:cl:
