### PR TITLE
Give Senior Uniform to Chadmos

### DIFF
--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -59,8 +59,8 @@
 	name = "Atmospheric Technician (Life Support Specialist)"
 	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1, /obj/item/storage/box/survival=2)
 
-/datum/outfit/job/atmos/chadmos
-	name = "Atmospheric Technician (Chadmos)"
+/datum/outfit/job/atmos/chadmos                // WaspStation Edit - Give Chadmos Sr. Uniform
+	name = "Atmospheric Technician (Chadmos)"  // WaspStation Edit - Give Chadmos Sr. Uniform
 
 	belt = null
 	uniform = /obj/item/clothing/under/suit/senior_atmos

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -59,8 +59,8 @@
 	name = "Atmospheric Technician (Life Support Specialist)"
 	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1, /obj/item/storage/box/survival=2)
 
-/datum/outfit/job/atmos/senioratmospherics
-	name = "Atmospheric Technician (Senior Atmospheric Technician)"
+/datum/outfit/job/atmos/chadmos
+	name = "Atmospheric Technician (Chadmos)"
 
 	belt = null
 	uniform = /obj/item/clothing/under/suit/senior_atmos


### PR DESCRIPTION
## About The Pull Request

Gives the Senior Atmos Tech uniform to the Chadmos senior title.

The alt title name at the end of /datum/outfit/job/atmos/chadmos has to match the alt title.  Didn't know this at the time.

## Why It's Good For The Game

Bugfix for issue caused by changing atmos tech senior title name in #399 

## Changelog
:cl:
fix: Chadmos get the senior atmos tech uniforms
/:cl:
