### PR TITLE
bicaridine plus no longer requires plasma as a catalyst

### DIFF
--- a/waspstation/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/waspstation/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -5,7 +5,6 @@
 /datum/chemical_reaction/bicaridinep
 	results = list(/datum/reagent/medicine/bicaridinep = 3)
 	required_reagents = list(/datum/reagent/medicine/bicaridine = 1, /datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/sodiumchloride = 1)
-	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
 
 /datum/chemical_reaction/kelotane
 	results = list(/datum/reagent/medicine/kelotane = 2)


### PR DESCRIPTION
Do you  ever look back at something you've done in the past and wonder,

"What the fuck was I doing?"

## About The Pull Request

Bicaridine Plus no longer requires plasma as a catalyst.

## Why It's Good For The Game

Bicaridine Plus is one of the more involved chems to make. Although you can get all you need for it without forced InTerDePaRtMeNtAl CoOpErAtIoN, the making of nutriment is convoluted and requires the use of the grinder and the chem master. That's all well and good; medicines shouldn't be *that* easy to make, but adding plasma as a catalyst on top of that? If I could go back in time to smack myself in the face when I did that, I would, but unfortunately I cannot, so this will have to do.

## Changelog
:cl:
tweak: bicard plus no longer requires plasma as a catalyst
/:cl:
