### PR TITLE
Admin Fax fixes

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -141,8 +141,10 @@
 	. = ..()
 	if(!in_range(user, src) && !isobserver(user))
 		. += "<span class='warning'>You're too far away to read it!</span>"
+		if (check_rights_for(usr, R_ADMIN))
+			. += "<span class='notice'>If you're attempting to read this as an admin, either remotely or from a CentCom/Syndicate fax, make sure to turn on Admin AI Interact.</span>"
 		return
-	if(user.can_read(src))
+	if(user.can_read(src) || !check_rights_for(usr, R_ADMIN))
 		ui_interact(user)
 		return
 	. += "<span class='warning'>You cannot read it!</span>"
@@ -151,9 +153,9 @@
 		// Are we on fire?  Hard ot read if so
 	if(resistance_flags & ON_FIRE)
 		return UI_CLOSE
-	if(!in_range(user,src))
+	if(!in_range(user,src) && IsAdminGhost(user))
 		return UI_CLOSE
-	if(user.incapacitated(TRUE, TRUE) || (isobserver(user) && !check_rights_for(usr, R_ADMIN)))
+	if(user.incapacitated(TRUE, TRUE) || (isobserver(user) && !check_rights_for(user.client, R_ADMIN)))
 		return UI_UPDATE
 	// Even harder to read if your blind...braile? humm
 	// .. or if you cannot read
@@ -230,6 +232,8 @@
 		ui = new(user, src, "PaperSheet", name)
 		ui.open()
 
+// /datum/wires/ui_state(mob/user)
+// 	return GLOB.physical_state
 
 /obj/item/paper/ui_static_data(mob/user)
 	. = list()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -153,7 +153,7 @@
 		// Are we on fire?  Hard ot read if so
 	if(resistance_flags & ON_FIRE)
 		return UI_CLOSE
-	if(!in_range(user,src) && IsAdminGhost(user))
+	if(!in_range(user,src) && !IsAdminGhost(user))
 		return UI_CLOSE
 	if(user.incapacitated(TRUE, TRUE) || (isobserver(user) && !check_rights_for(user.client, R_ADMIN)))
 		return UI_UPDATE


### PR DESCRIPTION
… examine to enable admin AI interact

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes an issue with papers from CentCom faxes not being readable by admins. Adds a reminder to activate Admin AI Interact on inspect.

## Why It's Good For The Game

It'd be nice for the Admins to be able to see faxes from the station in the event of _insert command staff overreach & fuckery here_.

## Changelog
:cl:
fix: Fixed admins being unable to view centcom/syndicate faxes.
admin: Added a reminder string to paper examine as admin to enable Admin AI Interact
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
