### PR TITLE
gives the CMO advanced hypospray kit the upgraded trek chems

### DIFF
--- a/waspstation/code/modules/reagents/reagent_containers/hypovial.dm
+++ b/waspstation/code/modules/reagents/reagent_containers/hypovial.dm
@@ -119,7 +119,7 @@
 	comes_with = list(/datum/reagent/medicine/bicaridine = 60)
 
 /obj/item/reagent_containers/glass/bottle/vial/small/preloaded/antitoxin
-	name = "green hypovial (Anti-Tox)"
+	name = "green hypovial (Dylovene)"
 	icon_state = "hypovial-a"
 	comes_with = list(/datum/reagent/medicine/antitoxin = 60)
 

--- a/waspstation/code/modules/reagents/reagent_containers/hypovial.dm
+++ b/waspstation/code/modules/reagents/reagent_containers/hypovial.dm
@@ -144,24 +144,24 @@
 	comes_with = list(/datum/reagent/medicine/omnizine = 40, /datum/reagent/medicine/leporazine = 40, /datum/reagent/medicine/atropine = 40)
 
 /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/bicaridine
-	name = "large red hypovial (bicaridine)"
+	name = "large red hypovial (bicaridine plus)"
 	icon_state = "hypoviallarge-b"
-	comes_with = list(/datum/reagent/medicine/bicaridine = 120)
+	comes_with = list(/datum/reagent/medicine/bicaridinep = 120)
 
 /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/antitoxin
-	name = "large green hypovial (anti-tox)"
+	name = "large green hypovial (carthatoline)"
 	icon_state = "hypoviallarge-a"
-	comes_with = list(/datum/reagent/medicine/antitoxin = 120)
+	comes_with = list(/datum/reagent/medicine/carthatoline = 120)
 
 /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/kelotane
-	name = "large orange hypovial (kelotane)"
+	name = "large orange hypovial (dermaline)"
 	icon_state = "hypoviallarge-k"
-	comes_with = list(/datum/reagent/medicine/kelotane = 120)
+	comes_with = list(/datum/reagent/medicine/dermaline = 120)
 
 /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/dexalin
-	name = "large blue hypovial (dexalin)"
+	name = "large blue hypovial (dexalin plus)"
 	icon_state = "hypoviallarge-d"
-	comes_with = list(/datum/reagent/medicine/dexalin = 120)
+	comes_with = list(/datum/reagent/medicine/dexalinp = 120)
 
 /obj/item/reagent_containers/glass/bottle/vial/large/preloaded/charcoal
 	name = "large black hypovial (charcoal)"


### PR DESCRIPTION
## About The Pull Request

replaces the original set of bicaridine, kelotane, anti toxin, and dexalin for its upgraded variants of bicaridine plus, dermaline, carthatoline, and dexalin plus

## Why It's Good For The Game

it's astounding how fast you piss through the basic trek chems, it's unbecoming of a CMO how fast

20 units from bicaridine, kelotane, antitoxin, and dexalin heal only 32 damage of their respective calibers, as opposed to the 128 damage that is healed from 20 units of the upgraded chemicals

## Changelog
:cl:
balance: the CMO hypospray kit comes with the upgraded chemicals instead of the basic ones, as is befitting of their status
/:cl: