### PR TITLE
Adds Kobolds and replaces ashwalkers with them

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -63,7 +63,7 @@
 		return ..()
 	var/mob/living/carbon/human/yolk = new /mob/living/carbon/human/(get_turf(src))
 	yolk.fully_replace_character_name(null,random_unique_lizard_name(gender))
-	yolk.set_species(/datum/species/lizard/ashwalker)
+	yolk.set_species(/datum/species/lizard/ashwalker/kobold) //Wasp Edit - Kobold
 	yolk.underwear = "Nude"
 	yolk.equipOutfit(/datum/outfit/ashwalker)//this is an authentic mess we're making
 	yolk.update_body()
@@ -78,7 +78,7 @@
 	mob_name = "an ash walker"
 	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
 	icon_state = "large_egg"
-	mob_species = /datum/species/lizard/ashwalker
+	mob_species = /datum/species/lizard/ashwalker/kobold //Wasp Edit - Kobold
 	outfit = /datum/outfit/ashwalker
 	roundstart = FALSE
 	death = FALSE

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -89,3 +89,17 @@
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE)
 	inherent_traits = list(TRAIT_CHUNKYFINGERS,TRAIT_NOBREATH)
 	species_language_holder = /datum/language_holder/lizard/ash
+//Wasp Edit Start - Kobold
+//Ashwalker subspecies: KOBOLD
+/datum/species/lizard/ashwalker/kobold
+	name = "Kobold"
+	id = "kobold"
+	limbs_id = "lizard"
+	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE)
+	inherent_traits = list(TRAIT_CHUNKYFINGERS,TRAIT_NOBREATH)
+	species_language_holder = /datum/language_holder/lizard/ash
+
+/datum/species/lizard/ashwalker/kobold/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
+  . = ..() //call everything from species/on_species_gain()
+  C.dna.add_mutation(DWARFISM)
+//Wasp Edit End - Kobold

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -278,7 +278,7 @@
 	H.dna.add_mutation(DWARFISM)
 
 /obj/effect/mob_spawn/human/corpse/damaged/legioninfested/Initialize()
-	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 5, "Kobold" = 5, "Golem" = 10,"Clown" = 10, pick(list("Shadow", "YeOlde","Operative", "Cultist")) = 4))
+	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 5, "Kobold" = 5, "Golem" = 10,"Clown" = 10, pick(list("Shadow", "YeOlde","Operative", "Cultist")) = 4)) //Wasp Edit - Kobold
 	switch(type)
 		if("Miner")
 			mob_species = pickweight(list(/datum/species/human = 70, /datum/species/lizard = 26, /datum/species/fly = 2, /datum/species/plasmaman = 2))

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -278,7 +278,7 @@
 	H.dna.add_mutation(DWARFISM)
 
 /obj/effect/mob_spawn/human/corpse/damaged/legioninfested/Initialize()
-	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 10, "Golem" = 10,"Clown" = 10, pick(list("Shadow", "YeOlde","Operative", "Cultist")) = 4))
+	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 5, "Kobold" = 5, "Golem" = 10,"Clown" = 10, pick(list("Shadow", "YeOlde","Operative", "Cultist")) = 4))
 	switch(type)
 		if("Miner")
 			mob_species = pickweight(list(/datum/species/human = 70, /datum/species/lizard = 26, /datum/species/fly = 2, /datum/species/plasmaman = 2))
@@ -321,6 +321,25 @@
 				r_pocket = /obj/item/kitchen/knife/combat/bone
 			if(prob(30))
 				l_pocket = /obj/item/kitchen/knife/combat/bone
+		//Wasp Edit Start - Kobold
+		if("Kobold")
+			mob_species = /datum/species/lizard/ashwalker/kobold
+			uniform = /obj/item/clothing/under/costume/gladiator/ash_walker
+			if(prob(95))
+				head = /obj/item/clothing/head/helmet/gladiator
+			else
+				head = /obj/item/clothing/head/helmet/skull
+				suit = /obj/item/clothing/suit/armor/bone
+				gloves = /obj/item/clothing/gloves/bracer
+			if(prob(5))
+				back = pickweight(list(/obj/item/spear/bonespear = 3, /obj/item/fireaxe/boneaxe = 2))
+			if(prob(10))
+				belt = /obj/item/storage/belt/mining/primitive
+			if(prob(30))
+				r_pocket = /obj/item/kitchen/knife/combat/bone
+			if(prob(30))
+				l_pocket = /obj/item/kitchen/knife/combat/bone
+		//Wasp Edit End - Kobold
 		if("Clown")
 			name = pick(GLOB.clown_names)
 			outfit = /datum/outfit/job/clown

--- a/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
@@ -82,7 +82,7 @@
 
 /obj/structure/lavaland/ash_walker/proc/remake_walker(var/datum/mind/oldmind, var/oldname)
 	var/mob/living/carbon/human/M = new /mob/living/carbon/human(get_step(loc, pick(GLOB.alldirs)))
-	M.set_species(/datum/species/lizard/ashwalker)
+	M.set_species(/datum/species/lizard/ashwalker/kobold) //Wasp Edit - Kobold
 	M.real_name = oldname
 	M.underwear = "Nude"
 	M.update_body()

--- a/waspstation/code/modules/mob/living/carbon/human/human.dm
+++ b/waspstation/code/modules/mob/living/carbon/human/human.dm
@@ -77,3 +77,7 @@
 
 /mob/living/carbon/human/species/squid
 	race = /datum/species/squid
+
+/mob/living/carbon/human/species/lizard/ashwalker/kobold
+	race = /datum/species/lizard/ashwalker/kobold
+	

--- a/waspstation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/waspstation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1,0 +1,7 @@
+/datum/reagent/mutationtoxin/kobold
+	name = "Kobold Mutation Toxin"
+	description = "An ashen toxin. Something about this seems lesser."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/lizard/ashwalker/kobold
+	process_flags = ORGANIC | SYNTHETIC //WaspStation Edit - IPCs
+	taste_description = "short savagery"

--- a/waspstation/code/modules/reagents/chemistry/recipes/others.dm
+++ b/waspstation/code/modules/reagents/chemistry/recipes/others.dm
@@ -7,4 +7,3 @@
 /datum/chemical_reaction/mutationtoxin/kobold
 	results = list(/datum/reagent/mutationtoxin/ash = 1)
 	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/mutationtoxin/lizard = 1, /datum/reagent/ash = 10, /datum/reagent/consumable/tinlux = 5)
-	

--- a/waspstation/code/modules/reagents/chemistry/recipes/others.dm
+++ b/waspstation/code/modules/reagents/chemistry/recipes/others.dm
@@ -3,3 +3,8 @@
 
 /datum/chemical_reaction/life_friendly
 	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/synthflesh = 1, /datum/reagent/consumable/sugar = 1)
+
+/datum/chemical_reaction/mutationtoxin/kobold
+	results = list(/datum/reagent/mutationtoxin/ash = 1)
+	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/mutationtoxin/lizard = 1, /datum/reagent/ash = 10, /datum/reagent/consumable/tinlux = 5)
+	


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ashwalkers, from the spawner menu, now spawn with dwarfism as Kobolds. Additionally, a new mutation toxin is christened for kobolds with the recipe replacing Entropic Polypnium from the ash toxin recipe with Tinea Luxor.

Regular Ashwalkers are still available as admin spawns or legion corpse spawns. Now an extinct race, bred out by a need for sturdier bearing.

Thanks given to callabe from tgstation for the original implementation idea of making dorf lizards - tgstation/tgstation#54186

## Why It's Good For The Game

short lizarb

## Changelog
:cl:
add: A new mutation toxin for stout savages. Replace Polypnium with Tinea Luxor.
tweak: The lizard people you've found planetside seem shorter than the stories.
balance: The legions now have an equal chance to spawn kobolds and their taller predecessors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
