### PR TITLE
Shuttles intercoms and firelocks

### DIFF
--- a/_maps/map_files/MidwayStation/MidwayStation.dmm
+++ b/_maps/map_files/MidwayStation/MidwayStation.dmm
@@ -8092,6 +8092,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"aLF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "aLG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -11035,6 +11047,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"bBU" = (
+/obj/item/kirbyplants/random,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "bCf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12738,21 +12757,6 @@
 	},
 /turf/open/floor/circuit,
 /area/maintenance/starboard/central)
-"cUx" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "cUK" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/donkpockets,
@@ -13501,6 +13505,18 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"dAX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "dBR" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -18363,18 +18379,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hwF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "hwG" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -18805,6 +18809,15 @@
 /obj/machinery/microwave,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"hMN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "hNj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -19184,6 +19197,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"ifW" = (
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "ige" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
@@ -19456,6 +19482,22 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"isi" = (
+/obj/machinery/door/airlock/command{
+	name = "Gateway Access";
+	req_access_txt = "62"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "isA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -19664,18 +19706,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"iAM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Gateway"
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "iBp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -20999,15 +21029,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"jwC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "jwD" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/door/window/eastleft{
@@ -21111,6 +21132,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"jCK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "jCL" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -21173,11 +21206,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"jFG" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "jGi" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
@@ -21867,6 +21895,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"kgp" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/spawner/xmastree,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "kgx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -25885,6 +25934,24 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"ntQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "nug" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4;
@@ -28141,19 +28208,27 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"oZm" = (
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
+"oZo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/gateway)
+/area/hallway/primary/fore)
 "oZp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29471,24 +29546,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"pSm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "pUp" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
@@ -32037,25 +32094,6 @@
 /obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"rTb" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "rTH" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -32079,6 +32117,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rVI" = (
+/obj/machinery/camera{
+	c_tag = "Gateway"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/gateway)
 "rVY" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -32792,29 +32837,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"sBP" = (
-/obj/machinery/door/airlock/command{
-	name = "Gateway Access";
-	req_access_txt = "62"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "sCa" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -34209,13 +34231,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"tBG" = (
-/obj/structure/closet/secure_closet/exile,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "tBK" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/red{
@@ -34237,6 +34252,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"tDt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "tDu" = (
 /turf/open/floor/carpet,
 /area/chapel/main)
@@ -36620,15 +36642,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"vlo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "vlL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4;
@@ -37271,6 +37284,18 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"vHg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "vHn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -38234,21 +38259,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"wAJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "wAZ" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plasteel,
@@ -38491,24 +38501,6 @@
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"wGh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "wGz" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
@@ -38959,6 +38951,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"wVb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "wVW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -38996,6 +39011,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
+"wZY" = (
+/obj/structure/closet/secure_closet/exile,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "xaH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -59393,8 +59418,8 @@ awt
 awC
 eBo
 awb
-oZm
-tBG
+ifW
+wZY
 axg
 wTc
 axc
@@ -59565,7 +59590,7 @@ mbq
 oVY
 joi
 wPq
-aTu
+sZy
 aaa
 nMT
 aaa
@@ -59595,9 +59620,9 @@ akT
 awD
 awJ
 awb
-iAM
-awU
-awU
+rVI
+aLF
+hSN
 awU
 axc
 wJZ
@@ -59767,7 +59792,7 @@ aTu
 tyF
 wVW
 bCs
-sZy
+aTu
 aaa
 nMT
 aaa
@@ -59797,8 +59822,8 @@ awu
 awE
 awb
 awb
-hwF
-hSN
+awU
+vHg
 awU
 jcx
 axc
@@ -59968,8 +59993,8 @@ aaa
 oOF
 lHH
 nXv
-jwC
-sZy
+jCK
+aTu
 lEA
 lEA
 lEA
@@ -59999,8 +60024,8 @@ awb
 awb
 awb
 awb
-sBP
 axc
+isi
 wHf
 axc
 axc
@@ -60201,8 +60226,8 @@ fXm
 vso
 mRq
 qMM
-wGh
-cUx
+wOj
+oZo
 ufC
 iwD
 mKS
@@ -60403,8 +60428,8 @@ iLo
 dox
 dox
 dox
-wAJ
-vlo
+dox
+ntQ
 doo
 aac
 mbK
@@ -60605,8 +60630,8 @@ mMS
 vzz
 lqV
 xaH
-pmy
-pSm
+dAX
+wVb
 bDO
 mjz
 rYm
@@ -60807,7 +60832,7 @@ dpw
 omS
 omS
 omS
-oZB
+hMN
 nmX
 aac
 aac
@@ -62042,7 +62067,7 @@ ikE
 ikE
 ikE
 arS
-rTb
+kgp
 mSs
 aOs
 aOs
@@ -65493,7 +65518,7 @@ qod
 uvz
 arT
 arT
-dqy
+tDt
 tKc
 rDC
 kik
@@ -66496,7 +66521,7 @@ eni
 aAy
 ogi
 arT
-arT
+kTY
 arT
 jIP
 dPe
@@ -68911,10 +68936,10 @@ auM
 jqp
 tDu
 shM
-jqp
+bBU
 auM
-arT
-jFG
+aAy
+aAy
 evP
 hhP
 kSb
@@ -69114,8 +69139,8 @@ bIW
 tDu
 eAE
 qdC
-auM
-auM
+bIW
+bIW
 auM
 evP
 evP

--- a/_maps/map_files/MidwayStation/MidwayStation.dmm
+++ b/_maps/map_files/MidwayStation/MidwayStation.dmm
@@ -73,12 +73,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"aaG" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aaK" = (
 /turf/closed/wall,
 /area/medical/surgery)
@@ -200,6 +194,13 @@
 "abW" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"abY" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "aca" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -350,43 +351,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"adb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "adc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"add" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	external_pressure_bound = 140;
-	name = "killroom vent";
-	pressure_checks = 0
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -915,9 +884,6 @@
 "agt" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hor)
-"agu" = (
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science)
 "agx" = (
 /obj/machinery/rnd/server,
 /turf/open/floor/plasteel,
@@ -975,12 +941,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
-"agW" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "agX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -1222,16 +1182,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
-"ahV" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science)
 "ahX" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
@@ -1256,20 +1206,6 @@
 /obj/machinery/rnd/bepis,
 /turf/open/floor/plasteel,
 /area/science/explab)
-"aig" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/computer/security/telescreen/research{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science)
 "aih" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1659,12 +1595,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"ajq" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "ajt" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -1701,15 +1631,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"ajE" = (
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "ajJ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -1749,12 +1670,6 @@
 /obj/item/storage/box/disks_nanite,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"ajS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "ajU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -1782,15 +1697,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"aka" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "akb" = (
 /obj/machinery/nanite_programmer,
 /obj/effect/turf_decal/bot,
@@ -2660,29 +2566,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"anr" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window{
-	dir = 1;
-	icon_state = "rightsecure";
-	name = "Science EVA";
-	req_access_txt = "47"
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
 "ant" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"anv" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "anw" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes{
@@ -3618,15 +3505,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"aqL" = (
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "aqN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -3737,6 +3615,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aro" = (
+/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "arp" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -4388,12 +4277,6 @@
 /obj/item/pen/invisible,
 /turf/open/floor/engine/cult,
 /area/library)
-"atR" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "atT" = (
 /turf/closed/wall,
 /area/chapel/office)
@@ -4644,12 +4527,6 @@
 "avW" = (
 /turf/closed/wall,
 /area/maintenance/port/fore)
-"avY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "avZ" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
@@ -4828,13 +4705,6 @@
 "axp" = (
 /turf/open/floor/plasteel,
 /area/teleporter)
-"axq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "axs" = (
 /obj/machinery/computer/teleporter{
 	dir = 1
@@ -5343,27 +5213,6 @@
 /obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"azi" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"azj" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "azm" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5374,15 +5223,6 @@
 	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
-/area/science/xenobiology)
-"azo" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "azp" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -5855,25 +5695,9 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"aBe" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"aBf" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "aBg" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall,
-/area/science/xenobiology)
-"aBh" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "aBi" = (
 /obj/structure/disposalpipe/trunk{
@@ -5881,9 +5705,6 @@
 	},
 /obj/structure/disposaloutlet,
 /turf/open/floor/engine,
-/area/science/xenobiology)
-"aBl" = (
-/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "aBm" = (
 /mob/living/simple_animal/slime,
@@ -5914,19 +5735,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/hallway/primary/aft)
-"aBr" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology South";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "aBs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6816,18 +6624,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"aGj" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "aGm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 8
@@ -7125,13 +6921,6 @@
 /obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aHz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aHC" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -7304,12 +7093,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/primary)
-"aHT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "aHU" = (
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
@@ -7318,6 +7101,17 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
+"aHW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aHX" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
@@ -7403,12 +7197,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
-"aIj" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "aIk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -7446,6 +7234,34 @@
 	dir = 1
 	},
 /area/crew_quarters/fitness/recreation)
+"aIt" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/sign/directions/vault{
+	pixel_x = -32;
+	pixel_y = -9
+	},
+/obj/structure/sign/directions/supply{
+	pixel_x = -32;
+	pixel_y = -3
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_x = -32;
+	pixel_y = 3
+	},
+/obj/structure/sign/directions/medical{
+	pixel_x = -32;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aIu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -7469,13 +7285,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"aIB" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aIG" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plasteel,
@@ -7733,16 +7542,6 @@
 /obj/item/clothing/suit/apron/surgical,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"aJF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aJH" = (
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/plasteel/white,
@@ -8092,18 +7891,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
-"aLF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "aLG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -8238,18 +8025,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"aMl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "aMm" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -8276,19 +8051,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"aMp" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science)
 "aMr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -8362,16 +8124,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"aMK" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "aML" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
@@ -8488,38 +8240,27 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"aNm" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
+"aNp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"aNn" = (
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/science/research)
 "aNt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"aNz" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aND" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -8529,22 +8270,9 @@
 "aNO" = (
 /turf/closed/wall,
 /area/maintenance/port/aft)
-"aNR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "aNV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"aNW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -8719,12 +8447,6 @@
 /obj/structure/window/spawner/west,
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
-"aOT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "aOX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
@@ -8805,18 +8527,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
-"aPl" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "aPp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -8838,24 +8548,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aPz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aPA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"aPB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8866,22 +8563,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"aPE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"aPG" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "aPJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8896,19 +8577,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"aPQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aPU" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -8950,10 +8618,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"aQb" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aQf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -9012,18 +8676,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/medical)
-"aQy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "aQC" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
@@ -9077,17 +8729,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/server)
-"aQM" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "aQS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -9126,16 +8767,6 @@
 	dir = 8
 	},
 /area/chapel/main)
-"aQZ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "aRa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -9166,34 +8797,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/lobby)
-"aRp" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"aRq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "aRs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1;
@@ -9425,18 +9028,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"aTg" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "aTi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -9458,21 +9049,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"aTm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"aTn" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aTq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -9602,6 +9178,21 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/medical/medbay/lobby)
+"aUm" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "aUo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -9615,12 +9206,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"aUt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"aUp" = (
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
-/area/science/xenobiology)
+/area/science/research)
 "aUv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9637,26 +9235,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aUK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"aUL" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "aUN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -9786,12 +9364,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"aVH" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aVL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -9830,6 +9402,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"aVP" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "aVW" = (
 /obj/machinery/light{
 	dir = 1
@@ -9847,18 +9426,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
-"aWb" = (
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science)
 "aWj" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -10274,30 +9841,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"aYZ" = (
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"aZh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"aZm" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "aZn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10378,12 +9921,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"aZN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aZT" = (
 /obj/item/radio/intercom{
 	pixel_x = -27;
@@ -10415,6 +9952,10 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
+"baU" = (
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bby" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
@@ -10424,6 +9965,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"bbT" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "bci" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -10459,6 +10013,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"bdJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "beH" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room";
@@ -10501,6 +10067,21 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/warehouse)
+"bgv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bgw" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/lattice,
@@ -10542,6 +10123,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"biv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "biM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -10614,13 +10207,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"bjE" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 1;
-	name = "Hot loop supply"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "bjF" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma{
@@ -10652,6 +10238,33 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"bjU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"bke" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "bkn" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Bow Solar Access";
@@ -10695,6 +10308,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"blf" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"blS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bmd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -10908,6 +10543,14 @@
 	},
 /turf/open/space/basic,
 /area/maintenance/solars/port/aft)
+"bwt" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "bwy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -10951,6 +10594,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"bxS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "byK" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
@@ -10990,12 +10647,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"bzD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "bzF" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 1
@@ -11010,6 +10661,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/library)
+"bzP" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "bAs" = (
 /obj/machinery/vending/boozeomat/all_access,
 /turf/open/floor/wood,
@@ -11047,13 +10717,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"bBU" = (
-/obj/item/kirbyplants/random,
-/obj/item/radio/intercom{
-	pixel_y = -26
+"bBW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bCf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11085,13 +10758,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
-"bCs" = (
-/obj/machinery/light,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "bCR" = (
 /obj/structure/table,
 /obj/item/grenade/chem_grenade/smart_metal_foam{
@@ -11106,11 +10772,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"bDe" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bDi" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"bDH" = (
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bDO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -11121,19 +10809,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"bEe" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "bEZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -11279,34 +10954,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"bKU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"bKQ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Ari";
-	location = "Vlt"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"bKV" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit/departure_lounge)
 "bMG" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -11323,6 +10986,20 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"bMM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -11376,6 +11053,27 @@
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
+"bOv" = (
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"bOF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "bOJ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -11385,6 +11083,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
+"bPk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "bPs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11452,19 +11156,6 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
-"bRt" = (
-/obj/machinery/suit_storage_unit/atmos,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window{
-	dir = 1;
-	icon_state = "rightsecure";
-	name = "Atmospherics EVA";
-	req_one_access_txt = "11;24"
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
 "bRz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -11554,6 +11245,14 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"bVe" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "bVl" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -11605,11 +11304,19 @@
 "bWP" = (
 /turf/open/space/basic,
 /area/engine/engine_room)
-"bWV" = (
-/obj/structure/table,
-/obj/item/storage/crayons,
+"bXo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/science/research)
+/area/hallway/primary/central)
 "bXD" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -11634,6 +11341,17 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/engine,
 /area/science/explab)
+"bZQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bZS" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -11656,15 +11374,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"caQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "cbd" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -11704,23 +11413,16 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/shutters,
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
-"cds" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
+"cdE" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Bar";
+	location = "Sci"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/science)
+/area/hallway/primary/aft)
 "ceb" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room Access";
@@ -11749,6 +11451,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"cen" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cez" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -11846,6 +11571,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"chp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "chH" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
@@ -11953,10 +11684,55 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"clt" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "cmB" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"cmU" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cns" = (
+/obj/machinery/camera{
+	c_tag = "Gateway"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/gateway)
+"cnD" = (
+/obj/machinery/camera/autoname,
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"coh" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "coA" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Aft";
@@ -12107,6 +11883,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"csS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "ctq" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -12118,12 +11906,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"ctu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "ctB" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -12181,6 +11963,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"cxS" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cxU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8;
@@ -12243,6 +12033,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"cBk" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "cBH" = (
 /obj/item/storage/box/lights/mixed,
 /obj/structure/disposalpipe/segment{
@@ -12290,41 +12094,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"cEI" = (
-/obj/effect/turf_decal/tile/red,
-/obj/item/kirbyplants/random,
-/obj/structure/sign/directions/security{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = -3
-	},
-/obj/structure/sign/directions/science{
-	pixel_x = 32;
-	pixel_y = -9
-	},
-/obj/structure/sign/directions/evac{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = 9
-	},
-/obj/structure/sign/directions/command{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = 3
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"cFd" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "cFg" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -12349,12 +12118,19 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"cFu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"cFy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/central)
 "cFz" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -12434,6 +12210,16 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
+"cIF" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cIN" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
@@ -12524,6 +12310,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"cNa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "cNh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen Maintenance";
@@ -12580,6 +12377,25 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"cOb" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cOc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -12674,6 +12490,16 @@
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/wood,
 /area/lawoffice)
+"cQZ" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "cRl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -12706,6 +12532,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"cSL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "cTa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -12806,17 +12638,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"cWh" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 4;
-	icon_state = "volpump_map-2";
-	name = "cold loop supply"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "cWr" = (
 /obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/plating,
@@ -12922,31 +12743,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/lobby)
-"dbq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"dbx" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "dbU" = (
 /obj/machinery/button/crematorium{
 	id = "crematoriumChapel";
@@ -13055,6 +12851,37 @@
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"dfx" = (
+/obj/effect/turf_decal/tile/red,
+/obj/item/kirbyplants/random,
+/obj/structure/sign/directions/security{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = -3
+	},
+/obj/structure/sign/directions/science{
+	pixel_x = 32;
+	pixel_y = -9
+	},
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 9
+	},
+/obj/structure/sign/directions/command{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 3
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "dgs" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -13068,31 +12895,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"dhe" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/structure/sign/directions/vault{
-	pixel_x = -32;
-	pixel_y = -9
-	},
-/obj/structure/sign/directions/supply{
-	pixel_x = -32;
-	pixel_y = -3
-	},
-/obj/structure/sign/directions/engineering{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = 3
-	},
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = 9
+"dgZ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -13102,6 +12907,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"dhH" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "diB" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -13180,11 +12994,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
-"dli" = (
-/obj/machinery/light,
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "dmg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1;
@@ -13214,34 +13023,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"dnf" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/obj/structure/sign/directions/vault{
-	dir = 8;
-	pixel_x = -32;
-	pixel_y = -9
-	},
-/obj/structure/sign/directions/supply{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = -3
-	},
-/obj/structure/sign/directions/engineering{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = 3
-	},
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "dns" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -13277,12 +13058,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"doo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "dox" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -13301,25 +13076,6 @@
 	},
 /turf/closed/wall,
 /area/security/detectives_office)
-"dpw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"dpB" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "dqy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -13346,6 +13102,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"drp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "dru" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -13371,12 +13136,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
-"dtr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "dtR" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
@@ -13406,12 +13165,6 @@
 	},
 /turf/open/floor/plating,
 /area/solar/starboard/fore)
-"duJ" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "duQ" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock";
@@ -13451,6 +13204,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"dwB" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "dwQ" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -13466,18 +13225,24 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"dye" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "dyh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"dze" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "dzy" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable/yellow{
@@ -13495,6 +13260,12 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"dzH" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dzJ" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -13505,18 +13276,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"dAX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "dBR" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -13557,12 +13316,6 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel,
 /area/gateway)
-"dCI" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "dCL" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -13617,6 +13370,12 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
+"dGz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dGE" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -13634,6 +13393,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"dGR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "dGS" = (
 /obj/machinery/telecomms/bus/preset_four,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -13728,15 +13501,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
-"dLu" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "dLz" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Delivery Office";
@@ -13765,10 +13529,6 @@
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"dNo" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "dNL" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable{
@@ -13922,12 +13682,6 @@
 	},
 /turf/open/space/basic,
 /area/maintenance/solars/port/aft)
-"dRE" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "dRQ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -14159,6 +13913,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"dZh" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dZj" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -14173,6 +13937,15 @@
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space)
+"dZU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dZX" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock";
@@ -14380,6 +14153,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ehq" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ehw" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -14531,6 +14310,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"elS" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "emf" = (
 /obj/machinery/light{
 	dir = 1
@@ -14558,12 +14348,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"enP" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "enV" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14670,26 +14454,16 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"erj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"esk" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+"erk" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/engine/engine_room)
+/area/hallway/primary/aft)
 "esB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -14830,6 +14604,13 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ewt" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "ewI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14942,6 +14723,14 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
+"eAK" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eBb" = (
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
@@ -14996,6 +14785,42 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"eBJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"eBT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eBX" = (
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
@@ -15046,6 +14871,19 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/medical/medbay/lobby)
+"eEL" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eES" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -15113,6 +14951,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"eHn" = (
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eJo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -15128,6 +14978,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"eJL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eKb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -15187,12 +15050,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"eLL" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "eMf" = (
 /obj/structure/rack,
 /obj/item/aicard,
@@ -15402,6 +15259,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
+"eTT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eTX" = (
 /obj/machinery/computer/security/qm{
 	dir = 4
@@ -15464,20 +15334,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"eVO" = (
-/obj/machinery/vending/cola/random,
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"eVP" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "eWg" = (
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 10
@@ -15560,12 +15416,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"eYh" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "eYY" = (
 /obj/structure/chair/stool/bar,
 /obj/structure/cable{
@@ -15635,6 +15485,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"fbX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fcm" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
@@ -15652,6 +15518,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"feL" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ffj" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
@@ -15668,14 +15543,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"fgr" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 4;
-	icon_state = "volpump_map-2";
-	name = "cold loop supply"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "fgL" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
@@ -15744,6 +15611,13 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"fky" = (
+/obj/machinery/atmospherics/components/binary/pump,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "flX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -15833,12 +15707,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fqo" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
+"frt" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/science/xenobiology)
 "ftt" = (
 /turf/closed/wall,
 /area/medical/pharmacy)
@@ -15873,6 +15748,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"fwr" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "fwL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -15884,6 +15771,24 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"fwP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fxm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15896,6 +15801,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"fxp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fxt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15973,6 +15888,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"fAu" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fAD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -16115,23 +16040,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAS)
-"fEp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/table,
-/obj/item/healthanalyzer,
-/turf/open/floor/plasteel,
-/area/science/research)
 "fEQ" = (
 /obj/structure/table,
 /obj/item/assembly/signaler,
@@ -16154,6 +16062,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"fFv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "fFw" = (
 /obj/machinery/door/airlock/external{
 	name = "MiniSat External Access";
@@ -16164,17 +16079,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"fFO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "fGq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -16196,6 +16100,15 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"fGC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fGF" = (
 /obj/machinery/camera{
 	c_tag = "Brig Control Room";
@@ -16265,6 +16178,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"fJf" = (
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fJp" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/machinery/meter{
@@ -16280,6 +16200,20 @@
 /obj/machinery/power/tracker,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
+"fJy" = (
+/obj/machinery/camera{
+	c_tag = "Security Post - Science";
+	dir = 4;
+	network = list("ss13","rd")
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "fJC" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -16408,12 +16342,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"fPK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "fQs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -16436,6 +16364,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
+"fSG" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "fSN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
@@ -16443,6 +16378,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
+"fTk" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "fTs" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -16463,6 +16410,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"fTv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "fTw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -16485,6 +16444,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"fTH" = (
+/obj/machinery/newscaster{
+	pixel_x = -30
+	},
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "fVm" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
@@ -16502,18 +16482,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/lobby)
-"fVE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "fWt" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -16592,12 +16560,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
-"fYs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "fYM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -16610,6 +16572,19 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
+"fYT" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fZz" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/white,
@@ -16642,20 +16617,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"gbl" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "gbp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -16691,6 +16652,24 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"gbL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gco" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -16792,28 +16771,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"gfs" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "gfv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"gfw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "gfS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -16835,13 +16798,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"ghN" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
+"ggH" = (
+/obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gio" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"gje" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "gkE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16892,14 +16876,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"gmB" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = 24
+"gmt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "gmE" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -16994,6 +16979,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"gpf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "gpX" = (
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -17070,15 +17064,6 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"gtu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "gtA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4
@@ -17177,15 +17162,14 @@
 "gwh" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/AIsatextAS)
-"gwA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"gwo" = (
+/obj/machinery/light,
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
-/area/science/xenobiology)
+/area/hallway/secondary/exit/departure_lounge)
 "gxb" = (
 /obj/machinery/camera{
 	c_tag = "Bridge External Access";
@@ -17240,6 +17224,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"gzh" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gzp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -17261,6 +17252,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"gzK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile,
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gzO" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/tile/green{
@@ -17318,6 +17325,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"gAS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gBa" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/camera/autoname{
@@ -17401,6 +17421,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/AIsatextAS)
+"gDq" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "gDC" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room";
@@ -17465,6 +17495,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"gFf" = (
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gFk" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -17487,6 +17526,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"gGq" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gGB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17534,6 +17582,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"gHT" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gIw" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/sunglasses{
@@ -17628,6 +17685,30 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/crew_quarters/locker)
+"gOj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/landmark/observer_start,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gOI" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -17792,11 +17873,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"gUT" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "gUX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1;
@@ -17813,17 +17889,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"gVR" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "gWh" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -17910,6 +17975,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"gYh" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "gYo" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
@@ -17962,6 +18039,16 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"hbg" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "hcp" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 4;
@@ -18000,6 +18087,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"hey" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Eng";
+	location = "AftH"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "heF" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -18034,6 +18132,15 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"hgp" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "hgu" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -18170,6 +18277,32 @@
 /obj/item/storage/lockbox/medal,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"hkO" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/directions/security{
+	pixel_x = 32;
+	pixel_y = -3
+	},
+/obj/structure/sign/directions/science{
+	pixel_x = 32;
+	pixel_y = -9
+	},
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 9
+	},
+/obj/structure/sign/directions/command{
+	pixel_x = 32;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "hlE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -18235,6 +18368,37 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"hpG" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window{
+	dir = 1;
+	icon_state = "rightsecure";
+	name = "Science EVA";
+	req_access_txt = "47"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
+"hqt" = (
+/obj/structure/table,
+/obj/item/storage/crayons,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "hqS" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -18268,6 +18432,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hrn" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "hrt" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -18276,6 +18451,19 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"hrz" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "hrV" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -18284,13 +18472,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/bridge)
-"hsD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "hsU" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -18307,6 +18488,14 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
+"hty" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "htD" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -18346,6 +18535,16 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"hvi" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "hvo" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
@@ -18358,6 +18557,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"hvH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "hvR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -18372,13 +18580,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"hwE" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=QM";
-	location = "Cent"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "hwG" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -18434,13 +18635,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"hxc" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "hxo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -18450,28 +18644,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"hxC" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay Cryogenics";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/plasteel,
-/area/medical/medbay/central)
 "hyb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8;
@@ -18490,6 +18662,13 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"hyo" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hyL" = (
 /obj/item/radio/intercom{
 	pixel_y = 26
@@ -18505,19 +18684,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
-"hzj" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "hzp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18595,6 +18761,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"hAq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "hAF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -18621,16 +18794,6 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
-"hBA" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "hBP" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -18696,6 +18859,19 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
+"hDP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hDS" = (
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
@@ -18706,6 +18882,13 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"hEL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "hES" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
@@ -18769,6 +18952,13 @@
 "hJZ" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
+"hKn" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hKB" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Long-Term Cell 1";
@@ -18809,13 +18999,8 @@
 /obj/machinery/microwave,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"hMN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
+"hLN" = (
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "hNj" = (
@@ -18834,6 +19019,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"hOf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "hOE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18887,6 +19081,20 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"hQe" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "hRh" = (
 /obj/item/analyzer{
 	pixel_x = 7;
@@ -18908,6 +19116,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"hRM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "hRV" = (
 /obj/structure/closet{
 	name = "Evidence Closet 5"
@@ -18939,13 +19158,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"hSZ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+"hSU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/machinery/vending/snack/random,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/central)
 "hTL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -18968,6 +19190,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"hUz" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"hUO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "hUQ" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -19035,6 +19281,29 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
+"hZr" = (
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "hZz" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Warehouse Maintenance";
@@ -19134,6 +19403,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"idj" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"idF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "idP" = (
 /obj/machinery/button/door{
 	id = "commissaryshutter";
@@ -19151,19 +19434,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"iep" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window{
-	dir = 1;
-	icon_state = "rightsecure";
-	name = "Engineering EVA";
-	req_one_access_txt = "11;24"
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
 "iex" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -19197,19 +19467,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"ifW" = (
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "ige" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
@@ -19265,6 +19522,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"igM" = (
+/obj/machinery/vending/snack/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "igS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19280,6 +19548,27 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
+"ihd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ihH" = (
 /obj/machinery/airalarm/directional/north{
 	pixel_y = 24
@@ -19391,6 +19680,19 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
+"inv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "inG" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/item/radio/intercom{
@@ -19398,6 +19700,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"ioO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "ipl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -19455,6 +19775,16 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"irf" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "irp" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/machinery/camera/autoname,
@@ -19482,22 +19812,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"isi" = (
-/obj/machinery/door/airlock/command{
-	name = "Gateway Access";
-	req_access_txt = "62"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "isA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -19530,6 +19844,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"ivj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "ivp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -19556,18 +19882,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"iwD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "iwE" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -19650,16 +19964,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing/chamber)
-"iyZ" = (
-/obj/machinery/door/firedoor/border_only{
+"iyI" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "izj" = (
@@ -19797,12 +20110,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tech)
-"iFb" = (
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "iFf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/power/apc/auto_name/north{
@@ -19860,6 +20167,22 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"iHn" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology South";
+	dir = 4;
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "iHo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19990,12 +20313,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"iJq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+"iIV" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"iJk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "iJA" = (
@@ -20020,6 +20348,24 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"iJL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "iKg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20041,30 +20387,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"iKk" = (
-/obj/machinery/light{
+"iKK" = (
+/obj/machinery/computer/shuttle/mining/common{
 	dir = 8
 	},
-/obj/structure/noticeboard{
-	pixel_x = -32
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/secondary/entry)
 "iLg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
-"iLo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "iMl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -20171,12 +20511,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
-"iQT" = (
-/obj/item/radio/intercom{
-	pixel_x = -28
+"iQe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/xenobiology)
+/area/hallway/primary/fore)
 "iRe" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -20299,6 +20647,14 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"iWd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "iXd" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -20326,13 +20682,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"iYp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+"iXX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "iYV" = (
@@ -20444,16 +20798,19 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"jdo" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "jdJ" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel,
 /area/janitor)
+"jdZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jem" = (
 /obj/item/assembly/timer{
 	pixel_x = 5;
@@ -20577,6 +20934,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/AIsatextAS)
+"jgA" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"jgG" = (
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jgR" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -20659,10 +21036,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"jiN" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "jiT" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"jiY" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "jji" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -20670,6 +21064,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
+"jjp" = (
+/obj/machinery/vending/snack/random,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jju" = (
 /obj/machinery/camera/autoname,
 /obj/structure/disposalpipe/segment{
@@ -20695,6 +21103,18 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"jlp" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jlt" = (
 /obj/machinery/airalarm/directional/north{
 	pixel_y = 24
@@ -20818,12 +21238,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"joZ" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "jpj" = (
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -20837,24 +21251,6 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
-"jqd" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jqm" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -20945,6 +21341,16 @@
 "jst" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"jti" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "juE" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;25;46"
@@ -21050,20 +21456,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"jya" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"jyb" = (
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "jyk" = (
 /obj/machinery/light{
 	dir = 1
@@ -21094,6 +21486,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"jzf" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jzX" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -21103,47 +21501,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"jAP" = (
-/obj/effect/turf_decal/tile/blue{
+"jAX" = (
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"jAR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"jBP" = (
-/obj/machinery/vending/engivend,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/engine_room)
-"jCK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
+/area/hallway/primary/fore)
+"jBd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/area/hallway/secondary/entry)
 "jCL" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -21154,6 +21537,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"jDX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "jEa" = (
 /obj/machinery/reagentgrinder,
 /obj/effect/turf_decal/tile/yellow{
@@ -21206,6 +21597,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"jFx" = (
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jGi" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
@@ -21317,6 +21717,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"jKJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "jKL" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -21336,13 +21756,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"jKS" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = 24
+"jLj" = (
+/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/secondary/entry)
 "jMz" = (
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/plasteel,
@@ -21413,6 +21839,12 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
+"jPL" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "jQd" = (
 /obj/machinery/airalarm/directional/north{
 	pixel_y = 24
@@ -21576,6 +22008,27 @@
 /obj/structure/chair/wood/wings,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
+"jVF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "jVY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -21618,34 +22071,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"jXx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jXB" = (
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"jYf" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "jYp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -21809,6 +22245,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"kaZ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "kbs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -21819,6 +22262,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"kbz" = (
+/obj/item/kirbyplants/random,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "kbB" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -21838,12 +22288,34 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"kdc" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+"kcx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
+"kcJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "kdn" = (
 /obj/machinery/airalarm/directional/east{
 	pixel_x = 24
@@ -21895,27 +22367,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"kgp" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/spawner/xmastree,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "kgx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -22000,15 +22451,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"kmo" = (
-/obj/machinery/light{
-	dir = 8
-	},
+"klv" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/science/research)
+/area/hallway/secondary/entry)
 "kmQ" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
@@ -22035,20 +22486,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
-"knP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "knX" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -22096,6 +22533,23 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"koZ" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"kpv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "kpF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22154,13 +22608,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"ktZ" = (
-/obj/machinery/door/firedoor/border_only{
+"ktV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/central)
 "kun" = (
 /obj/structure/table,
 /obj/item/grenade/chem_grenade/cleaner,
@@ -22279,18 +22746,15 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/main)
-"kzO" = (
-/obj/machinery/door/firedoor/border_only{
+"kzJ" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/science/xenobiology)
 "kAX" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -22374,9 +22838,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"kFB" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+"kFg" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -22402,13 +22872,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"kJZ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "kKt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -22433,6 +22896,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"kLC" = (
+/obj/machinery/vending/snack/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "kLQ" = (
 /obj/machinery/computer/rdconsole/core,
 /obj/effect/turf_decal/tile/purple{
@@ -22443,6 +22917,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"kMy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "kMH" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -22483,13 +22966,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"kOd" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Eng";
-	location = "AftH"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "kOj" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/tile/brown{
@@ -22499,6 +22975,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"kOB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kPb" = (
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel,
@@ -22538,10 +23023,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"kQj" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "kQs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -22578,6 +23059,12 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"kRX" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "kSb" = (
 /turf/open/floor/plasteel,
 /area/escapepodbay)
@@ -22764,19 +23251,6 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"kVh" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "kVn" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
@@ -22829,18 +23303,6 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
-"kXW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "kYq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -22989,6 +23451,18 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"lbH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "lbK" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
@@ -23035,6 +23509,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"ldk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	sortType = 22
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ldT" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Control Room";
@@ -23106,10 +23602,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"lgm" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lgo" = (
 /obj/machinery/telecomms/server/presets/science,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"lgL" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Sec";
+	location = "Bar2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lgM" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Server Room";
@@ -23144,6 +23668,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"lhb" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "lhc" = (
 /obj/machinery/sleeper{
 	dir = 1;
@@ -23235,19 +23769,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"lkS" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "llb" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint";
@@ -23316,6 +23837,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"lpJ" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "lqq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -23419,14 +23946,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"lsd" = (
-/obj/machinery/light,
-/obj/item/kirbyplants/random,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "lsf" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -23454,6 +23973,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"ltO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "luI" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
@@ -23475,13 +24003,6 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/shutters,
 /turf/open/floor/plating,
 /area/engine/engine_room)
-"lvo" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lwd" = (
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/camera/autoname{
@@ -23503,14 +24024,6 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"lxC" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Burnchamber bypas"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "lyp" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -23554,6 +24067,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
+"lAj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lAS" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -23626,16 +24147,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"lCL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "lDd" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -23668,6 +24179,15 @@
 "lEO" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"lFa" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "lFd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -23716,13 +24236,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"lHH" = (
-/obj/structure/chair,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "lHU" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -23730,6 +24243,21 @@
 "lIC" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"lJw" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "lJR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -23775,6 +24303,15 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/fitness/recreation)
+"lKT" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "lKX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -23900,12 +24437,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"lOj" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "lOO" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -23916,6 +24447,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"lPi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "lPO" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -23930,22 +24473,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"lRA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"lPR" = (
+/obj/machinery/light,
+/obj/item/kirbyplants/random,
+/obj/item/radio/intercom{
+	pixel_y = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Cha";
-	location = "Bar"
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/secondary/entry)
 "lRJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -24002,6 +24541,22 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
+"lTc" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lTg" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm2";
@@ -24149,22 +24704,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"lYU" = (
-/obj/effect/turf_decal/tile/green,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lZo" = (
 /obj/machinery/door/airlock/external{
 	name = "Bridge External Access";
@@ -24228,16 +24767,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"mbK" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "mbY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -24260,32 +24789,37 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
-"mem" = (
-/obj/machinery/camera{
-	c_tag = "Research Division East";
-	network = list("ss13","rd")
+"meP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/item/kirbyplants/random,
+/obj/structure/sign/directions/vault{
+	dir = 8;
+	pixel_x = -32;
+	pixel_y = -9
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
+/obj/structure/sign/directions/supply{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = -3
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = 3
+	},
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/research)
-"mfi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/primary/aft)
 "mfE" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 1
@@ -24314,6 +24848,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"mgq" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east{
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile,
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mgu" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -24354,6 +24901,20 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"miG" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "miR" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -24475,6 +25036,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"mom" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "mop" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -24493,6 +25069,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/lobby)
+"mpk" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "mpv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/disposalpipe/segment{
@@ -24535,9 +25128,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"mqW" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
+"mrj" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -24583,6 +25182,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"msD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile,
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mtY" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
@@ -24663,11 +25273,42 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"mvY" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/item/radio/headset/headset_medsci,
+/obj/item/storage/pill_bottle/mutadone,
+/obj/item/storage/box/rxglasses,
+/obj/item/storage/box/disks{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/machinery/requests_console{
+	department = "Genetics";
+	name = "Genetics Requests Console";
+	pixel_y = 30
+	},
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "mwb" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"mwh" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/security/telescreen/research{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "mww" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -24760,11 +25401,57 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"mzs" = (
-/obj/machinery/camera/autoname,
-/obj/structure/chair,
+"myD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/sign/directions/vault{
+	pixel_x = -32;
+	pixel_y = -9
+	},
+/obj/structure/sign/directions/supply{
+	pixel_x = -32;
+	pixel_y = -3
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_x = -32;
+	pixel_y = 3
+	},
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/area/hallway/primary/central)
+"myM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Sci";
+	location = "Ari"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"mzf" = (
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "mzT" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -24794,6 +25481,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
+"mAU" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mBq" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Stage";
@@ -24808,6 +25501,41 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"mBJ" = (
+/obj/machinery/light,
+/obj/machinery/suit_storage_unit/cmo{
+	suit_type = /obj/item/clothing/suit/space/hardsuit/medical
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window{
+	dir = 1;
+	icon_state = "rightsecure";
+	name = "Medbay EVA";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
+"mCu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/science/research)
 "mCM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -24993,16 +25721,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"mKS" = (
-/obj/machinery/door/firedoor/border_only,
+"mKZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -25078,6 +25806,19 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/fitness/recreation)
+"mNs" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/vending/snack/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "mNI" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -25176,15 +25917,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"mRq" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "mSk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -25251,19 +25983,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"mUD" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "mUQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -25324,6 +26043,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"mWQ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mWT" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -25331,29 +26062,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"mWY" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/sign/directions/security{
-	pixel_x = 32;
-	pixel_y = -3
-	},
-/obj/structure/sign/directions/science{
-	pixel_x = 32;
-	pixel_y = -9
-	},
-/obj/structure/sign/directions/evac{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = 9
-	},
-/obj/structure/sign/directions/command{
-	pixel_x = 32;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "mXu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -25379,6 +26087,49 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"mYm" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
+"mYX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"mYY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mZc" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/camera/autoname{
@@ -25404,6 +26155,20 @@
 	},
 /turf/open/floor/grass,
 /area/crew_quarters/bar)
+"naj" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "nal" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -25451,6 +26216,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/security/processing)
+"nbD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "nca" = (
 /obj/machinery/computer/card{
 	dir = 1
@@ -25501,6 +26273,47 @@
 /obj/structure/window/spawner/east,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"ndn" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"ndp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ngo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ngr" = (
 /obj/machinery/biogenerator,
 /obj/machinery/door/firedoor/border_only{
@@ -25604,6 +26417,16 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/solar/starboard/fore)
+"nkR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nlw" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
@@ -25662,6 +26485,22 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"nlN" = (
+/obj/machinery/door/airlock/command{
+	name = "Gateway Access";
+	req_access_txt = "62"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "nlR" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -25754,6 +26593,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"nnm" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "nnr" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -25777,6 +26620,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"nnt" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "nnz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -25836,6 +26691,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"noy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "noA" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -25870,6 +26731,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"npQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "npV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -25934,24 +26815,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"ntQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "nug" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4;
@@ -25959,6 +26822,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"nus" = (
+/obj/machinery/suit_storage_unit/atmos,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window{
+	dir = 1;
+	icon_state = "rightsecure";
+	name = "Atmospherics EVA";
+	req_one_access_txt = "11;24"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "nuB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25974,6 +26860,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"nuD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "nuQ" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -26015,16 +26913,6 @@
 /obj/item/seeds/sunflower/moonflower,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"nvy" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "nvJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -26109,13 +26997,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"nxh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "nxn" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = 0;
@@ -26138,31 +27019,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"nxN" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/sign/directions/vault{
-	pixel_x = -32;
-	pixel_y = -9
-	},
-/obj/structure/sign/directions/supply{
-	pixel_x = -32;
-	pixel_y = -3
-	},
-/obj/structure/sign/directions/engineering{
-	pixel_x = -32;
-	pixel_y = 3
-	},
-/obj/structure/sign/directions/medical{
-	pixel_x = -32;
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "nxV" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -26220,6 +27076,15 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engine_room)
+"nzd" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "nze" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -26369,6 +27234,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"nBN" = (
+/obj/machinery/camera{
+	c_tag = "Toxins Launch Room Access"
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "nBU" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room";
@@ -26394,6 +27276,20 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engine_room)
+"nCa" = (
+/obj/structure/closet/emcloset,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "nCp" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -26446,25 +27342,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"nES" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/item/radio/headset/headset_medsci,
-/obj/item/storage/pill_bottle/mutadone,
-/obj/item/storage/box/rxglasses,
-/obj/item/storage/box/disks{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/machinery/requests_console{
-	department = "Genetics";
-	name = "Genetics Requests Console";
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "nFO" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -26777,6 +27654,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"nRy" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "nRH" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
@@ -26798,6 +27684,35 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nSg" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"nTr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "nTx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26847,6 +27762,22 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"nVm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nVp" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -26873,6 +27804,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nVT" = (
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"nVV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nWB" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Telecommunications";
@@ -27068,6 +28018,28 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"obO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Cha";
+	location = "Bar"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "obU" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -27184,6 +28156,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"ofM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "ofV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27268,6 +28246,22 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
+"ohV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ojm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -27487,6 +28481,46 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"ooh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"opk" = (
+/obj/structure/table,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel,
+/area/engine/lobby)
 "opl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "hosspace";
@@ -27509,6 +28543,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"oqu" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "oqL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -27530,6 +28571,13 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"osl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "osO" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -27547,6 +28595,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"ovw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ovD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -27623,6 +28690,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"oxz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oxE" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -27655,6 +28745,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"ozF" = (
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "oAa" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -27689,6 +28783,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"oBT" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"oBZ" = (
+/obj/machinery/light,
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "oCt" = (
 /obj/machinery/power/apc/auto_name/east{
 	pixel_x = 24
@@ -27808,6 +28922,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/lobby)
+"oEF" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "oEM" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -27872,6 +28997,15 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/head_of_personnel)
+"oHr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "oIN" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -27970,15 +29104,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"oLM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "oMm" = (
 /obj/machinery/shower{
 	dir = 8
@@ -28013,6 +29138,24 @@
 /obj/effect/landmark/start/head_of_personnel,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/head_of_personnel)
+"oML" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "oNv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -28041,13 +29184,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"oPw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
+"oPb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"oPA" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 24
 	},
-/turf/open/floor/plating,
-/area/engine/engine_smes)
+/obj/effect/turf_decal/tile,
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oPP" = (
 /obj/structure/transit_tube/crossing{
 	dir = 4
@@ -28079,6 +29232,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
+"oTu" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "oTA" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -28107,13 +29267,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"oUj" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Sec";
-	location = "Bar2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "oUA" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -28137,15 +29290,17 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/medical/medbay/lobby)
-"oVY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
+"oVP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/area/hallway/secondary/entry)
 "oWk" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -28208,27 +29363,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"oZo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "oZp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28244,15 +29378,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"oZB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "pay" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Airlock"
@@ -28326,16 +29451,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
-"pcY" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "pdD" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/sec/surgery{
@@ -28398,6 +29513,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"pfD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pgm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -28409,6 +29537,21 @@
 /obj/effect/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"pgV" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"phg" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "phw" = (
 /obj/machinery/light{
 	dir = 8
@@ -28455,6 +29598,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"piA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "piF" = (
 /obj/docking_port/stationary/random{
 	dir = 2;
@@ -28680,19 +29839,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"pmy" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "pmD" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -28717,6 +29863,12 @@
 	},
 /turf/open/floor/plating,
 /area/medical/pharmacy)
+"poS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "poU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28757,6 +29909,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tech)
+"prp" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "prN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -28771,11 +29929,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/grass,
 /area/hallway/primary/aft)
-"psq" = (
-/obj/machinery/light,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "psF" = (
 /obj/machinery/computer/operating{
 	dir = 8;
@@ -28863,6 +30016,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"puc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "pvF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -28887,12 +30049,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"pvO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "pvR" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -28932,6 +30088,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"pxZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"pyF" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "pzF" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -28969,24 +30148,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"pBB" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "pBQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29071,31 +30232,6 @@
 /obj/item/storage/crayons,
 /turf/open/floor/wood,
 /area/library)
-"pFC" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/sign/directions/vault{
-	pixel_x = -32;
-	pixel_y = -9
-	},
-/obj/structure/sign/directions/supply{
-	pixel_x = -32;
-	pixel_y = -3
-	},
-/obj/structure/sign/directions/engineering{
-	dir = 8;
-	pixel_x = -32;
-	pixel_y = 3
-	},
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "pFQ" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -29191,6 +30327,15 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"pHV" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "pHY" = (
 /obj/effect/landmark/start/geneticist,
 /turf/open/floor/plasteel/white,
@@ -29309,6 +30454,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"pKJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "pMb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -29546,6 +30700,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"pUk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"pUn" = (
+/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "pUp" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
@@ -29576,6 +30756,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"pVt" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "pVT" = (
 /obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
@@ -29614,20 +30806,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"pYs" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/landmark/observer_start,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "pYF" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -29694,6 +30872,21 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/visible,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"qac" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "qax" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -29792,11 +30985,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "qdr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/vending/engivend,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/area/engine/engine_room)
 "qdt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -29870,6 +31062,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"qhu" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qhY" = (
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/dark,
@@ -30035,19 +31234,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"qok" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "qoz" = (
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
@@ -30142,14 +31328,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"qqR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "qrb" = (
 /obj/machinery/computer/card{
 	dir = 1
@@ -30225,15 +31403,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"qtA" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4
+"qtG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 6
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/engine_room)
+/area/hallway/primary/aft)
+"qtI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qtR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -30266,6 +31453,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"qvA" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "qvP" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
@@ -30274,6 +31467,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"qwr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qxD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/rnd,
@@ -30296,12 +31501,29 @@
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"qBh" = (
-/obj/machinery/light{
+"qyB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/hallway/secondary/entry)
+"qAg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qBL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30340,13 +31562,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
-"qCq" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "qDa" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -30426,18 +31641,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
-"qHo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "qHA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -30473,12 +31676,9 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"qJx" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
+"qJF" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -30631,6 +31831,24 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"qOY" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"qPd" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qPz" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
@@ -30644,24 +31862,26 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"qPP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"qPS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/fore)
 "qQu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30733,6 +31953,37 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"qRA" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"qSm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "qSC" = (
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/plasteel/dark,
@@ -31140,6 +32391,18 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"rhL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "rif" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/light{
@@ -31185,6 +32448,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rjx" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay Cryogenics";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "rjR" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint";
@@ -31236,6 +32521,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"rlI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"rlR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "rmN" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maint Bar Access";
@@ -31259,6 +32565,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"rnI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "rnV" = (
 /obj/effect/mob_spawn/human/skeleton,
 /turf/open/floor/plating,
@@ -31278,6 +32606,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"rpg" = (
+/obj/machinery/vending/cola/random,
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rpo" = (
 /obj/structure/chair{
 	dir = 4;
@@ -31300,15 +32638,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/library)
-"rqp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "rqS" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -31360,12 +32689,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"rrR" = (
-/obj/machinery/computer/shuttle/mining/common{
-	dir = 8
+"rsv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/central)
 "rsC" = (
 /obj/machinery/computer/slot_machine,
 /obj/machinery/light/small{
@@ -31399,22 +32732,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"run" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 22
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ruq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31483,6 +32800,40 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"rwg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/structure/sign/directions/vault{
+	pixel_x = -32;
+	pixel_y = -9
+	},
+/obj/structure/sign/directions/supply{
+	pixel_x = -32;
+	pixel_y = -3
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = 3
+	},
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rwW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -31563,10 +32914,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"ryi" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel,
-/area/science/research)
 "rys" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -31611,6 +32958,19 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"rAK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "rAO" = (
 /obj/machinery/camera{
 	c_tag = "Brig Central";
@@ -31653,6 +33013,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"rBi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rBl" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -31758,6 +33131,36 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"rDS" = (
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"rEt" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/spawner/xmastree,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "rEy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/tile/blue{
@@ -31785,6 +33188,20 @@
 /obj/structure/closet/secure_closet/lieutenant,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"rFd" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "rFe" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -31797,43 +33214,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"rFP" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/structure/sign/directions/security{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = -3
-	},
-/obj/structure/sign/directions/science{
-	pixel_x = 32;
-	pixel_y = -9
-	},
-/obj/structure/sign/directions/command{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = 3
-	},
-/obj/structure/sign/directions/evac{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rGk" = (
-/obj/machinery/camera{
-	c_tag = "Toxins Launch Room Access"
-	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel,
-/area/science/research)
 "rGT" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -31864,14 +33244,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"rHC" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "rJf" = (
 /obj/structure/table,
 /obj/item/retractor,
@@ -31916,22 +33288,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"rME" = (
-/obj/structure/table,
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/lobby)
 "rMJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 1
@@ -31976,6 +33332,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"rPa" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rPg" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rPk" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -32055,6 +33437,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"rQB" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rRh" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -32064,6 +33455,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/education)
+"rSc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "rSz" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32117,13 +33524,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"rVI" = (
-/obj/machinery/camera{
-	c_tag = "Gateway"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
-/area/gateway)
 "rVY" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -32301,6 +33701,15 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"sbB" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "sbE" = (
 /obj/machinery/light{
 	dir = 4
@@ -32354,6 +33763,28 @@
 /obj/item/circuitboard/machine/stasis,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"set" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "seD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8;
@@ -32406,6 +33837,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"seO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "seT" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -32418,6 +33856,21 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"sfm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sfr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32442,6 +33895,16 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
+"shU" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sio" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -32545,12 +34008,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"soG" = (
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "soU" = (
 /obj/structure/table,
 /obj/machinery/power/apc/auto_name/south{
@@ -32575,6 +34032,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"spq" = (
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "sps" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
@@ -32591,10 +34057,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"spt" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "spU" = (
 /obj/machinery/button/door{
 	id = "ceprivacy";
@@ -32625,6 +34087,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"sqA" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "sqG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -32684,6 +34159,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"stj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "stq" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8
@@ -32705,6 +34186,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"suy" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "svc" = (
 /obj/item/reagent_containers/blood,
 /obj/machinery/iv_drip,
@@ -32877,6 +34367,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"sDt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "sEp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -32913,6 +34412,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"sFX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sGu" = (
 /obj/machinery/button/ignition/incinerator{
 	id = "TEG_igniter";
@@ -33069,6 +34576,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"sLE" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "sLK" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/structure/extinguisher_cabinet{
@@ -33110,30 +34628,17 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/medical)
-"sNX" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "sOj" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"sOm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Vlt";
-	location = "QM"
+"sOn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/engine/engine_smes)
 "sON" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -33161,6 +34666,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"sPc" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/science/research)
 "sPh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -33211,6 +34727,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"sQD" = (
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "sQF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/cargo_technician,
@@ -33253,6 +34779,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"sTi" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "sTl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -33300,6 +34835,15 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
+"sTy" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "sTA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -33464,6 +35008,13 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"tac" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "tah" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/blue{
@@ -33527,13 +35078,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"tdl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "tdY" = (
 /obj/machinery/photocopier,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -33751,6 +35295,16 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"tfX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tgg" = (
 /obj/item/beacon,
 /turf/open/floor/plasteel,
@@ -33879,6 +35433,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"tkg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"tky" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "tkC" = (
 /obj/machinery/door/airlock/maintenance{
 	id_tag = "commissarydoor";
@@ -33997,6 +35583,19 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/solar/starboard/fore)
+"tos" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "toz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -34004,12 +35603,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"tpd" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "tpf" = (
 /obj/machinery/light{
 	dir = 8
@@ -34081,12 +35674,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tech)
-"tsZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "tum" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/r_wall,
@@ -34126,15 +35713,6 @@
 	dir = 4
 	},
 /area/chapel/main)
-"two" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "twt" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -34162,9 +35740,25 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "tyF" = (
-/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/area/hallway/primary/aft)
 "tyQ" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
@@ -34220,17 +35814,6 @@
 /obj/effect/landmark/start/chief_medical_officer,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"tBt" = (
-/obj/machinery/camera{
-	c_tag = "Security Post - Science";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science)
 "tBK" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/red{
@@ -34248,17 +35831,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"tCe" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "tCT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
-"tDt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "tDu" = (
 /turf/open/floor/carpet,
 /area/chapel/main)
@@ -34311,6 +35895,16 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"tGB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tGC" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -34359,13 +35953,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"tLj" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "tLv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -34382,6 +35969,15 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"tNa" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tNz" = (
 /obj/machinery/computer/monitor{
 	dir = 4;
@@ -34416,26 +36012,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"tPe" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"tQo" = (
+"tPF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "tQr" = (
@@ -34499,15 +36085,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"tRj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "tRx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -34586,6 +36163,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
+"tSy" = (
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "tSE" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
@@ -34669,10 +36253,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"tUt" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
+"tUq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/aft)
 "tUz" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -34729,6 +36320,19 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"tWe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tWf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/atmos{
@@ -34796,6 +36400,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tZl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"tZG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tZW" = (
 /obj/machinery/vending/cart,
 /obj/machinery/light{
@@ -34838,6 +36465,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"ubI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ucf" = (
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
@@ -34860,6 +36500,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"udK" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uec" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35003,6 +36650,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"ufs" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "ufC" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
@@ -35024,15 +36680,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload)
-"ufL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "uge" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -35046,27 +36693,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"ugE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"ugF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ugQ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -35175,6 +36801,16 @@
 	},
 /turf/open/floor/plating,
 /area/solar/starboard/fore)
+"ujt" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "ujC" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -35195,6 +36831,16 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/library)
+"ulO" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/science/research)
 "ulU" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -35329,6 +36975,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"upj" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "upL" = (
 /obj/machinery/rnd/production/protolathe/department/science,
 /obj/machinery/camera{
@@ -35370,21 +37027,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/science)
-"urR" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"urV" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "utg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -35435,15 +37077,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"uuh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"uul" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/engine/engine_room)
 "uuD" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -35454,6 +37097,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"uuQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uvh" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots{
@@ -35533,6 +37186,16 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"uxH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "uyI" = (
 /turf/closed/wall,
 /area/maintenance/disposal)
@@ -35568,12 +37231,44 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"uBk" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "uBr" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"uBK" = (
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "uBR" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -35612,6 +37307,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"uDX" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window{
+	dir = 1;
+	icon_state = "rightsecure";
+	name = "Engineering EVA";
+	req_one_access_txt = "11;24"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "uEq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -35668,6 +37386,15 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/storage/tech)
+"uFd" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "uFj" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -35714,6 +37441,38 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"uGv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/structure/sign/directions/security{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = -3
+	},
+/obj/structure/sign/directions/science{
+	pixel_x = 32;
+	pixel_y = -9
+	},
+/obj/structure/sign/directions/command{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = 3
+	},
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uGB" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -35744,19 +37503,6 @@
 "uHY" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
-"uIa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "uJg" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod"
@@ -35891,6 +37637,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"uNw" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "uNz" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8
@@ -35930,34 +37691,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"uNR" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/obj/structure/sign/directions/command{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = 3
-	},
-/obj/structure/sign/directions/evac{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = 9
-	},
-/obj/structure/sign/directions/science{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = -9
-	},
-/obj/structure/sign/directions/security{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "uOh" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east{
@@ -36139,6 +37872,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/AIsatextAS)
+"uUc" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "uUH" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 10
@@ -36207,6 +37944,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"uXz" = (
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"uXS" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=QM";
+	location = "Cent"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uYr" = (
 /turf/closed/wall,
 /area/maintenance/solars/port/aft)
@@ -36411,12 +38164,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"vbG" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "vbJ" = (
 /obj/structure/table,
 /obj/item/electropack,
@@ -36530,6 +38277,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"vds" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "vdZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -36642,6 +38398,10 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"vkI" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "vlL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4;
@@ -36649,6 +38409,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"vmB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/table,
+/obj/item/healthanalyzer,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "vmD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -36728,21 +38508,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"vou" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "voQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36839,34 +38604,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload)
-"vsf" = (
-/obj/machinery/light,
-/obj/machinery/suit_storage_unit/cmo{
-	suit_type = /obj/item/clothing/suit/space/hardsuit/medical
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window{
-	dir = 1;
-	icon_state = "rightsecure";
-	name = "Medbay EVA";
-	req_access_txt = "5"
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
-"vso" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "vsD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -37044,15 +38781,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"vxi" = (
-/obj/effect/turf_decal/tile/yellow{
+"vxD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Cooling bypas"
-	},
 /turf/open/floor/plasteel,
-/area/engine/engine_room)
+/area/hallway/secondary/entry)
 "vxG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -37132,16 +38872,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"vBo" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "vBs" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -37284,18 +39014,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"vHg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "vHn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -37313,6 +39031,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vIH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "vIJ" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/effect/turf_decal/tile/blue{
@@ -37386,19 +39116,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"vOG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vPa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -37421,6 +39138,18 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/solar/starboard/fore)
+"vRB" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "vRG" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/secure/briefcase,
@@ -37622,6 +39351,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"vZz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"vZB" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "vZE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -37654,6 +39397,13 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"wac" = (
+/obj/effect/turf_decal/tile,
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wad" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -37676,6 +39426,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"wbr" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "wbY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -37724,6 +39480,25 @@
 /obj/structure/window/spawner/west,
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/grass,
+/area/hallway/primary/central)
+"wcP" = (
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wdg" = (
 /obj/machinery/door/airlock/external{
@@ -37826,16 +39601,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"wju" = (
-/obj/effect/turf_decal/tile/yellow{
+"wjT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/secondary/entry)
 "wkg" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
@@ -37907,15 +39681,26 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"wlF" = (
-/obj/effect/turf_decal/tile/yellow{
+"wlM" = (
+/obj/machinery/camera{
+	c_tag = "Research Division East";
+	network = list("ss13","rd")
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/science/research)
 "wlQ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Desk";
@@ -37985,6 +39770,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wqo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "wqw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -38072,6 +39880,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"wtW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wuC" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 3";
@@ -38164,19 +39982,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"wxt" = (
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "wxN" = (
 /obj/machinery/door/airlock/external{
 	name = "MiniSat External Access";
@@ -38279,21 +40084,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
-"wBN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "wBX" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -38391,21 +40181,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"wEm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "wEs" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -38501,6 +40276,16 @@
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"wGc" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Vlt";
+	location = "QM"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "wGz" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
@@ -38538,6 +40323,13 @@
 /obj/item/crowbar/red,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"wGU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "wHe" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -38788,6 +40580,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"wOD" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wOQ" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/green{
@@ -38801,6 +40602,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"wPg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "wPn" = (
 /obj/machinery/light{
 	dir = 4
@@ -38809,13 +40622,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"wPq" = (
-/obj/structure/closet/emcloset,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "wPw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -38823,6 +40629,26 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"wQu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "wQA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -38920,6 +40746,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
+"wTE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"wTG" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "wUf" = (
 /obj/docking_port/stationary/random{
 	dir = 2;
@@ -38951,29 +40801,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"wVb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+"wVr" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/science/research)
 "wVW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -39011,16 +40850,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
-"wZY" = (
-/obj/structure/closet/secure_closet/exile,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "xaH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -39035,6 +40864,12 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
+"xbf" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "xbn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/external{
@@ -39048,6 +40883,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"xbr" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xbI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -39101,13 +40945,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"xcT" = (
-/obj/machinery/vending/snack/random,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "xdW" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
@@ -39152,13 +40989,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/lobby)
-"xeF" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Bar";
-	location = "Sci"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "xeJ" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -39178,6 +41008,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
+"xfh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xgL" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
@@ -39315,6 +41157,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xkq" = (
+/obj/structure/closet/secure_closet/exile,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
+"xku" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xlu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39367,32 +41236,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"xnT" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"xnU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "xnW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39414,15 +41257,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"xoU" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xoV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -39461,6 +41295,11 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"xqE" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xqU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39497,6 +41336,19 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/shutters,
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
+"xsj" = (
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "xsk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39527,6 +41379,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"xso" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "xsM" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -39564,6 +41429,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"xuB" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "xvc" = (
 /obj/structure/table/glass,
 /obj/item/storage/bag/trash,
@@ -39594,6 +41477,13 @@
 /obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"xwc" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xwK" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/tile/neutral,
@@ -39803,6 +41693,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"xCf" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xCi" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -39829,6 +41732,16 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"xCF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xDc" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -39938,15 +41851,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"xGF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "xHl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -39988,6 +41892,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"xIh" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/noticeboard{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "xIA" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -40031,6 +41947,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"xIZ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xJO" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -40074,12 +42000,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"xKP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "xLb" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -40106,9 +42026,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"xLf" = (
-/obj/item/radio/intercom{
-	pixel_x = -28
+"xLj" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -40157,6 +42080,15 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xMA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "xMB" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -40295,6 +42227,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"xQs" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "xQY" = (
 /obj/machinery/computer/cargo/request{
 	dir = 8
@@ -40353,13 +42291,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"xTT" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "xUb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -40376,6 +42307,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"xUd" = (
+/obj/machinery/light,
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"xUi" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xUl" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 1
@@ -40425,10 +42369,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xXj" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "xYs" = (
 /obj/machinery/telecomms/server/presets/medical,
 /obj/machinery/light{
@@ -40506,10 +42446,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ydD" = (
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "ydK" = (
 /obj/structure/displaycase/captain,
 /obj/item/radio/intercom{
@@ -40517,6 +42453,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"yed" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "yeR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -40524,10 +42472,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"yeW" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "yeY" = (
 /obj/effect/turf_decal/tile/green,
 /obj/structure/sign/directions/security{
@@ -40613,6 +42557,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"ygQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/obj/structure/sign/directions/command{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = 3
+	},
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 9
+	},
+/obj/structure/sign/directions/science{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = -9
+	},
+/obj/structure/sign/directions/security{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "ygX" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 8
@@ -40706,6 +42679,16 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
+"yjB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "yjQ" = (
 /obj/machinery/door/airlock/research{
 	name = "Experimentation Lab";
@@ -50159,15 +52142,15 @@ wAA
 jyu
 szn
 nhY
-oPw
-pBB
-kXW
-vxi
-bEe
-esk
-jBP
+sOn
+pVt
+dwB
+dwB
+ivj
+ufs
+vds
 pmD
-hBA
+upj
 aax
 aaa
 aaa
@@ -50362,14 +52345,14 @@ aow
 apy
 isf
 vWo
-cWh
-fgr
+lFa
+kRX
 azf
 azf
 azf
 wvn
 nwS
-xgL
+qdr
 aax
 aaa
 aaa
@@ -51578,8 +53561,8 @@ dYV
 aso
 tgg
 aCA
-bjE
 aDa
+azf
 aDi
 cpD
 boi
@@ -51780,10 +53763,10 @@ lMA
 aso
 azf
 aCA
-bjE
 aDa
-qtA
-rHC
+azf
+aDi
+uul
 aax
 aaa
 aaa
@@ -51981,10 +53964,10 @@ aax
 nJH
 ast
 azf
-aCA
-lxC
-gVR
-lkS
+jEw
+xgL
+hvi
+gDq
 xmB
 aax
 aaa
@@ -53188,7 +55171,7 @@ ayU
 daW
 aRg
 viv
-rME
+opk
 fVm
 aAF
 pIb
@@ -54595,7 +56578,7 @@ cIa
 aco
 aco
 aco
-aKa
+aKx
 aDr
 fXx
 ePK
@@ -54989,7 +56972,7 @@ lie
 aAW
 jhe
 abM
-hxC
+rjx
 dzA
 abL
 vcb
@@ -55196,7 +57179,7 @@ atf
 abL
 aSc
 aco
-nES
+mvY
 gkE
 pHY
 nJw
@@ -55596,7 +57579,7 @@ tAU
 qKq
 abE
 arZ
-atR
+wbr
 aIw
 aEE
 aco
@@ -58031,7 +60014,7 @@ acy
 acy
 aKx
 aDr
-axH
+bDe
 aGN
 aGN
 aQF
@@ -58233,7 +60216,7 @@ xsM
 acy
 aKx
 aDr
-aUL
+jiY
 aGN
 hVB
 aHq
@@ -58292,14 +60275,14 @@ aaa
 aaa
 aaa
 aOa
-gUT
+cBk
 wAZ
-dRE
+rQB
 sKB
-sKB
+wOD
 mtY
-wAZ
-ghN
+fky
+miG
 xPw
 aaa
 aaa
@@ -58435,7 +60418,7 @@ aQw
 acy
 aMV
 aVq
-axH
+bDe
 aGN
 aGV
 aHq
@@ -58480,9 +60463,9 @@ aIm
 aIm
 aIm
 aIm
-xXj
+jLj
 yhb
-spt
+kLC
 aOa
 aaa
 aaa
@@ -58494,14 +60477,14 @@ aaa
 aaa
 aaa
 aOa
-tUt
+kaZ
 hvo
 xUl
 iUq
 xqh
 skF
 wAZ
-ghN
+iyI
 xPw
 aaa
 aaa
@@ -58637,7 +60620,7 @@ aUP
 acy
 mLp
 aeq
-gtu
+fTv
 aGN
 aGV
 aHe
@@ -58682,9 +60665,9 @@ aIm
 aIm
 aIm
 aIm
-aZN
+qOY
 yhb
-yeW
+xqE
 aOa
 aOa
 aOa
@@ -58696,14 +60679,14 @@ aOa
 aOa
 aOa
 aOa
-gfs
+sqA
 agb
 agb
 agb
 agb
 agb
 agb
-aQb
+eAK
 aOa
 aOa
 aOa
@@ -58839,7 +60822,7 @@ acR
 acR
 wev
 qHA
-aPl
+aUm
 aGN
 jML
 lUJ
@@ -58884,35 +60867,35 @@ aJj
 aJo
 aJt
 aIm
-jdo
+suy
 yhb
-aNn
-mqW
-joZ
-lCL
+fJf
+gFf
+xLj
+eTT
+uFd
+rlI
+noy
+rlI
+xLj
+rlI
 aSF
-agb
-agb
-agb
-joZ
-agb
-aSF
-agb
-agb
+oHr
+rlI
 agb
 aPC
 agb
 agb
 agb
 agb
-agb
-enP
-urR
-oLM
-agb
-aSF
-pvO
-agb
+noy
+feL
+kFg
+vxD
+noy
+vRB
+biv
+uxH
 aOa
 nzM
 pUp
@@ -58998,7 +60981,7 @@ uHY
 uvh
 kMT
 eyZ
-bRt
+nus
 akD
 uZE
 uZf
@@ -59041,7 +61024,7 @@ fOr
 dGE
 qTY
 lsI
-axH
+bDe
 aGN
 aHd
 aHe
@@ -59086,7 +61069,7 @@ aTH
 aJu
 aJu
 aJx
-agb
+ehq
 gfU
 aPw
 aPw
@@ -59200,7 +61183,7 @@ uHY
 iex
 rxX
 sYU
-iep
+uDX
 akD
 aum
 oIN
@@ -59243,7 +61226,7 @@ abW
 vcv
 axH
 aDr
-axH
+bDe
 aGN
 jQd
 aHe
@@ -59288,35 +61271,35 @@ nXu
 aJq
 aSx
 nMt
-ajS
+mYX
 wEM
-agb
-agb
-agb
-aPB
-pvO
-agb
-agb
-agb
-agb
-agb
-agb
-gfw
-cFu
-dze
-aPE
-iFb
-agb
-aVH
-agb
-aPE
-agb
-agb
-agb
-agb
-agb
-aPE
-xXj
+pyF
+idF
+pyF
+fxp
+tfX
+idF
+pyF
+idF
+pyF
+idF
+pyF
+nkR
+wjT
+iXX
+qAg
+oTu
+idF
+iJk
+idF
+bVe
+idF
+pyF
+idF
+pyF
+idF
+bVe
+aro
 aOa
 nzM
 pUp
@@ -59402,7 +61385,7 @@ uHY
 ueF
 uQi
 oOo
-vsf
+mBJ
 akD
 oMx
 bNa
@@ -59418,8 +61401,8 @@ awt
 awC
 eBo
 awb
-ifW
-wZY
+xsj
+xkq
 axg
 wTc
 axc
@@ -59445,7 +61428,7 @@ jiT
 chQ
 aKa
 aDr
-psq
+xUd
 aGN
 ckj
 aOy
@@ -59490,9 +61473,9 @@ aOh
 aWa
 dUE
 aJx
-dpB
+mrj
 bkD
-kzO
+blf
 aOa
 aOa
 aOa
@@ -59587,9 +61570,9 @@ loP
 bxv
 kLe
 mbq
-oVY
+ioO
 joi
-wPq
+nCa
 sZy
 aaa
 nMT
@@ -59604,7 +61587,7 @@ uHY
 akP
 hnU
 nlx
-anr
+hpG
 akD
 auo
 oHn
@@ -59620,8 +61603,8 @@ akT
 awD
 awJ
 awb
-rVI
-aLF
+cns
+lbH
 hSN
 awU
 axc
@@ -59647,7 +61630,7 @@ vWJ
 aTW
 aKx
 aDr
-tpd
+sbB
 aGN
 jGi
 aHe
@@ -59692,9 +61675,9 @@ aJn
 onx
 aJw
 aIm
-agb
+tNa
 vxG
-lsd
+lPR
 aOa
 aaa
 xPw
@@ -59789,9 +61772,9 @@ sZy
 sZy
 sZy
 aTu
-tyF
+ujt
 wVW
-bCs
+gwo
 aTu
 aaa
 nMT
@@ -59823,7 +61806,7 @@ awE
 awb
 awb
 awU
-vHg
+dye
 awU
 jcx
 axc
@@ -59849,7 +61832,7 @@ okQ
 aMQ
 mop
 aDr
-axH
+hAq
 aGN
 xwK
 wLn
@@ -59894,9 +61877,9 @@ aIm
 aIm
 aIm
 aIm
-agb
+mAU
 vxG
-eYh
+sTi
 aOa
 aaa
 xPw
@@ -59991,9 +61974,9 @@ aaa
 aaa
 aaa
 oOF
-lHH
+sQD
 nXv
-jCK
+tkg
 aTu
 lEA
 lEA
@@ -60025,7 +62008,7 @@ awb
 awb
 awb
 axc
-isi
+nlN
 wHf
 axc
 axc
@@ -60051,7 +62034,7 @@ aXa
 aUj
 aKa
 aDr
-axH
+uUc
 aGN
 aGN
 paJ
@@ -60096,9 +62079,9 @@ aIm
 aIm
 aIm
 aIm
-agb
+ehq
 vxG
-agb
+pyF
 xPw
 aaa
 aaa
@@ -60193,9 +62176,9 @@ aaa
 aaa
 aaa
 sZy
-mzs
+cnD
 qJt
-dbx
+oEF
 aTu
 aXx
 aXx
@@ -60206,7 +62189,7 @@ aOB
 aXx
 aZp
 aTF
-hSZ
+mNs
 mWN
 rrr
 wqw
@@ -60223,61 +62206,61 @@ ixh
 hBP
 jwl
 fXm
-vso
-mRq
+lJw
+pHV
 qMM
 wOj
-oZo
+jVF
 ufC
-iwD
-mKS
-run
-qJx
-nxN
-tRj
-jqd
-wlF
-aTn
-wju
-mUD
-arn
+wPg
+lTc
+ldk
+lgm
+aIt
+vIH
+gbL
+gHT
+jgG
+jti
+xCf
+prp
 arn
 xCn
-oNv
-nIk
-jAP
-oNv
-xCn
-oNv
 nvQ
-xCn
+nIk
+fYT
+nvQ
+nIk
+nvQ
+nvQ
+nIk
 oNv
 aZn
-aah
-pFC
+stj
+myD
 fBS
 vcZ
 tRx
-dLu
-pcY
-jss
+rPg
+inv
+vcZ
 vcZ
 nyq
 pIY
 sMr
 ykt
-aah
-nvy
-dCI
-aah
-aIB
-aah
-dhe
-iKk
-ugE
-dtr
-aqL
-bKV
+jss
+mKZ
+jFx
+jss
+shU
+jss
+rwg
+xIh
+nuD
+gmt
+bOv
+fTk
 pMb
 rBl
 rVY
@@ -60297,10 +62280,10 @@ aKY
 rLt
 mMx
 cpz
-dnf
-agb
+meP
+mAU
 vxG
-agb
+noy
 xPw
 aaa
 aaa
@@ -60395,79 +62378,79 @@ sZy
 sZy
 sZy
 aTu
-ctu
+gpf
 rkG
-aYZ
-rii
-aac
-aac
-qBh
-aac
-fYs
-vbG
-qBh
-aac
-ktZ
-aac
+chp
+bKQ
+ofM
+ofM
+gje
+ofM
+bOF
+sTy
+gje
+ofM
+hUz
+poS
 aac
 aac
 fxt
 aac
 aac
+hLN
+oqu
 aac
-aac
-aac
-aac
+oqu
 vDI
-qCq
-wBN
+ndn
+kcx
 nGh
 dox
-mfi
-iLo
-dox
-dox
-dox
-dox
-ntQ
-doo
-aac
-mbK
-dbq
-aah
-aah
+dGR
+iQe
+tac
+sDt
+kpv
+sDt
+jAX
+fFv
+oqu
+bZQ
+fwP
+hKn
+dgZ
 ayW
-ugF
+ubI
+gzh
+baU
+xIZ
+gzh
+jzf
 aah
-aah
+lAj
+xwc
+xwc
+cmU
+xwc
+xwc
+xwc
+hSU
+xwc
+hey
+fbX
+uXS
 tGC
+blS
+wad
+pfD
+wad
+raF
+nVV
 aah
-aah
-aah
-aHz
-aah
-aah
-tGC
-aah
-aah
-aah
-ayW
-aah
-kOd
-aZn
-hwE
-tGC
-avY
-aah
-aZn
-aah
-aah
-ayW
-aah
-avY
-aah
-tGC
-aah
+blS
+xMx
+cmU
+wad
 tQH
 lDd
 piu
@@ -60475,34 +62458,34 @@ kxO
 xko
 fpQ
 qQu
-qok
-ugE
-dtr
-aOT
+bxS
+rAK
+bBW
+hOf
 afR
+ozF
+erk
+tCe
+hOf
+ozF
+wGc
 afR
-kJZ
-aNR
-aOT
+hEL
+xbf
+ozF
+xbf
+hty
+xbf
 afR
-sOm
-afR
-aNW
-afR
-afR
-afR
-kJZ
-afR
-afR
-afR
-aNR
-afR
-afR
-afR
-kJZ
+ozF
+tUq
+ozF
+ozF
+ozF
+erk
 agb
 jVY
-agb
+gio
 xPw
 aaa
 aaa
@@ -60597,7 +62580,7 @@ dZX
 bxv
 vqv
 wdg
-qdr
+eBJ
 bwy
 qeS
 iNq
@@ -60616,60 +62599,60 @@ bhn
 pUJ
 bDO
 bDO
-bDO
+hUO
 dFK
 vbL
 bfL
 cHL
 ilG
-pmy
+bzP
 bDO
 bDO
-xnU
+qPS
 mMS
 vzz
 lqV
 xaH
-dAX
-wVb
-bDO
+qSm
+wqo
+bke
 mjz
 rYm
 uGI
 pen
-aWt
+ohV
 wCw
-vou
+pxZ
 vsD
 dYN
 wcN
 yfp
+hDP
 aZr
-aZr
-jya
-aWt
-aWt
+rPa
+npQ
+ktV
+eBT
+ktV
+ktV
+ktV
+cen
+oxz
+ktV
+gOj
+ndp
 xhl
-aWt
-aWt
-aWt
-hzj
-aWt
-aWt
-pYs
-aWt
-xhl
-aPQ
+xku
 aZY
 aHY
 aHR
 aPY
-aNm
+cOb
 aWt
-aJF
+ngo
 kKt
 iFn
-aZr
+bXo
 npV
 aYn
 aXh
@@ -60677,31 +62660,31 @@ htV
 kYV
 knJ
 aYn
-uIa
+tyF
 fMt
 iRM
-aUK
+rnI
 qff
-aWw
+nTr
 prN
 aBb
 boL
 aEJ
+piA
 aWw
-aWw
-aRp
+mpk
 aDl
 aBp
 adP
 aQr
+piA
 aWw
-aWw
-adb
+tky
 aik
 aJN
 aMY
 aYz
-knP
+wQu
 amn
 esB
 agb
@@ -60799,79 +62782,79 @@ sZy
 sZy
 sZy
 aTu
-tyF
+koZ
 hOJ
 uQP
 rii
-soG
-aac
-aaG
-aac
-aac
-aac
-aaG
-aac
-ktZ
-aac
-aac
-aac
+ewt
+vkI
+vZB
+vkI
+vkI
+vkI
+vZB
+vkI
+idj
+cSL
 aac
 aac
 aac
 aac
 aac
+bPk
+wTG
 aac
-aac
+wTG
 khy
-dpw
-oZB
+rSc
+yed
 tkd
 omS
-uuh
-dpw
-omS
-omS
-omS
-hMN
+ooh
+rSc
+xMA
+kMy
+csS
+lPi
 nmX
-aac
-aac
-mbK
-vOG
-erj
-aah
+jPL
+nRy
+eEL
+nVm
+sfm
+qJF
 aZn
+pgV
+qPd
+pgV
+rsv
+gGq
+uXz
 aah
-aah
-aah
+bgv
+kOB
+kOB
+qRA
+kOB
+kOB
+lgL
+obO
+kOB
+kOB
+cFy
+jss
 tGC
+stj
+jss
+uuQ
+jss
+stj
+wTE
 aah
-aah
-aah
-aZn
-aah
-aah
-tGC
-aah
-aah
-oUj
-lRA
-aah
-aah
-axq
-aah
-tGC
-aah
-aah
-axq
-aah
-aah
-aZn
-aah
-aah
-aah
-tGC
-aah
+stj
+kOB
+qRA
+jss
 wpK
 aaA
 jTn
@@ -60879,34 +62862,34 @@ ayD
 aeE
 qrb
 aaA
-tPe
-afR
-afR
-aOT
+uNw
+lKT
+phg
+qtG
 aNV
-xeF
-kJZ
-jyb
+cdE
+irf
+tSy
+xQs
+dzH
+xQs
 afR
+rlR
+xQs
+dzH
+xQs
+dZh
+xQs
 afR
-afR
-afR
-aQy
-afR
-afR
-afR
-kJZ
-afR
-afR
-jAR
-afR
-afR
-afR
-afR
-kJZ
+rhL
+dZU
+dGz
+dGz
+dGz
+jiN
 agb
-bKU
-agb
+myM
+gio
 xPw
 aaa
 aaa
@@ -61014,8 +62997,8 @@ aOL
 aOL
 aWr
 aSh
-kQj
-mWY
+pUn
+hkO
 acF
 acF
 txC
@@ -61026,55 +63009,55 @@ njh
 atU
 xOr
 mSY
-yfP
+jDX
 acF
 aac
-bzD
-cEI
-aft
+nbD
+dfx
+aVP
 mZc
 aft
 rif
-fVE
-aaG
-jKS
-mbK
-lYU
-wxt
+xso
+jYf
+bwt
+aHW
+wcP
+bDH
 yeY
 ezO
 afs
 afs
 afs
 lwd
-kdc
-anv
-lvo
-aZn
-xoU
-aah
-tGC
-aah
-aah
-aah
-aZn
-aah
-aah
-aah
-aah
-rFP
+hyo
+udK
+oPA
+gzK
+mgq
+wac
+msD
+wac
+wac
+wac
+gzK
+wac
+wac
+wac
+wac
+uGv
 raF
-gmB
-raF
-eVP
+jgA
+xwc
+xCF
 xMx
 xAn
-cFd
-wad
+sFX
+xMx
 mjB
 yfg
 rYw
-hsD
+tGB
 llb
 aeE
 aeE
@@ -61085,30 +63068,30 @@ xTo
 czE
 pIT
 aRb
-ajq
-ajq
-xnT
-ajq
-ajq
-aZm
-aQZ
+fSG
+fSG
+hrn
+fSG
+fSG
+cIF
+oBT
 iUk
 aWU
 aOp
-kVh
-ajq
-sNX
-ajq
-ajq
-aOT
-lOj
-aIj
-hxc
-afR
-uNR
-agb
+hQe
+fSG
+uBk
+mzf
+mzf
+vZz
+abY
+wGU
+cxS
+nnm
+ygQ
+idF
 dPI
-agb
+pyF
 xPw
 aaa
 aaa
@@ -61229,9 +63212,9 @@ api
 api
 api
 api
-tdl
+clt
 aac
-xTT
+nVT
 akC
 akC
 akC
@@ -61308,9 +63291,9 @@ aaf
 aaf
 aaf
 aaf
-agb
+rlI
 dPI
-agb
+noy
 xPw
 aaa
 aaa
@@ -61510,9 +63493,9 @@ aaf
 uvF
 wxP
 aaf
-agb
+idF
 dPI
-fqo
+xUi
 aOa
 aaa
 xPw
@@ -61712,9 +63695,9 @@ iwE
 nyD
 khW
 aaf
-agb
+pKJ
 dPI
-dli
+oBZ
 aOa
 aaa
 xPw
@@ -61914,9 +63897,9 @@ aaf
 riX
 omU
 aaf
-dpB
+mWQ
 eMy
-iyZ
+hrz
 aOa
 aOa
 aOa
@@ -62067,7 +64050,7 @@ ikE
 ikE
 ikE
 arS
-kgp
+rEt
 mSs
 aOs
 aOs
@@ -62116,22 +64099,22 @@ aaf
 cqL
 ajZ
 ugQ
-aTm
+ggH
 bNQ
-agb
-agb
-agb
-aPz
-fPK
-aSF
-agb
-agb
-eVO
-agb
-agb
-tsZ
-xKP
-spt
+noy
+rlI
+noy
+gAS
+tPF
+xbr
+noy
+rlI
+rpg
+rlI
+noy
+qwr
+puc
+igM
 xPw
 aaa
 aaa
@@ -62318,7 +64301,7 @@ aaf
 aaf
 aaf
 aaf
-urV
+spq
 piK
 adF
 aVL
@@ -62520,22 +64503,22 @@ qEj
 xZD
 vDm
 aaf
-aZN
-tQo
-kFB
-aNz
-iFb
-aPB
-aVH
-tLj
-agb
-agb
-iFb
-agb
-agb
-aVH
-qqR
-dNo
+dhH
+hRM
+cQZ
+eHn
+oTu
+qtI
+iJk
+fAu
+pyF
+idF
+oTu
+idF
+pyF
+fGC
+ltO
+elS
 xPw
 aaa
 aaa
@@ -62722,8 +64705,8 @@ xvc
 aaB
 aaB
 aaf
-agb
-caQ
+rlI
+xfh
 aOa
 aOa
 xPw
@@ -62924,8 +64907,8 @@ wQZ
 sdz
 jHf
 aaf
-agb
-caQ
+idF
+wtW
 aOa
 aaa
 aaa
@@ -63108,9 +65091,9 @@ aQk
 agp
 agp
 agp
-aWb
+fTH
 aTt
-aMp
+jKJ
 urs
 aUo
 aMD
@@ -63126,8 +65109,8 @@ dVA
 aaB
 lWj
 aaf
-agb
-xGF
+pKJ
+bjU
 tlD
 iqN
 dwj
@@ -63309,8 +65292,8 @@ rnV
 ydg
 agq
 tfm
-tBt
-agu
+fJy
+qvA
 ain
 ajh
 aih
@@ -63328,8 +65311,8 @@ atW
 vYF
 xnv
 aaf
-aZN
-iYp
+jlp
+qyB
 saj
 gDW
 lUS
@@ -63450,7 +65433,7 @@ xEF
 teS
 dBX
 biM
-jXx
+ihd
 dns
 lNP
 chJ
@@ -63510,9 +65493,9 @@ aAy
 arT
 jkP
 agq
-ahV
-aig
-cds
+sLE
+mwh
+rFd
 aio
 ais
 aih
@@ -63530,8 +65513,8 @@ aaf
 aaf
 crK
 aaf
-agb
-caQ
+pKJ
+mYY
 xPw
 xPw
 xPw
@@ -63732,8 +65715,8 @@ jTY
 aaB
 aaB
 gXm
-agb
-qHo
+rlI
+pUk
 aOa
 aaa
 aaa
@@ -63934,8 +65917,8 @@ aaB
 aaB
 aaB
 aaf
-dpB
-qPP
+mWQ
+ovw
 aOa
 aOa
 xPw
@@ -64136,22 +66119,22 @@ aaB
 aaB
 oHl
 aaf
-ydD
-caQ
-aSF
-agb
-agb
-agb
-agb
-xLf
-agb
-agb
-aSF
-agb
-agb
-vBo
-iJq
-xcT
+qhu
+xfh
+bdJ
+rlI
+noy
+rlI
+noy
+klv
+noy
+rlI
+uFd
+rlI
+noy
+bbT
+oVP
+jjp
 aOa
 xPw
 xPw
@@ -64338,23 +66321,23 @@ aaB
 aaB
 aaB
 aaf
-rrR
-rqp
-aPw
-aPw
-aPw
-aPw
-two
-fFO
-aPw
-aPw
-aPw
-aPw
-aPw
-aPw
-nxh
-sbg
-agb
+iKK
+eJL
+jdZ
+jBd
+oPb
+jBd
+yjB
+bMM
+oPb
+jBd
+oPb
+jBd
+oPb
+jBd
+iWd
+tWe
+rBi
 gUm
 agb
 oTA
@@ -64866,7 +66849,7 @@ tGD
 jji
 amk
 mSk
-add
+tZG
 mRb
 iLg
 akZ
@@ -65518,7 +67501,7 @@ qod
 uvz
 arT
 arT
-tDt
+osl
 tKc
 rDC
 kik
@@ -66950,9 +68933,9 @@ dxw
 eBx
 xvt
 aAy
-ufL
+xuB
 iBp
-eLL
+aUp
 aaf
 aaB
 aaB
@@ -67354,9 +69337,9 @@ arT
 arT
 arT
 aAy
-mem
+wlM
 tSb
-ago
+ulO
 aaf
 oHl
 aaB
@@ -67758,9 +69741,9 @@ aAy
 aAy
 aAy
 agz
-ufL
+mYm
 asw
-ago
+lhb
 ayo
 ayO
 ayX
@@ -67956,11 +69939,11 @@ aaa
 aaa
 aaa
 agz
-rGk
-bWV
-kmo
-ago
-ago
+nBN
+hqt
+wVr
+aLM
+ajJ
 asw
 pko
 ayo
@@ -68158,13 +70141,13 @@ aaa
 aaa
 aaa
 rBS
-fEp
+vmB
 aTi
-aTi
-aTi
-aTi
-aQM
-ago
+mCu
+cNa
+cNa
+naj
+hbg
 ayo
 ayQ
 ayZ
@@ -68360,9 +70343,9 @@ aaa
 xzM
 aaa
 rBS
-aMl
+aNp
 ago
-ago
+aLM
 agz
 ayr
 ckD
@@ -68384,7 +70367,7 @@ ayo
 ayo
 ayo
 ayo
-azi
+nSg
 aDn
 azD
 aBJ
@@ -68562,31 +70545,31 @@ aaa
 aaa
 aaa
 agz
-wEm
+set
 nRH
-ryi
+sPc
 agz
-ajE
-aRq
-ays
-ays
-ays
-aBe
-aBf
-aBh
-aHT
-aBl
-aHT
-aBr
-ays
-ays
-iQT
-agW
-ays
-duJ
-ays
-ays
-azj
+uBK
+oML
+lpJ
+iIV
+lpJ
+kzJ
+frt
+nzd
+hvH
+iIV
+hvH
+iHn
+coh
+coh
+rDS
+nzd
+lpJ
+hgp
+lpJ
+iIV
+gYh
 aYP
 azE
 azB
@@ -68771,24 +70754,24 @@ axI
 ihH
 afG
 aQh
-aPG
-aka
-aUt
-aUt
-aUt
-aGj
-aUt
-aTg
-aUt
-aka
-aUt
-aka
-gwA
-aka
-aUt
-aka
-aPG
-aMK
+kcJ
+nnt
+seO
+drp
+seO
+qac
+seO
+mom
+seO
+nnt
+seO
+nnt
+tZl
+nnt
+seO
+nnt
+kcJ
+tos
 aYk
 azF
 azL
@@ -68936,7 +70919,7 @@ auM
 jqp
 tDu
 shM
-bBU
+kbz
 auM
 aAy
 aAy
@@ -68965,8 +70948,8 @@ nMT
 nMT
 nMT
 axI
-gbl
-aZh
+hZr
+iJL
 aJr
 ayf
 axI
@@ -68990,7 +70973,7 @@ aqf
 aeT
 aMo
 ayo
-azo
+fwr
 aNd
 azG
 aeL

--- a/_maps/map_files/MidwayStation/MidwayStation.dmm
+++ b/_maps/map_files/MidwayStation/MidwayStation.dmm
@@ -79,16 +79,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aaI" = (
-/obj/docking_port/stationary{
-	dwidth = 11;
-	height = 18;
-	id = "emergency_home";
-	name = "KiloStation emergency evac bay";
-	width = 30
-	},
-/turf/open/space/basic,
-/area/space)
 "aaK" = (
 /turf/closed/wall,
 /area/medical/surgery)
@@ -149,15 +139,6 @@
 	},
 /turf/open/space/basic,
 /area/engine/engine_room)
-"abv" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
 "abE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -778,22 +759,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
-"afr" = (
-/obj/machinery/light,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen/coldroom)
 "afs" = (
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
@@ -925,6 +890,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"agk" = (
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "agn" = (
 /turf/closed/wall/r_wall,
 /area/science/research)
@@ -8744,17 +8713,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"aOW" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "aOX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
@@ -9494,6 +9452,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"aTn" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aTq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10136,6 +10103,27 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/floor/grass,
 /area/crew_quarters/bar)
+"aXN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/shower{
+	pixel_y = 15
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "aXO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -10384,6 +10372,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"aZT" = (
+/obj/item/radio/intercom{
+	pixel_x = -27;
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "aZY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -10417,6 +10412,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"bci" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/head_of_personnel)
 "bcw" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -10457,13 +10461,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"beN" = (
-/obj/structure/closet/secure_closet/exile,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "beT" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/engineering,
@@ -10686,38 +10683,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"bln" = (
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
-"blo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -25;
-	pixel_y = -2;
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bmd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -10791,15 +10756,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"brd" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
-/obj/item/clothing/under/rank/security/officer/mallcop,
-/turf/open/floor/plasteel,
-/area/security/main)
 "brB" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -10940,6 +10896,17 @@
 	},
 /turf/open/space/basic,
 /area/maintenance/solars/port/aft)
+"bwy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Com";
+	location = "Evac"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "bwP" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/machinery/camera/autoname{
@@ -10947,11 +10914,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"bxh" = (
-/obj/structure/table,
-/obj/item/paper/fluff/holodeck/disclaimer,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "bxn" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
@@ -10977,28 +10939,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"bxO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/head_of_personnel)
-"byb" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "byK" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
@@ -11095,6 +11035,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"bCf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "bCi" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -11233,6 +11183,22 @@
 /obj/item/wrench,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"bIJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bIW" = (
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -11260,16 +11226,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"bJL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "bKb" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -11304,6 +11260,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"bKU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Ari";
+	location = "Vlt"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "bKV" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -11544,25 +11519,6 @@
 	},
 /turf/open/floor/plating,
 /area/solar/starboard/fore)
-"bUx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "bUR" = (
 /obj/machinery/power/generator,
 /obj/structure/cable/yellow,
@@ -11627,25 +11583,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bWl" = (
-/obj/machinery/camera{
-	c_tag = "Brig Control Room";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/computer/secure_data{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/warden)
 "bWP" = (
 /turf/open/space/basic,
 /area/engine/engine_room)
@@ -11691,16 +11628,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"bZU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "caq" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -11845,6 +11772,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"cgP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "cgT" = (
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
@@ -12090,16 +12036,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"cra" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/computer/atmos_control/tank/oxygen_tank{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "crq" = (
 /obj/structure/chair{
 	dir = 4
@@ -12117,17 +12053,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"crU" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/security,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/storage/tech)
 "csf" = (
 /obj/machinery/computer/med_data{
 	dir = 8
@@ -12271,6 +12196,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"czq" = (
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "czE" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -12318,6 +12249,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"cCg" = (
+/obj/structure/table,
+/obj/item/nanite_scanner,
+/obj/item/nanite_remote,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/science/nanite)
 "cDY" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -12328,6 +12271,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"cEI" = (
+/obj/effect/turf_decal/tile/red,
+/obj/item/kirbyplants/random,
+/obj/structure/sign/directions/security{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = -3
+	},
+/obj/structure/sign/directions/science{
+	pixel_x = 32;
+	pixel_y = -9
+	},
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 9
+	},
+/obj/structure/sign/directions/command{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 3
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "cFd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -12703,18 +12674,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"cRM" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "cRP" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -12974,17 +12933,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dbv" = (
-/obj/machinery/camera{
-	c_tag = "Security Post - Science";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science)
 "dbx" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -13212,12 +13160,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"dkR" = (
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "dkS" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -13256,16 +13198,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"dmK" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "dna" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -13365,6 +13297,16 @@
 	},
 /turf/closed/wall,
 /area/security/detectives_office)
+"dpw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "dpB" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -13505,6 +13447,17 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"dwQ" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "dxw" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -13542,16 +13495,12 @@
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"dzO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
+"dAl" = (
+/obj/item/radio/intercom{
+	pixel_y = -32
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/turf/open/floor/engine,
+/area/science/explab)
 "dBR" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -13586,6 +13535,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"dCl" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel,
+/area/gateway)
 "dCI" = (
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -24
@@ -13608,16 +13563,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
-"dDo" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "dDP" = (
 /obj/structure/table,
 /obj/item/crowbar,
@@ -13636,19 +13581,6 @@
 "dEi" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"dEv" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "dEZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -13869,12 +13801,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"dPg" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "dPI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -14017,10 +13943,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"dTE" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
 "dUi" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 1
@@ -14048,6 +13970,9 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
+"dUH" = (
+/turf/open/space/basic,
+/area/space/nearstation)
 "dUP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -14246,22 +14171,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"eaH" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "eaU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -14521,10 +14430,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"ejw" = (
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "ejF" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
@@ -14544,12 +14449,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/head_of_personnel)
-"ejK" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel,
-/area/gateway)
 "ejV" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/structure/cable{
@@ -14643,23 +14542,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"enk" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/kirbyplants/random,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "enP" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -14915,6 +14797,23 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/janitor)
+"evW" = (
+/obj/machinery/airalarm/directional/south{
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "ewI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14937,6 +14836,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"eyg" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "eys" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -14994,6 +14910,22 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"eAE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Bar2";
+	location = "Cha"
+	},
+/turf/open/floor/carpet,
+/area/chapel/main)
 "eBb" = (
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
@@ -15003,6 +14935,31 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"eBe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "eBo" = (
 /obj/machinery/computer/upload/ai{
 	dir = 1
@@ -15032,22 +14989,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
-"eDJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "eEc" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -15265,24 +15206,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"eMo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "eMy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15525,6 +15448,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"eVO" = (
+/obj/machinery/vending/cola/random,
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eVP" = (
 /obj/machinery/light{
 	dir = 4
@@ -15561,6 +15491,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"eWF" = (
+/obj/machinery/light,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen/coldroom)
 "eXa" = (
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -24
@@ -15614,6 +15560,12 @@
 "eZl" = (
 /turf/closed/wall,
 /area/storage/tech)
+"eZB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "faq" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -15708,19 +15660,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"fgF" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "fgL" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
@@ -15805,20 +15744,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"fmj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/window/spawner/west,
-/obj/structure/window/spawner/east,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/spawner/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/grass,
-/area/hallway/primary/aft)
 "fou" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15898,15 +15823,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"fqv" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ftt" = (
 /turf/closed/wall,
 /area/medical/pharmacy)
@@ -16025,6 +15941,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fAb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -25;
+	pixel_y = -2;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fAD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -16137,19 +16069,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"fDI" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/light{
+"fDn" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "fDT" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/eight,
@@ -16246,6 +16180,25 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"fGF" = (
+/obj/machinery/camera{
+	c_tag = "Brig Control Room";
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/warden)
 "fGT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -16296,19 +16249,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"fJe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "fJp" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/machinery/meter{
@@ -16414,6 +16354,19 @@
 /obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"fOr" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/vending/cola/random,
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "fOy" = (
 /obj/machinery/libraryscanner,
 /obj/structure/sign/poster/official/random{
@@ -16575,6 +16528,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"fXm" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "fXx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16767,21 +16733,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"gcV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "gcZ" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
@@ -17638,12 +17589,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"gLP" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+"gLz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/bridge)
+/area/tcommsat/computer)
 "gND" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/firealarm{
@@ -17777,14 +17728,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"gUb" = (
-/obj/effect/spawner/structure/window/reinforced/shutters,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "gUc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -17951,27 +17894,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gYe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "gYo" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
@@ -17997,22 +17919,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"gYV" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "gZB" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -18033,15 +17939,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"gZX" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "hbf" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -18137,6 +18034,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"hgT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "hhB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1;
@@ -18171,16 +18083,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hir" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "hiP" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -18440,6 +18342,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"hvR" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine/longrange{
+	department = "Captain"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"hwE" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=QM";
+	location = "Cent"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hwF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -18545,12 +18468,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
-"hxD" = (
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "hyb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8;
@@ -18569,6 +18486,12 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"hyL" = (
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/turf/open/floor/carpet,
+/area/library)
 "hyU" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -18647,34 +18570,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
-"hzE" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"hzF" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "hzX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -18732,13 +18627,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"hBH" = (
-/obj/item/radio/intercom{
-	pixel_x = -27;
-	pixel_y = -8
-	},
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "hBP" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -18986,16 +18874,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"hRf" = (
-/obj/machinery/light,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "hRh" = (
 /obj/item/analyzer{
 	pixel_x = 7;
@@ -19023,6 +18901,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"hSw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "hSN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1;
@@ -19043,6 +18939,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"hTW" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "hUQ" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -19052,6 +18964,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"hVB" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "hWD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -19199,28 +19121,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"ibJ" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Telecommunications";
-	req_access_txt = "61"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
-"icM" = (
-/obj/structure/closet/crate/wooden/toy,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "idP" = (
 /obj/machinery/button/door{
 	id = "commissaryshutter";
@@ -19318,15 +19218,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "igo" = (
-/obj/structure/closet/secure_closet/security,
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/clothing/under/rank/security/officer/mallcop,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "igL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -19384,6 +19284,27 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"ikf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "ikE" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -19444,6 +19365,13 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
+"inG" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/science/storage)
 "ipl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -19586,6 +19514,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"iwD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "iwE" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -19668,6 +19608,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing/chamber)
+"iyZ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "izj" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -19712,6 +19664,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"iAM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Gateway"
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "iBp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -19778,19 +19742,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"iEz" = (
-/obj/machinery/computer/cargo/request{
-	dir = 1;
-	icon_state = "computer"
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "iEQ" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/flash/handheld,
@@ -19945,6 +19896,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"iHS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "iHZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19976,6 +19940,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
+"iIE" = (
+/obj/structure/table,
+/obj/item/paper/fluff/holodeck/disclaimer,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "iIF" = (
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel/white,
@@ -20056,6 +20025,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
+"iLo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "iMl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -20162,6 +20141,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
+"iQT" = (
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "iRe" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -20302,14 +20287,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"iXj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
 "iXP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20398,17 +20375,29 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"jcK" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+"jcx" = (
+/obj/machinery/button/door{
+	id = "stationawaygate";
+	name = "Gateway Access Shutter Control";
+	pixel_x = -1;
+	pixel_y = -24;
+	req_access_txt = "31"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/light,
-/obj/item/radio/intercom{
-	pixel_y = -32
+/obj/structure/table,
+/obj/item/radio/off{
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/item/radio/off{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/radio/off{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/radio/off,
+/turf/open/floor/plasteel,
+/area/gateway)
 "jcX" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -20435,18 +20424,6 @@
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel,
 /area/janitor)
-"jef" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "jem" = (
 /obj/item/assembly/timer{
 	pixel_x = 5;
@@ -20476,6 +20453,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"jeB" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "jeD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -20852,12 +20841,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"jqK" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "jrm" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -20890,6 +20873,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"jrw" = (
+/obj/machinery/power/floodlight,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "jsc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -20916,22 +20906,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
-"jse" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "jss" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20968,20 +20942,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"juX" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = 1;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "jve" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/structure/sign/poster/official/random{
@@ -20999,6 +20959,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"jvI" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "jwf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -21046,13 +21016,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"jwX" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/science/storage)
 "jxl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21110,13 +21073,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"jzc" = (
-/obj/structure/chair,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "jzX" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -21126,6 +21082,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"jAP" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jAR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -21145,18 +21111,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"jCg" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "jCL" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -21190,6 +21144,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"jFc" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	freerange = 1;
+	name = "Station Intercom (Telecomms)";
+	pixel_y = 30
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "jFd" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage";
@@ -21228,16 +21195,6 @@
 	},
 /turf/open/floor/circuit,
 /area/maintenance/starboard/central)
-"jHL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "jIl" = (
 /obj/structure/sign/poster/contraband,
 /turf/closed/wall,
@@ -21520,16 +21477,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
-"jSk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "jSl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21601,6 +21548,25 @@
 /obj/structure/chair/wood/wings,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
+"jVY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Ari";
+	location = "Vlt"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jWh" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -21624,16 +21590,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"jXs" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "jXx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -21662,6 +21618,22 @@
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"jYp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "jYU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -21828,6 +21800,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"kce" = (
+/obj/docking_port/stationary{
+	dwidth = 13;
+	height = 9;
+	id = "emergency_home";
+	name = "Midwaystation emergency evac bay";
+	width = 26
+	},
+/turf/open/space/basic,
+/area/space)
 "kdc" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -21969,6 +21951,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"kmo" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "kmQ" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
@@ -21978,6 +21969,11 @@
 	},
 /turf/open/floor/circuit,
 /area/maintenance/starboard/central)
+"knn" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "knJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -22051,32 +22047,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"kpv" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/security/med,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/machinery/camera{
-	c_tag = "Security Post - Medbay";
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/item/clothing/under/rank/security/officer/mallcop,
-/turf/open/floor/plasteel/white,
-/area/security/checkpoint/medical)
 "kpF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22249,19 +22219,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kym" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/lieutenant,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "kzE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -22322,6 +22279,18 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"kCz" = (
+/obj/structure/table,
+/obj/item/gun/syringe,
+/obj/item/clothing/neck/stethoscope,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "kCD" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -22454,6 +22423,24 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/security/processing)
+"kNO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"kOd" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Eng";
+	location = "AftH"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kOj" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/tile/brown{
@@ -22502,26 +22489,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"kPU" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "kQj" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
@@ -22571,6 +22538,22 @@
 /obj/item/analyzer,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"kSq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "kSy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet,
@@ -22713,6 +22696,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"kUX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Cent";
+	location = "Eng"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "kVg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22944,6 +22940,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"lbK" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/obj/item/clothing/under/rank/security/officer/mallcop,
+/turf/open/floor/plasteel,
+/area/security/main)
 "lbM" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Air In"
@@ -22984,6 +22986,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"ldT" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Control Room";
+	req_access_txt = "19; 61"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "leb" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/deputy,
@@ -23098,14 +23116,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"lhj" = (
-/obj/machinery/light,
-/obj/item/kirbyplants/random,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "lho" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -23176,12 +23186,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"lkC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "lkS" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
 	dir = 4
@@ -23223,30 +23227,6 @@
 "lma" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"lmu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "lni" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23390,6 +23370,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"lsd" = (
+/obj/machinery/light,
+/obj/item/kirbyplants/random,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lsf" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -23442,6 +23430,17 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"lwd" = (
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -23506,6 +23505,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
+"lAS" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "lAU" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -23567,6 +23577,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"lCL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lDd" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -23647,6 +23667,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"lHH" = (
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "lHU" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -23654,24 +23681,6 @@
 "lIC" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"lJJ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "lJR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -23704,6 +23713,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"lKI" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/closet/lasertag/blue,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/crew_quarters/fitness/recreation)
 "lKX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -23810,16 +23832,6 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
-"lNz" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "lNP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23839,15 +23851,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"lOc" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "lOj" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -23878,6 +23881,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"lRA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Cha";
+	location = "Bar"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lRJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -23989,6 +24008,20 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"lUN" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "lUS" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 2"
@@ -24333,6 +24366,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"mkt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "mlt" = (
 /mob/living/simple_animal/bot/medbot{
 	auto_patrol = 1;
@@ -24486,21 +24534,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"mtx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "mtY" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
@@ -24678,19 +24711,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"myY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/closet/lasertag/blue,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/crew_quarters/fitness/recreation)
+"mzs" = (
+/obj/machinery/camera/autoname,
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "mzT" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -24755,22 +24780,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"mDi" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "mDJ" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics/cloning)
+"mDR" = (
+/obj/structure/closet/secure_closet/security/cargo,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Security Post - Cargo";
+	dir = 1
+	},
+/obj/item/clothing/under/rank/security/officer/mallcop,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "mEI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24904,31 +24937,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"mJy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "mKO" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /obj/machinery/firealarm{
@@ -24986,6 +24994,15 @@
 /obj/effect/landmark/start/virologist,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"mMx" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "mMS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -25020,6 +25037,12 @@
 /obj/structure/transit_tube/crossing,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"mOq" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "mOC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -25070,6 +25093,22 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"mPz" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "mPA" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -25120,6 +25159,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"mSY" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "mTf" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenic Lounge"
@@ -25153,6 +25202,19 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"mUD" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mUQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -25356,6 +25418,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ncn" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ncO" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
@@ -25399,19 +25469,6 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"nha" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "nhl" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -25466,6 +25523,16 @@
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"njh" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_x = 31;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "njO" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock";
@@ -25569,24 +25636,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"nmS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "nmU" = (
 /obj/structure/plasticflaps,
 /obj/machinery/navbeacon{
@@ -25772,6 +25821,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"npV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nqn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25792,6 +25854,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"nrL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "nrM" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -25817,6 +25885,28 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"nug" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
+"nuB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "nuQ" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -26324,6 +26414,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"nGh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Med";
+	location = "Com"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "nGz" = (
 /obj/structure/closet/secure_closet/head_of_personnel,
 /obj/structure/disposalpipe/segment{
@@ -26436,6 +26536,27 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
+"nKV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 24
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nLM" = (
 /obj/structure/table,
 /obj/item/mmi,
@@ -26521,16 +26642,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
-"nNk" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "nNn" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -26679,6 +26790,37 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
+"nVr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"nWB" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications";
+	req_access_txt = "61"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "nXa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
@@ -26746,12 +26888,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
-"nYa" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
+"nYg" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/carpet,
-/area/library)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "nYy" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -27011,6 +27163,18 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ogQ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ogS" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -27299,13 +27463,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"osc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "osO" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -27624,46 +27781,10 @@
 /obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
-"oFB" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "hopqueue";
-	name = "Queue Shutters Control";
-	pixel_x = -4;
-	pixel_y = 25;
-	req_access_txt = "57"
-	},
-/obj/machinery/button/door{
-	id = "hop";
-	name = "Privacy Shutters Control";
-	pixel_x = 6;
-	pixel_y = 25;
-	req_access_txt = "57"
-	},
-/obj/machinery/button/ticket_machine{
-	pixel_x = -4;
-	pixel_y = 33
-	},
-/obj/effect/landmark/start/head_of_personnel,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/head_of_personnel)
 "oGB" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"oGC" = (
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "oHk" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks,
@@ -27737,6 +27858,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"oLm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/warehouse)
 "oLq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -27783,6 +27912,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"oMm" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/restrooms)
+"oMx" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "hopqueue";
+	name = "Queue Shutters Control";
+	pixel_x = -4;
+	pixel_y = 25;
+	req_access_txt = "57"
+	},
+/obj/machinery/button/door{
+	id = "hop";
+	name = "Privacy Shutters Control";
+	pixel_x = 6;
+	pixel_y = 25;
+	req_access_txt = "57"
+	},
+/obj/machinery/button/ticket_machine{
+	pixel_x = -4;
+	pixel_y = 33
+	},
+/obj/effect/landmark/start/head_of_personnel,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/head_of_personnel)
 "oNv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -27798,19 +27961,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"oOI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+"oOF" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/turf/closed/wall,
+/area/hallway/secondary/exit/departure_lounge)
 "oOJ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -27886,6 +28040,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"oUj" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Sec";
+	location = "Bar2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oUA" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -27966,16 +28127,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"oXB" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "oYs" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/disposalpipe/segment{
@@ -27990,6 +28141,19 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"oZm" = (
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "oZp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28118,20 +28282,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
-"pdF" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/structure/fireaxecabinet{
-	pixel_x = 1;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "pdJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -28296,13 +28446,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"pjU" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge";
-	req_access_txt = "19"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "pkl" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -28499,6 +28642,21 @@
 	},
 /turf/open/floor/plating,
 /area/medical/pharmacy)
+"poU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ppj" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -28524,22 +28682,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tech)
-"pqy" = (
+"prN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"psm" = (
-/obj/structure/closet/emcloset,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/structure/window/spawner/west,
+/obj/structure/window/spawner/east,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/spawner/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/grass,
+/area/hallway/primary/aft)
 "psq" = (
 /obj/machinery/light,
 /obj/effect/landmark/start/assistant,
@@ -28701,34 +28857,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"pzD" = (
-/obj/effect/turf_decal/tile/red,
-/obj/item/kirbyplants/random,
-/obj/structure/sign/directions/security{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = -3
+"pzF" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
-/obj/structure/sign/directions/science{
-	pixel_x = 32;
-	pixel_y = -9
-	},
-/obj/structure/sign/directions/evac{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = 9
-	},
-/obj/structure/sign/directions/command{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = 3
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/shower{
 	dir = 1
 	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/engine/engine_room)
 "pzJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
@@ -28740,18 +28881,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
-"pAz" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "pBt" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -28867,18 +28996,6 @@
 /obj/item/storage/crayons,
 /turf/open/floor/wood,
 /area/library)
-"pEV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "pFC" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -28904,6 +29021,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pFQ" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "pFT" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -28914,6 +29044,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"pGj" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = 5
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/storage/box/monkeycubes,
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "pGH" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -29081,6 +29234,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"pMb" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "pMJ" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -29170,6 +29335,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"pPw" = (
+/obj/structure/closet/crate/wooden/toy,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "pPC" = (
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
@@ -29192,20 +29364,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"pQC" = (
-/obj/machinery/photocopier,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/wood,
-/area/lawoffice)
 "pQQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29551,21 +29709,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/lobby)
-"qbU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "qcc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29621,10 +29764,42 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"qdG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "qeq" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/chapel/main)
+"qeS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"qff" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "qfU" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/wood,
@@ -29638,23 +29813,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"qhv" = (
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "qhY" = (
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/dark,
@@ -29778,27 +29936,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qlQ" = (
-/obj/structure/closet/secure_closet/security/cargo,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Security Post - Cargo";
-	dir = 1
-	},
-/obj/item/clothing/under/rank/security/officer/mallcop,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
 "qlX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29976,6 +30113,30 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"qrG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qta" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8;
@@ -30122,6 +30283,13 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
+"qCq" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "qDa" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -30201,20 +30369,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
-"qGY" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/radio/off,
-/obj/item/book/manual/wiki/tcomms,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
-	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "qHo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -30255,21 +30409,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"qJr" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "qJt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -30448,22 +30587,24 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"qPX" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+"qPP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/secondary/entry)
 "qQu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30703,13 +30844,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"qWV" = (
-/obj/machinery/power/floodlight,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "qYs" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Lab";
@@ -30752,22 +30886,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"qYL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "qZU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30859,29 +30977,6 @@
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"rdm" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes{
-	pixel_y = 5
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/storage/box/monkeycubes,
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "rdX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -30964,21 +31059,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"rgR" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "rht" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -30996,18 +31076,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"rhD" = (
-/obj/structure/table,
-/obj/item/nanite_scanner,
-/obj/item/nanite_remote,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/science/nanite)
 "rhG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31032,6 +31100,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"riA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "riE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -31068,21 +31146,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/medical)
-"rjS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "rkq" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Science Maintenance";
@@ -31272,6 +31335,13 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"rtH" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "run" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -31315,22 +31385,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"rvp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "rvC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -31473,6 +31527,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"rzf" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/security,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/storage/tech)
 "rAr" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -31531,6 +31596,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"rBl" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "rBp" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -31634,6 +31715,19 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"rEL" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/lieutenant,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "rFe" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -31756,22 +31850,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/fitness/recreation)
-"rLl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -25;
-	pixel_y = -2;
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "rLt" = (
 /obj/machinery/light{
 	dir = 8
@@ -32001,28 +32079,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"rVv" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/camera/autoname,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/machinery/disposal/bin,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "rVY" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -32074,6 +32130,12 @@
 	},
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science/robotics/mechbay)
+"rXf" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "rXg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
 	dir = 1
@@ -32174,6 +32236,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"sbu" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "sbE" = (
 /obj/machinery/light{
 	dir = 4
@@ -32209,6 +32291,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"sbN" = (
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "scH" = (
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/bar)
@@ -32347,15 +32436,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"siZ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "sjT" = (
 /obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plating,
@@ -32486,22 +32566,6 @@
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"sqe" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = 10;
-	pixel_y = 6
-	},
-/obj/item/pen,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "sql" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Maintenance";
@@ -32704,10 +32768,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"szg" = (
-/obj/effect/spawner/structure/window/reinforced/shutters,
-/turf/closed/wall,
-/area/hallway/secondary/exit/departure_lounge)
 "szn" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
@@ -32918,6 +32978,16 @@
 /obj/item/clothing/mask/horsehead,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"sKi" = (
+/obj/structure/closet/secure_closet/security,
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_y = 30
+	},
+/obj/item/clothing/under/rank/security/officer/mallcop,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs)
 "sKn" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance";
@@ -32965,6 +33035,18 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"sLo" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "sLK" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/structure/extinguisher_cabinet{
@@ -32985,18 +33067,19 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/head_of_personnel)
-"sMJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+"sMr" = (
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_y = -26
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/hallway/primary/central)
 "sML" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -33005,10 +33088,30 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/medical)
+"sNX" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "sOj" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"sOm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Vlt";
+	location = "QM"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "sON" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -33073,28 +33176,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"sQr" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/obj/item/clothing/under/rank/security/officer/mallcop,
-/turf/open/floor/plasteel,
-/area/security/main)
-"sQu" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Control Room";
-	req_access_txt = "19; 61"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "sQv" = (
 /obj/structure/closet/crate/solarpanel_small,
 /obj/machinery/light{
@@ -33273,6 +33354,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"sXt" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "sXu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -33416,6 +33512,20 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"tdY" = (
+/obj/machinery/photocopier,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "tea" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33555,6 +33665,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"tfm" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -30
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/closet/secure_closet/security/science,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/clothing/under/rank/security/officer/mallcop,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "tfn" = (
 /obj/effect/mapping_helpers/ianbirthday,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33714,6 +33847,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"tkd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Evac";
+	location = "Sec"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "tkC" = (
 /obj/machinery/door/airlock/maintenance{
 	id_tag = "commissarydoor";
@@ -33777,6 +33920,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"tmr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "tnf" = (
 /obj/item/storage/secure/safe{
 	name = "evidence safe";
@@ -33937,29 +34092,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"tvu" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -30
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/closet/secure_closet/security/science,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/clothing/under/rank/security/officer/mallcop,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science)
 "twc" = (
 /obj/structure/chair/pew/right{
 	dir = 4;
@@ -34048,6 +34180,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
+"tAN" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/computer/atmos_control/tank/oxygen_tank{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "tAU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4;
@@ -34056,6 +34198,41 @@
 /obj/effect/landmark/start/chief_medical_officer,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
+"tBt" = (
+/obj/machinery/camera{
+	c_tag = "Security Post - Science";
+	dir = 4;
+	network = list("ss13","rd")
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
+"tBG" = (
+/obj/structure/closet/secure_closet/exile,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
+"tBK" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "tCT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -34093,36 +34270,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"tEd" = (
-/obj/effect/spawner/structure/window/reinforced/shutters,
-/obj/effect/spawner/structure/window/reinforced/shutters,
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "tFb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/closed/wall,
 /area/maintenance/department/science)
-"tFj" = (
-/obj/machinery/vending/cola/random,
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"tFA" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "tFK" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -34198,6 +34351,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"tMe" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "tMC" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -34249,48 +34406,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"tPF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Gateway"
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
-"tPT" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"tPV" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "tQo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -34488,6 +34603,28 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"tTD" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin,
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "tTK" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -34591,13 +34728,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"tXf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "tXh" = (
 /obj/structure/transit_tube/horizontal{
 	dir = 2
@@ -34708,16 +34838,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"udA" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "uec" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34823,18 +34943,6 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
-"ueW" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "uff" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -34894,6 +35002,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload)
+"ufL" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "uge" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -34961,6 +35078,16 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"uhe" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "uhT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -35030,19 +35157,6 @@
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"ujV" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
-	},
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
 "uln" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -35088,6 +35202,19 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"umt" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -35150,16 +35277,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"unD" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/vacant_room/commissary)
 "unN" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -35169,27 +35286,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"uoi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/shower{
-	pixel_y = 15
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "uoq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -35252,6 +35348,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/science)
+"urR" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "urV" = (
 /obj/machinery/airalarm/directional/north{
 	pixel_y = 24
@@ -35295,6 +35400,19 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
+"utU" = (
+/obj/machinery/computer/cargo/request{
+	dir = 1;
+	icon_state = "computer"
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "uuh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35304,6 +35422,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"uuD" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "uvh" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots{
@@ -35432,24 +35560,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"uCB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "uDC" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 8
@@ -35480,6 +35590,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"uEq" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uEz" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/effect/turf_decal/tile/green,
@@ -35645,6 +35776,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"uLk" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/radio/off,
+/obj/item/book/manual/wiki/tcomms,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "uLl" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/green{
@@ -35809,15 +35954,6 @@
 /obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/medical)
-"uOT" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "uPE" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "armory";
@@ -35902,19 +36038,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"uRk" = (
-/obj/machinery/light{
+"uRw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_y = 30
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -25;
+	pixel_y = -2;
+	prison_radio = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uRy" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -36000,16 +36142,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"uVw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "uWu" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -36497,20 +36629,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"vlw" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/photocopier/faxmachine/longrange{
-	department = "Captain"
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "vlL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4;
@@ -36533,6 +36651,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vnP" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/fireaxecabinet{
+	pixel_x = 1;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "vnQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -36647,11 +36779,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"vrE" = (
-/obj/machinery/camera/autoname,
-/obj/structure/chair,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "vrH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
@@ -36681,12 +36808,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"vrX" = (
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "vsa" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
@@ -36721,6 +36842,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"vso" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "vsD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -36784,6 +36917,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"vuZ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "vvd" = (
 /obj/machinery/porta_turret/ai,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36914,29 +37065,6 @@
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"vym" = (
-/obj/machinery/button/door{
-	id = "stationawaygate";
-	name = "Gateway Access Shutter Control";
-	pixel_x = -1;
-	pixel_y = -24;
-	req_access_txt = "31"
-	},
-/obj/structure/table,
-/obj/item/radio/off{
-	pixel_y = 6
-	},
-/obj/item/radio/off{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/radio/off{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/radio/off,
-/turf/open/floor/plasteel,
-/area/gateway)
 "vyy" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/AI,
@@ -36991,9 +37119,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"vAL" = (
-/turf/open/space/basic,
-/area/space/nearstation)
 "vBo" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -37236,19 +37361,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"vOu" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "vOG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8;
@@ -37418,19 +37530,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
-"vWI" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/vending/cola/random,
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "vWJ" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
@@ -37652,12 +37751,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"wfc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "wgi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -37708,6 +37801,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"wju" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"wkg" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 24
+	},
+/obj/item/clothing/under/rank/security/officer/mallcop,
+/turf/open/floor/plasteel,
+/area/security/main)
 "wkE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1;
@@ -37792,12 +37904,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"wmf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "wmu" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -37829,6 +37935,19 @@
 /obj/item/cultivator,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"wnH" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
 "wpf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -37881,18 +38000,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
-"wrO" = (
-/obj/structure/table,
-/obj/item/gun/syringe,
-/obj/item/clothing/neck/stethoscope,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "wrS" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -37974,13 +38081,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"wvO" = (
-/obj/machinery/light,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "wvP" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -38717,6 +38817,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"wPq" = (
+/obj/structure/closet/emcloset,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "wPw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -38724,23 +38831,28 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"wQA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "wQZ" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"wRl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "wRz" = (
 /obj/machinery/computer/shuttle/labor{
 	dir = 1
@@ -38775,15 +38887,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"wRL" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "wRU" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -38803,12 +38906,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"wSi" = (
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "wSt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38821,6 +38918,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"wTc" = (
+/obj/machinery/light,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "wUf" = (
 /obj/docking_port/stationary/random{
 	dir = 2;
@@ -38852,16 +38959,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"wVG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "wVW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -39030,6 +39127,13 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/lobby)
+"xeF" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Bar";
+	location = "Sci"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "xeJ" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -39195,16 +39299,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"xmx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_x = 31;
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "xmB" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -39248,6 +39342,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"xnT" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "xnU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39354,6 +39458,12 @@
 	},
 /turf/open/floor/plating,
 /area/solar/starboard/fore)
+"xrO" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "xrP" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -39392,6 +39502,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"xsM" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/security/med,
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Security Post - Medbay";
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/item/clothing/under/rank/security/officer/mallcop,
+/turf/open/floor/plasteel/white,
+/area/security/checkpoint/medical)
 "xsP" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8
@@ -39569,6 +39705,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"xyC" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "xzm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 10
@@ -39723,27 +39868,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"xEI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "xFD" = (
 /obj/effect/landmark/start/chief_engineer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39957,6 +40081,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"xLf" = (
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xLD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40070,17 +40200,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"xOe" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge";
-	req_access_txt = "19"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/turf/open/floor/plating,
-/area/bridge)
 "xOf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -40222,6 +40341,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"xUc" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "xUl" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 1
@@ -40394,6 +40523,19 @@
 	dir = 8;
 	pixel_x = 32;
 	pixel_y = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"yfg" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -47970,7 +48112,7 @@ umv
 aDY
 aEe
 aHm
-ejw
+agk
 aBM
 aaa
 aaa
@@ -48768,7 +48910,7 @@ aDF
 aDF
 aDF
 aDF
-qWV
+jrw
 aDF
 aDF
 aDF
@@ -48965,17 +49107,17 @@ aaa
 aaa
 aaa
 aCU
-lkC
+eZB
 aDF
 aDF
 aDF
 aDF
-wfc
+nrL
 aDF
 aDF
 aDF
 aEQ
-cra
+tAN
 bDi
 aEb
 aBM
@@ -49172,7 +49314,7 @@ aDF
 aDF
 aDF
 aDF
-wfc
+nrL
 aDF
 aDF
 nyP
@@ -49374,7 +49516,7 @@ aCV
 aDF
 aDF
 aDF
-wfc
+nrL
 oGB
 aDF
 aDF
@@ -49576,7 +49718,7 @@ aFj
 aDF
 aDF
 eRK
-wfc
+nrL
 aDF
 aDF
 uhV
@@ -49778,7 +49920,7 @@ aFj
 aDF
 aDF
 aDF
-wfc
+nrL
 aDF
 aFR
 aGc
@@ -49980,9 +50122,9 @@ liE
 aDF
 aDF
 aDF
-jqK
+rXf
 ePN
-pAz
+ogQ
 ePN
 pSg
 aRy
@@ -51010,7 +51152,7 @@ aAL
 azf
 ibd
 aDi
-byb
+pzF
 aax
 aaa
 aaa
@@ -53015,7 +53157,7 @@ hbf
 hWD
 avW
 qpz
-aMW
+kUX
 jRa
 ayU
 daW
@@ -53428,11 +53570,11 @@ avp
 mpb
 auD
 wJo
-uoi
+aXN
 vEV
 wuV
 xNb
-jXs
+uhe
 aEw
 dZZ
 ayt
@@ -54028,7 +54170,7 @@ sEp
 fTz
 hFS
 ePK
-qGY
+uLk
 iOp
 ePK
 seM
@@ -54229,12 +54371,12 @@ wJO
 raz
 tqq
 eFY
-ibJ
-bJL
-jCg
+nWB
+bCf
+sLo
 vcr
-tXf
-wmf
+nug
+gLz
 aBL
 aCm
 xFD
@@ -54432,11 +54574,11 @@ aKa
 aDr
 fXx
 ePK
-uRk
-mtx
-sQu
-wVG
-tPV
+jFc
+nuB
+ldT
+riA
+pFQ
 aBL
 spU
 mbf
@@ -54621,7 +54763,7 @@ aAW
 qDU
 abM
 aqc
-qJr
+fDn
 axO
 aWP
 aco
@@ -55034,9 +55176,9 @@ gkE
 pHY
 nJw
 aco
-cRM
-nmS
-gcV
+jeB
+hSw
+mkt
 ePK
 vfz
 ptK
@@ -56444,7 +56586,7 @@ aSr
 nYy
 act
 jeS
-dmK
+igo
 cMA
 adA
 adH
@@ -56631,7 +56773,7 @@ abc
 abc
 rZL
 abc
-jcK
+kNO
 eBX
 aAW
 bgz
@@ -56655,7 +56797,7 @@ aDr
 lxB
 eZl
 bJh
-crU
+rzf
 gYv
 beT
 vMt
@@ -57022,7 +57164,7 @@ ash
 thX
 vfM
 lLj
-qhv
+evW
 aua
 aaa
 aaa
@@ -57227,7 +57369,7 @@ ydl
 uhX
 aua
 aaa
-vAL
+dUH
 aaa
 aaa
 eBX
@@ -57254,11 +57396,11 @@ act
 aKB
 aKK
 adU
-wrO
+kCz
 act
 aWY
 aDr
-sMJ
+tmr
 eZl
 eZl
 eZl
@@ -57685,7 +57827,7 @@ abe
 rqS
 vas
 bjl
-iXj
+oLm
 aea
 aed
 aed
@@ -57832,18 +57974,18 @@ fMM
 lcP
 uRL
 wDq
-kym
-sqe
+rEL
+mPz
 tlz
 aaa
-tEd
-kPU
+knn
+sbu
 mqp
 mqp
 fWW
 mqp
 mkd
-lJJ
+vuZ
 eBX
 aAW
 tRJ
@@ -58036,7 +58178,7 @@ dUi
 wDq
 ykQ
 gSi
-gUb
+ncn
 oms
 axc
 axc
@@ -58062,13 +58204,13 @@ acy
 xKn
 nBj
 aKQ
-kpv
+xsM
 acy
 aKx
 aDr
 aUL
 aGN
-lNz
+hVB
 aHq
 mGT
 aHs
@@ -58227,7 +58369,7 @@ sVo
 ban
 tgv
 aua
-pdF
+vnP
 rpo
 ePk
 sLk
@@ -58236,19 +58378,19 @@ sLk
 xgO
 dgD
 lUx
-nNk
-vlw
-gUb
+jvI
+hvR
+ncn
 aAW
-dPg
-aAW
-aAW
+mOq
 aAW
 aAW
 aAW
 aAW
 aAW
-udA
+aAW
+aAW
+xUc
 aAW
 kTr
 aaM
@@ -58438,9 +58580,9 @@ ofj
 jox
 mrv
 aua
-gUb
-gUb
-gUb
+ncn
+ncn
+ncn
 aAW
 axc
 axc
@@ -58452,7 +58594,7 @@ axk
 axk
 axk
 axk
-lmu
+qrG
 ftt
 boN
 tkW
@@ -58637,18 +58779,18 @@ auc
 auc
 auc
 auc
-xEI
-gLP
-xOe
+ikf
+xrO
+lAS
 aAW
 aAW
-pjU
+rtH
 aAW
 axc
 seG
 dKl
 tUW
-ejK
+dCl
 axc
 rgj
 qFO
@@ -58722,7 +58864,7 @@ yhb
 aNn
 mqW
 joZ
-jHL
+lCL
 aSF
 agb
 agb
@@ -58740,7 +58882,7 @@ agb
 agb
 agb
 enP
-gZX
+urR
 oLM
 agb
 aSF
@@ -58870,7 +59012,7 @@ aKw
 gSc
 xyl
 lVq
-vWI
+fOr
 dGE
 qTY
 lsI
@@ -59101,7 +59243,7 @@ qOT
 ugj
 oFm
 aeb
-juX
+lUN
 qta
 afd
 nNC
@@ -59237,7 +59379,7 @@ uQi
 oOo
 vsf
 akD
-oFB
+oMx
 bNa
 tbo
 mxO
@@ -59251,10 +59393,10 @@ awt
 awC
 eBo
 awb
-bln
-beN
+oZm
+tBG
 axg
-hRf
+wTc
 axc
 rFe
 axp
@@ -59301,7 +59443,7 @@ jfn
 mOH
 qkt
 lOO
-unD
+uuD
 aeb
 kAX
 tDL
@@ -59422,7 +59564,7 @@ kLe
 mbq
 oVY
 joi
-psm
+wPq
 aTu
 aaa
 nMT
@@ -59453,7 +59595,7 @@ akT
 awD
 awJ
 awb
-tPF
+iAM
 awU
 awU
 awU
@@ -59509,14 +59651,14 @@ iJD
 iMl
 aez
 vZE
-eDJ
+bIJ
 aLo
 whB
 afp
 rSR
 aRs
 aBF
-qlQ
+mDR
 afo
 aOI
 aIm
@@ -59527,7 +59669,7 @@ aJw
 aIm
 agb
 vxG
-lhj
+lsd
 aOa
 aaa
 xPw
@@ -59645,7 +59787,7 @@ aup
 aup
 aup
 tpf
-bxO
+bci
 akD
 eNM
 hrV
@@ -59658,7 +59800,7 @@ awb
 hwF
 hSN
 awU
-vym
+jcx
 axc
 umI
 axp
@@ -59823,8 +59965,8 @@ aaa
 aaa
 aaa
 aaa
-szg
-jzc
+oOF
+lHH
 nXv
 jwC
 sZy
@@ -60026,7 +60168,7 @@ aaa
 aaa
 aaa
 sZy
-vrE
+mzs
 qJt
 dbx
 aTu
@@ -60050,19 +60192,19 @@ ixh
 ixh
 wOj
 ome
-enk
+eyg
 yjm
 ixh
 hBP
 jwl
-fgF
-ueW
+fXm
+vso
 mRq
 qMM
 wGh
 cUx
 ufC
-pEV
+iwD
 mKS
 run
 qJx
@@ -60070,15 +60212,15 @@ nxN
 tRj
 jqd
 wlF
-fqv
-dDo
-fDI
+aTn
+wju
+mUD
 arn
 arn
 xCn
 oNv
 nIk
-oXB
+jAP
 oNv
 xCn
 oNv
@@ -60097,7 +60239,7 @@ jss
 vcZ
 nyq
 pIY
-mDi
+sMr
 ykt
 aah
 nvy
@@ -60111,8 +60253,8 @@ ugE
 dtr
 aqL
 bKV
-jef
-gYV
+pMb
+rBl
 rVY
 eOu
 afR
@@ -60122,13 +60264,13 @@ iPf
 aKZ
 aDx
 aKZ
-qPX
+hTW
 aKY
 aKY
 aKY
 aKY
 rLt
-lOc
+mMx
 cpz
 dnf
 agb
@@ -60252,12 +60394,12 @@ aac
 aac
 aac
 vDI
-hzF
+qCq
 wBN
-dox
+nGh
 dox
 mfi
-bZU
+iLo
 dox
 dox
 dox
@@ -60286,9 +60428,9 @@ aah
 aah
 ayW
 aah
-aah
+kOd
 aZn
-aah
+hwE
 tGC
 avY
 aah
@@ -60318,7 +60460,7 @@ kJZ
 aNR
 aOT
 afR
-afR
+sOm
 afR
 aNW
 afR
@@ -60334,7 +60476,7 @@ afR
 afR
 kJZ
 agb
-vxG
+jVY
 agb
 xPw
 aaa
@@ -60425,14 +60567,14 @@ aaa
 aaa
 aaa
 aaa
-aaI
+kce
 dZX
 bxv
 vqv
 wdg
 qdr
-osc
-jSk
+bwy
+qeS
 iNq
 bDO
 bDO
@@ -60503,7 +60645,7 @@ aJF
 kKt
 iFn
 aZr
-wRl
+npV
 aYn
 aXh
 htV
@@ -60514,9 +60656,9 @@ uIa
 fMt
 iRM
 aUK
-oOI
+qff
 aWw
-fmj
+prN
 aBb
 boL
 aEJ
@@ -60656,12 +60798,12 @@ aac
 aac
 aac
 khy
-dzO
+dpw
 oZB
-omS
+tkd
 omS
 uuh
-dzO
+dpw
 omS
 omS
 omS
@@ -60687,8 +60829,8 @@ aah
 tGC
 aah
 aah
-aah
-aZn
+oUj
+lRA
 aah
 aah
 axq
@@ -60717,7 +60859,7 @@ afR
 afR
 aOT
 aNV
-afR
+xeF
 kJZ
 jyb
 afR
@@ -60738,7 +60880,7 @@ afR
 afR
 kJZ
 agb
-dPI
+bKU
 agb
 xPw
 aaa
@@ -60836,7 +60978,7 @@ aaa
 aTu
 fBJ
 kbs
-tPT
+tBK
 aTu
 aOF
 aOL
@@ -60855,15 +60997,15 @@ txC
 yfP
 acF
 mab
-xmx
+njh
 atU
 xOr
-uVw
+mSY
 yfP
 acF
 aac
 bzD
-pzD
+cEI
 aft
 mZc
 aft
@@ -60879,7 +61021,7 @@ ezO
 afs
 afs
 afs
-oGC
+lwd
 kdc
 anv
 lvo
@@ -60905,7 +61047,7 @@ xAn
 cFd
 wad
 mjB
-nha
+yfg
 rYw
 hsD
 llb
@@ -60920,7 +61062,7 @@ pIT
 aRb
 ajq
 ajq
-hir
+xnT
 ajq
 ajq
 aZm
@@ -60930,7 +61072,7 @@ aWU
 aOp
 kVh
 ajq
-dEv
+sNX
 ajq
 ajq
 aOT
@@ -61111,7 +61253,7 @@ aIT
 aIT
 aIT
 aaA
-igo
+sKi
 aVB
 wcL
 aDc
@@ -61330,7 +61472,7 @@ aiW
 aEd
 agn
 fBb
-rvp
+jYp
 agn
 rBz
 sio
@@ -61472,7 +61614,7 @@ kwn
 akI
 uxm
 aqx
-pQC
+tdY
 akC
 lMC
 jmn
@@ -61524,7 +61666,7 @@ arT
 agP
 kBY
 rWU
-ujV
+wnH
 adt
 irp
 aiO
@@ -61749,7 +61891,7 @@ omU
 aaf
 dpB
 eMy
-tFA
+iyZ
 aOa
 aOa
 aOa
@@ -61868,11 +62010,11 @@ eXA
 gAc
 apC
 apJ
-iEz
+utU
 akk
 aml
 apz
-jse
+kSq
 akC
 vIQ
 cgV
@@ -61913,7 +62055,7 @@ kXn
 aIx
 ehe
 aIK
-wvO
+sbN
 aIT
 aIZ
 aJe
@@ -61959,7 +62101,7 @@ fPK
 aSF
 agb
 agb
-tFj
+eVO
 agb
 agb
 tsZ
@@ -62106,7 +62248,7 @@ aTd
 arS
 asT
 arS
-vOu
+umt
 asM
 aay
 aIe
@@ -62465,13 +62607,13 @@ aaa
 aaa
 aaa
 amy
-brd
+wkg
 akm
 aon
-sQr
+lbK
 anP
 bjn
-eaH
+nYg
 alJ
 alJ
 wlQ
@@ -62484,13 +62626,13 @@ aov
 are
 jcX
 akE
-qYL
+nVr
 jmn
 jmn
 jmn
 jKL
 ari
-rVv
+tTD
 jzX
 arq
 aal
@@ -62538,7 +62680,7 @@ aQL
 fHq
 lgM
 aUv
-pqy
+qdG
 aUv
 aJT
 aQg
@@ -62667,10 +62809,10 @@ xzM
 aaa
 aaa
 cuW
-sQr
+lbK
 akH
 aon
-sQr
+lbK
 anP
 eKw
 wkE
@@ -62923,7 +63065,7 @@ cXD
 qiB
 gUX
 vhO
-myY
+lKI
 aan
 aJb
 aJf
@@ -62951,7 +63093,7 @@ aSj
 kDz
 aMi
 aDj
-rhD
+cCg
 aiD
 pQQ
 aaf
@@ -63116,7 +63258,7 @@ oDo
 wgp
 qTJ
 arS
-aOW
+dwQ
 aan
 aFb
 aIg
@@ -63141,8 +63283,8 @@ aAy
 rnV
 ydg
 agq
-tvu
-dbv
+tfm
+tBt
 agu
 ain
 ajh
@@ -63289,7 +63431,7 @@ lNP
 chJ
 mJw
 gYN
-blo
+uRw
 ufm
 xbK
 vdl
@@ -63532,7 +63674,7 @@ aIR
 mMU
 aan
 aJg
-abv
+oMm
 bGT
 dqy
 arT
@@ -63556,7 +63698,7 @@ aWO
 rPE
 agG
 ahO
-jwX
+inG
 ahO
 agG
 pQQ
@@ -63704,14 +63846,14 @@ sYe
 rZE
 vrs
 lIC
-hxD
+czq
 rZE
 xUb
 aHK
 arJ
 arQ
 dUP
-afr
+eWF
 arw
 wly
 arw
@@ -63768,7 +63910,7 @@ aaB
 aaB
 aaf
 dpB
-eMo
+qPP
 aOa
 aOa
 xPw
@@ -63895,7 +64037,7 @@ fkb
 ktT
 rdb
 apL
-rLl
+fAb
 arb
 alJ
 aZI
@@ -63976,7 +64118,7 @@ agb
 agb
 agb
 agb
-wSi
+xLf
 agb
 agb
 aSF
@@ -64089,7 +64231,7 @@ akq
 alC
 alG
 aky
-bWl
+fGF
 uQH
 eMj
 foP
@@ -64323,7 +64465,7 @@ mOC
 arN
 eGK
 arw
-nYa
+hyL
 ejl
 atj
 atj
@@ -64361,7 +64503,7 @@ aJS
 agy
 ajt
 aZL
-siZ
+xyC
 agG
 eeB
 ahZ
@@ -64501,7 +64643,7 @@ acU
 ktT
 wuC
 apL
-rLl
+fAb
 arb
 alJ
 lMC
@@ -64518,7 +64660,7 @@ uec
 tZb
 tZb
 tZb
-fJe
+iHS
 gtT
 arw
 vAc
@@ -64712,7 +64854,7 @@ cvK
 aTs
 fjw
 aHK
-qbU
+poU
 aHK
 fKN
 fKN
@@ -65143,7 +65285,7 @@ aan
 uZr
 aIu
 aIz
-bxh
+iIE
 ivp
 cXR
 aan
@@ -65312,7 +65454,7 @@ iXd
 ara
 amK
 alJ
-uCB
+wQA
 aHK
 aHK
 nRY
@@ -65507,8 +65649,8 @@ alK
 fAX
 alK
 alK
-gYe
-mJy
+nKV
+eBe
 akx
 svc
 amG
@@ -65577,7 +65719,7 @@ aLN
 ahK
 bZo
 nDp
-dkR
+dAl
 ahL
 jQz
 aaB
@@ -65912,7 +66054,7 @@ oDw
 oDw
 oDw
 rys
-hzE
+uEq
 alJ
 amD
 aYD
@@ -66388,7 +66530,7 @@ jTY
 qYD
 aaf
 jQz
-dTE
+tMe
 aaB
 gmE
 aaa
@@ -66507,7 +66649,7 @@ amh
 iRe
 hkj
 cQq
-rjS
+hgT
 akt
 pdD
 aoX
@@ -66783,7 +66925,7 @@ dxw
 eBx
 xvt
 aAy
-uOT
+ufL
 iBp
 eLL
 aaf
@@ -66955,7 +67097,7 @@ auM
 huX
 mZD
 jIx
-bUx
+cgP
 qcc
 wsJ
 wsJ
@@ -67149,7 +67291,7 @@ yfW
 aTs
 asL
 rAH
-icM
+pPw
 asL
 tDu
 kXr
@@ -67362,7 +67504,7 @@ rNy
 evP
 hhP
 nrM
-hBH
+aZT
 kSb
 fgL
 evP
@@ -67591,7 +67733,7 @@ aAy
 aAy
 aAy
 agz
-uOT
+ufL
 asw
 ago
 ayo
@@ -67791,7 +67933,7 @@ aaa
 agz
 rGk
 bWV
-wRL
+kmo
 ago
 ago
 asw
@@ -68413,7 +68555,7 @@ aHT
 aBr
 ays
 ays
-vrX
+iQT
 agW
 ays
 duJ
@@ -68964,13 +69106,13 @@ aaa
 atT
 auB
 jwk
-rgR
+sXt
 auM
 jwD
 wgq
 bIW
 tDu
-shM
+eAE
 qdC
 auM
 auM
@@ -69007,7 +69149,7 @@ ayg
 axI
 ayu
 ays
-rdm
+pGj
 ayV
 aKn
 aBn

--- a/_maps/map_files/MidwayStation/MidwayStation.dmm
+++ b/_maps/map_files/MidwayStation/MidwayStation.dmm
@@ -149,6 +149,15 @@
 	},
 /turf/open/space/basic,
 /area/engine/engine_room)
+"abv" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/restrooms)
 "abE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -769,6 +778,22 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
+"afr" = (
+/obj/machinery/light,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen/coldroom)
 "afs" = (
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
@@ -1262,14 +1287,6 @@
 /obj/machinery/rnd/bepis,
 /turf/open/floor/plasteel,
 /area/science/explab)
-"aif" = (
-/obj/machinery/camera{
-	c_tag = "Security Post - Science";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science)
 "aig" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -2816,11 +2833,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/main)
-"anQ" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/main)
 "anR" = (
 /obj/structure/closet/bombcloset/security,
 /turf/open/floor/plasteel,
@@ -3696,15 +3708,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aqZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ara" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1;
@@ -4114,18 +4117,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"asD" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "asK" = (
 /turf/closed/wall,
 /area/library)
@@ -4214,10 +4205,6 @@
 /obj/structure/mirror{
 	pixel_y = -32
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"atb" = (
-/obj/structure/closet/crate/wooden/toy,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "atc" = (
@@ -4822,13 +4809,6 @@
 /obj/item/reagent_containers/food/drinks/flask/gold,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
-"awT" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "awU" = (
 /turf/open/floor/plasteel,
 /area/gateway)
@@ -4865,48 +4845,12 @@
 /obj/machinery/gateway/centerstation,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
-"axa" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/exile,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
-"axb" = (
-/obj/structure/table,
-/obj/item/radio/off{
-	pixel_y = 6
-	},
-/obj/item/radio/off{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/radio/off{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/radio/off,
-/turf/open/floor/plasteel,
-/area/gateway)
 "axc" = (
 /turf/closed/wall/r_wall,
 /area/gateway)
 "axg" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/turf/open/floor/plasteel,
-/area/gateway)
-"axi" = (
-/obj/machinery/button/door{
-	id = "stationawaygate";
-	name = "Gateway Access Shutter Control";
-	pixel_x = -1;
-	pixel_y = -24;
-	req_access_txt = "31"
-	},
 /turf/open/floor/plasteel,
 /area/gateway)
 "axk" = (
@@ -6903,12 +6847,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"aGi" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "aGj" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -6921,15 +6859,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"aGl" = (
-/obj/structure/closet/secure_closet/security,
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
 "aGm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 8
@@ -8132,19 +8061,6 @@
 "aLb" = (
 /turf/closed/wall,
 /area/maintenance/department/cargo)
-"aLk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "aLl" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -8440,14 +8356,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"aMA" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "aMB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -8830,21 +8738,23 @@
 /obj/structure/window/spawner/west,
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
-"aOQ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aOT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"aOW" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "aOX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
@@ -9016,22 +8926,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"aPM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/window/spawner/west,
-/obj/structure/window/spawner/east,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/spawner/north,
-/turf/open/floor/grass,
-/area/hallway/primary/aft)
 "aPQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -9372,10 +9266,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"aRX" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "aSc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -9439,13 +9329,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
-"aSy" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "aSD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9740,16 +9623,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/medical/medbay/lobby)
-"aUl" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aUo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -9978,12 +9851,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"aVS" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "aVW" = (
 /obj/machinery/light{
 	dir = 1
@@ -10135,15 +10002,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"aWV" = (
-/obj/structure/table,
-/obj/item/nanite_scanner,
-/obj/item/nanite_remote,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/science/nanite)
 "aWW" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -10271,16 +10129,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aXJ" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
 "aXK" = (
 /obj/structure/window/spawner/east,
 /obj/structure/window/spawner/west,
@@ -10339,19 +10187,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/security/checkpoint/customs)
-"aYw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "aYz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -10622,6 +10457,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"beN" = (
+/obj/structure/closet/secure_closet/exile,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "beT" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/engineering,
@@ -10681,24 +10523,6 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
-"bhf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "bhn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10862,6 +10686,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"bln" = (
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
+"blo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -25;
+	pixel_y = -2;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bmd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -10886,26 +10742,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"bnx" = (
-/obj/structure/closet/secure_closet/security/cargo,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Security Post - Cargo";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
 "boi" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutters,
 /turf/open/floor/plating,
@@ -10955,6 +10791,15 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"brd" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 24
+	},
+/obj/item/clothing/under/rank/security/officer/mallcop,
+/turf/open/floor/plasteel,
+/area/security/main)
 "brB" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -11095,31 +10940,6 @@
 	},
 /turf/open/space/basic,
 /area/maintenance/solars/port/aft)
-"bwz" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/security/med,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/machinery/camera{
-	c_tag = "Security Post - Medbay";
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/security/checkpoint/medical)
 "bwP" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/machinery/camera/autoname{
@@ -11127,26 +10947,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"bxi" = (
-/obj/machinery/camera{
-	c_tag = "Brig Control Room";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/computer/security{
-	dir = 4;
-	icon_state = "computer"
-	},
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
+"bxh" = (
+/obj/structure/table,
+/obj/item/paper/fluff/holodeck/disclaimer,
 /turf/open/floor/plasteel,
-/area/security/warden)
+/area/crew_quarters/fitness/recreation)
 "bxn" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
@@ -11172,6 +10977,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"bxO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/head_of_personnel)
+"byb" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "byK" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
@@ -11433,6 +11260,16 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"bJL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "bKb" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -11707,6 +11544,25 @@
 	},
 /turf/open/floor/plating,
 /area/solar/starboard/fore)
+"bUx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "bUR" = (
 /obj/machinery/power/generator,
 /obj/structure/cable/yellow,
@@ -11771,6 +11627,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"bWl" = (
+/obj/machinery/camera{
+	c_tag = "Brig Control Room";
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/warden)
 "bWP" = (
 /turf/open/space/basic,
 /area/engine/engine_room)
@@ -11816,6 +11691,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
+"bZU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "caq" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -11996,19 +11881,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"chu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "chH" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
@@ -12067,30 +11939,6 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"ckn" = (
-/obj/effect/turf_decal/tile/red,
-/obj/item/kirbyplants/random,
-/obj/structure/sign/directions/security{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = -3
-	},
-/obj/structure/sign/directions/science{
-	pixel_x = 32;
-	pixel_y = -9
-	},
-/obj/structure/sign/directions/evac{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = 9
-	},
-/obj/structure/sign/directions/command{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "ckv" = (
 /obj/machinery/light{
 	dir = 8
@@ -12242,6 +12090,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"cra" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/computer/atmos_control/tank/oxygen_tank{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "crq" = (
 /obj/structure/chair{
 	dir = 4
@@ -12259,6 +12117,17 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"crU" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/security,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/storage/tech)
 "csf" = (
 /obj/machinery/computer/med_data{
 	dir = 8
@@ -12412,15 +12281,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cAL" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "cAP" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/plant_analyzer,
@@ -12584,17 +12444,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
-"cIo" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/computer/atmos_control/tank/oxygen_tank{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "cIN" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
@@ -12854,6 +12703,18 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"cRM" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "cRP" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -13113,6 +12974,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dbv" = (
+/obj/machinery/camera{
+	c_tag = "Security Post - Science";
+	dir = 4;
+	network = list("ss13","rd")
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "dbx" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -13235,9 +13107,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"dgx" = (
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "dgD" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -13343,6 +13212,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"dkR" = (
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "dkS" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -13381,6 +13256,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"dmK" = (
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "dna" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -13620,10 +13505,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"dxa" = (
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "dxw" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -13661,6 +13542,16 @@
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"dzO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "dBR" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -13717,6 +13608,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
+"dDo" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dDP" = (
 /obj/structure/table,
 /obj/item/crowbar,
@@ -13735,6 +13636,19 @@
 "dEi" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"dEv" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dEZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -13894,17 +13808,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"dLB" = (
-/obj/machinery/photocopier,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/lawoffice)
 "dMq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8;
@@ -13966,6 +13869,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"dPg" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "dPI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -14108,6 +14017,10 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"dTE" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "dUi" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 1
@@ -14333,6 +14246,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"eaH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "eaU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -14395,13 +14324,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"ecs" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/radio/off,
-/obj/item/book/manual/wiki/tcomms,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "ecN" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Medical Officer";
@@ -14599,6 +14521,10 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"ejw" = (
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "ejF" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
@@ -14618,6 +14544,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/head_of_personnel)
+"ejK" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel,
+/area/gateway)
 "ejV" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/structure/cable{
@@ -14711,6 +14643,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"enk" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "enP" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -14998,28 +14947,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/security/execution/education)
-"eyR" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -30
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/closet/secure_closet/security/science,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science)
 "eyZ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -15031,20 +14958,6 @@
 /obj/structure/transit_tube/horizontal,
 /turf/open/space/basic,
 /area/space/nearstation)
-"ezl" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Telecommunications";
-	req_access_txt = "61"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "ezK" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -15119,6 +15032,22 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
+"eDJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "eEc" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -15336,16 +15265,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"eMp" = (
-/obj/structure/chair/office{
+"eMo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eMy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15771,6 +15708,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"fgF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "fgL" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
@@ -15855,18 +15805,20 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"fmq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"fmj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/processing)
+/obj/structure/window/spawner/west,
+/obj/structure/window/spawner/east,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/spawner/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/grass,
+/area/hallway/primary/aft)
 "fou" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15946,6 +15898,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"fqv" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ftt" = (
 /turf/closed/wall,
 /area/medical/pharmacy)
@@ -16176,6 +16137,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"fDI" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fDT" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/eight,
@@ -16322,6 +16296,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"fJe" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fJp" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/machinery/meter{
@@ -16666,12 +16653,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/server)
-"gaH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/head_of_personnel)
 "gbe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random{
@@ -16786,6 +16767,21 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"gcV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "gcZ" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
@@ -17642,13 +17638,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"gNt" = (
-/obj/effect/turf_decal/tile/brown{
+"gLP" = (
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/vacant_room/commissary)
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "gND" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/firealarm{
@@ -17782,6 +17777,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"gUb" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "gUc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -17948,6 +17951,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"gYe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 24
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gYo" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
@@ -17973,6 +17997,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"gYV" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "gZB" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -17993,6 +18033,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"gZX" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "hbf" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -18122,19 +18171,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hik" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "stationawaygate";
-	name = "Gateway Access Shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
+"hir" = (
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/gateway)
+/area/hallway/primary/aft)
 "hiP" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -18320,21 +18366,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/bridge)
-"hsw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "hsD" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -18403,19 +18434,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"hvu" = (
-/obj/machinery/light,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen/coldroom)
 "hvv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -18496,13 +18514,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"hxd" = (
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "hxo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -18534,6 +18545,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"hxD" = (
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "hyb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8;
@@ -18630,6 +18647,34 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"hzE" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"hzF" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "hzX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -18651,14 +18696,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"hAp" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/security,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/storage/tech)
 "hAF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -18695,6 +18732,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"hBH" = (
+/obj/item/radio/intercom{
+	pixel_x = -27;
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "hBP" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -18942,6 +18986,16 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"hRf" = (
+/obj/machinery/light,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "hRh" = (
 /obj/item/analyzer{
 	pixel_x = 7;
@@ -19138,20 +19192,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"ibb" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "ibd" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -19159,6 +19199,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"ibJ" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications";
+	req_access_txt = "61"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
+"icM" = (
+/obj/structure/closet/crate/wooden/toy,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "idP" = (
 /obj/machinery/button/door{
 	id = "commissaryshutter";
@@ -19255,6 +19317,16 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"igo" = (
+/obj/structure/closet/secure_closet/security,
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_y = 30
+	},
+/obj/item/clothing/under/rank/security/officer/mallcop,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs)
 "igL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -19303,22 +19375,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"ijx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = 10;
-	pixel_y = 6
-	},
-/obj/item/pen,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "ijB" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
@@ -19441,12 +19497,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"iqS" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "irc" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plating,
@@ -19728,6 +19778,19 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"iEz" = (
+/obj/machinery/computer/cargo/request{
+	dir = 1;
+	icon_state = "computer"
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "iEQ" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/flash/handheld,
@@ -19882,20 +19945,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"iHT" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/table/reinforced,
-/obj/machinery/photocopier/faxmachine/longrange{
-	department = "Captain"
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "iHZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20017,12 +20066,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"iMG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "iNq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -20259,6 +20302,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"iXj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/warehouse)
 "iXP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20347,6 +20398,17 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"jcK" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "jcX" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -20373,6 +20435,18 @@
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel,
 /area/janitor)
+"jef" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "jem" = (
 /obj/item/assembly/timer{
 	pixel_x = 5;
@@ -20459,15 +20533,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"jfm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "jfn" = (
 /turf/closed/wall,
 /area/vacant_room/commissary)
@@ -20493,16 +20558,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/AIsatextAS)
-"jgG" = (
-/obj/machinery/computer/cargo/request{
-	dir = 1;
-	icon_state = "computer"
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "jgR" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -20688,12 +20743,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"jmK" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "jmR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20803,6 +20852,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"jqK" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "jrm" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -20861,6 +20916,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"jse" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "jss" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20897,6 +20968,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"juX" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "jve" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/structure/sign/poster/official/random{
@@ -20961,6 +21046,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"jwX" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/science/storage)
 "jxl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21018,6 +21110,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"jzc" = (
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "jzX" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -21046,16 +21145,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"jCA" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+"jCg" = (
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/structure/closet/lasertag/blue,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/turf/open/floor/plasteel/white/corner,
-/area/crew_quarters/fitness/recreation)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "jCL" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -21127,6 +21228,16 @@
 	},
 /turf/open/floor/circuit,
 /area/maintenance/starboard/central)
+"jHL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jIl" = (
 /obj/structure/sign/poster/contraband,
 /turf/closed/wall,
@@ -21409,6 +21520,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
+"jSk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "jSl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21503,6 +21624,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"jXs" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "jXx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -21838,14 +21969,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"klO" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "kmQ" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
@@ -21928,6 +22051,32 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"kpv" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/security/med,
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Security Post - Medbay";
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/item/clothing/under/rank/security/officer/mallcop,
+/turf/open/floor/plasteel/white,
+/area/security/checkpoint/medical)
 "kpF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22100,6 +22249,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kym" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/lieutenant,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "kzE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -22146,22 +22308,6 @@
 /obj/effect/turf_decal/atmos/oxygen,
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
-"kBW" = (
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "kBY" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
@@ -22210,21 +22356,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"kEW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "kFB" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -22371,6 +22502,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"kPU" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "kQj" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
@@ -22391,16 +22542,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"kRa" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "kRp" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes,
@@ -22655,16 +22796,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"kXX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "kYq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -22967,6 +23098,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"lhj" = (
+/obj/machinery/light,
+/obj/item/kirbyplants/random,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lho" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -22982,31 +23121,6 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"lhF" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "hopqueue";
-	name = "Queue Shutters Control";
-	pixel_x = -4;
-	pixel_y = 25;
-	req_access_txt = "57"
-	},
-/obj/machinery/button/door{
-	id = "hop";
-	name = "Privacy Shutters Control";
-	pixel_x = 6;
-	pixel_y = 25;
-	req_access_txt = "57"
-	},
-/obj/machinery/button/ticket_machine{
-	pixel_x = -32;
-	pixel_y = 38
-	},
-/obj/effect/landmark/start/head_of_personnel,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/head_of_personnel)
 "lhQ" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -23062,6 +23176,12 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"lkC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lkS" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
 	dir = 4
@@ -23103,6 +23223,30 @@
 "lma" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"lmu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "lni" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23273,18 +23417,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"ltG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "luI" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
@@ -23385,15 +23517,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
-"lBA" = (
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "lBE" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -23531,6 +23654,24 @@
 "lIC" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"lJJ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "lJR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -23669,6 +23810,16 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
+"lNz" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "lNP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23688,6 +23839,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"lOc" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "lOj" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -23936,17 +24096,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"lZZ" = (
-/obj/structure/closet/secure_closet/lieutenant,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "mab" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -24123,25 +24272,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"miM" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/camera/autoname,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "miR" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -24356,6 +24486,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"mtx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "mtY" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
@@ -24387,11 +24532,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
-"mvc" = (
-/obj/structure/grille,
-/obj/machinery/light,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "mvo" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8;
@@ -24538,6 +24678,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"myY" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/closet/lasertag/blue,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/crew_quarters/fitness/recreation)
 "mzT" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -24602,6 +24755,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"mDi" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mDJ" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics/cloning)
@@ -24738,6 +24904,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"mJy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mKO" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /obj/machinery/firealarm{
@@ -24821,26 +25012,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/fitness/recreation)
-"mNp" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes{
-	pixel_y = 5
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/storage/box/monkeycubes,
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "mNI" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -24982,16 +25153,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"mUb" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "mUQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -25238,6 +25399,19 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"nha" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nhl" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -25395,6 +25569,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"nmS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nmU" = (
 /obj/structure/plasticflaps,
 /obj/machinery/navbeacon{
@@ -26278,20 +26470,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"nMn" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "nMt" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/vault{
@@ -26343,6 +26521,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
+"nNk" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "nNn" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -26558,6 +26746,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
+"nYa" = (
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/turf/open/floor/carpet,
+/area/library)
 "nYy" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -26734,13 +26928,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"odT" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "odV" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -27104,18 +27291,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
-"oqR" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "orj" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Aft";
@@ -27290,11 +27465,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"oBY" = (
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/obj/machinery/light,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "oCt" = (
 /obj/machinery/power/apc/auto_name/east{
 	pixel_x = 24
@@ -27454,10 +27624,46 @@
 /obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
+"oFB" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "hopqueue";
+	name = "Queue Shutters Control";
+	pixel_x = -4;
+	pixel_y = 25;
+	req_access_txt = "57"
+	},
+/obj/machinery/button/door{
+	id = "hop";
+	name = "Privacy Shutters Control";
+	pixel_x = 6;
+	pixel_y = 25;
+	req_access_txt = "57"
+	},
+/obj/machinery/button/ticket_machine{
+	pixel_x = -4;
+	pixel_y = 33
+	},
+/obj/effect/landmark/start/head_of_personnel,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/head_of_personnel)
 "oGB" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"oGC" = (
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oHk" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks,
@@ -27592,6 +27798,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"oOI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "oOJ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -27747,6 +27966,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"oXB" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oYs" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/disposalpipe/segment{
@@ -27785,16 +28014,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"pai" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "pay" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Airlock"
@@ -27899,6 +28118,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"pdF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/fireaxecabinet{
+	pixel_x = 1;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "pdJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -28063,6 +28296,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"pjU" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "pkl" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -28284,6 +28524,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tech)
+"pqy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"psm" = (
+/obj/structure/closet/emcloset,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "psq" = (
 /obj/machinery/light,
 /obj/effect/landmark/start/assistant,
@@ -28376,18 +28632,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"pva" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "pvF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -28457,6 +28701,34 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"pzD" = (
+/obj/effect/turf_decal/tile/red,
+/obj/item/kirbyplants/random,
+/obj/structure/sign/directions/security{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = -3
+	},
+/obj/structure/sign/directions/science{
+	pixel_x = 32;
+	pixel_y = -9
+	},
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 9
+	},
+/obj/structure/sign/directions/command{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 3
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "pzJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
@@ -28468,6 +28740,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
+"pAz" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "pBt" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -28583,6 +28867,18 @@
 /obj/item/storage/crayons,
 /turf/open/floor/wood,
 /area/library)
+"pEV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "pFC" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -28689,21 +28985,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"pIo" = (
-/obj/machinery/camera{
-	c_tag = "Gateway";
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "pIr" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -28745,27 +29026,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"pIW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "pIY" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -28838,16 +29098,6 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"pMU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "pNl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "permacell1";
@@ -28875,14 +29125,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"pNw" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "pNI" = (
 /obj/machinery/stasis,
 /obj/effect/turf_decal/tile/blue{
@@ -28950,6 +29192,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"pQC" = (
+/obj/machinery/photocopier,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "pQQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29295,18 +29551,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/lobby)
-"qbK" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+"qbU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qcc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29379,6 +29638,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"qhv" = (
+/obj/machinery/airalarm/directional/south{
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "qhY" = (
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/dark,
@@ -29502,6 +29778,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qlQ" = (
+/obj/structure/closet/secure_closet/security/cargo,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Security Post - Cargo";
+	dir = 1
+	},
+/obj/item/clothing/under/rank/security/officer/mallcop,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "qlX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29890,16 +30187,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"qGj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "qGl" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29914,6 +30201,20 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
+"qGY" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/radio/off,
+/obj/item/book/manual/wiki/tcomms,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "qHo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -29954,6 +30255,21 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"qJr" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "qJt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -30132,6 +30448,22 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"qPX" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "qQu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30371,6 +30703,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"qWV" = (
+/obj/machinery/power/floodlight,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "qYs" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Lab";
@@ -30389,13 +30728,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"qYA" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "qYD" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -30420,6 +30752,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"qYL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qZU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30511,6 +30859,29 @@
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"rdm" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = 5
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/storage/box/monkeycubes,
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "rdX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -30593,6 +30964,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rgR" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "rht" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -30610,6 +30996,18 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"rhD" = (
+/obj/structure/table,
+/obj/item/nanite_scanner,
+/obj/item/nanite_remote,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/science/nanite)
 "rhG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30670,6 +31068,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/medical)
+"rjS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "rkq" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Science Maintenance";
@@ -30700,18 +31113,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"rmk" = (
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/chair{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -30914,6 +31315,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rvp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "rvC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -31339,6 +31756,22 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/fitness/recreation)
+"rLl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -25;
+	pixel_y = -2;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rLt" = (
 /obj/machinery/light{
 	dir = 8
@@ -31568,6 +32001,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rVv" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin,
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "rVY" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -31892,6 +32347,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"siZ" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "sjT" = (
 /obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plating,
@@ -32006,10 +32470,6 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"spB" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "spU" = (
 /obj/machinery/button/door{
 	id = "ceprivacy";
@@ -32026,6 +32486,22 @@
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"sqe" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "sql" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Maintenance";
@@ -32196,16 +32672,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"swX" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/shower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
 "sxe" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -32238,25 +32704,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"syT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/shower,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_room)
+"szg" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/turf/closed/wall,
+/area/hallway/secondary/exit/departure_lounge)
 "szn" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
@@ -32394,16 +32845,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"sGy" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "sGD" = (
 /mob/living/carbon/monkey,
 /obj/effect/turf_decal/tile/green{
@@ -32544,6 +32985,18 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/head_of_personnel)
+"sMJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "sML" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -32552,27 +33005,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/medical)
-"sNz" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"sNP" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "sOj" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -32641,6 +33073,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"sQr" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/obj/item/clothing/under/rank/security/officer/mallcop,
+/turf/open/floor/plasteel,
+/area/security/main)
+"sQu" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Control Room";
+	req_access_txt = "19; 61"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "sQv" = (
 /obj/structure/closet/crate/solarpanel_small,
 /obj/machinery/light{
@@ -32787,15 +33241,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
-"sVA" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "sWj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -32854,11 +33299,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"sXB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
 "sYe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -32887,15 +33327,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"sYq" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "sYU" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -33506,6 +33937,29 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"tvu" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -30
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/closet/secure_closet/security/science,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/clothing/under/rank/security/officer/mallcop,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "twc" = (
 /obj/structure/chair/pew/right{
 	dir = 4;
@@ -33578,15 +34032,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"tze" = (
-/obj/structure/table,
-/obj/item/gun/syringe,
-/obj/item/clothing/neck/stethoscope,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "tAf" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -33615,19 +34060,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
-"tDd" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "tDu" = (
 /turf/open/floor/carpet,
 /area/chapel/main)
@@ -33661,12 +34093,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"tEd" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "tFb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/closed/wall,
 /area/maintenance/department/science)
+"tFj" = (
+/obj/machinery/vending/cola/random,
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"tFA" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tFK" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -33793,15 +34249,48 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"tPU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
+"tPF" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Gateway"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/gateway)
+"tPT" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"tPV" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "tQo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -33879,15 +34368,6 @@
 	},
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"tRv" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -34008,18 +34488,6 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
-"tTF" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "tTK" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -34123,6 +34591,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"tXf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "tXh" = (
 /obj/structure/transit_tube/horizontal{
 	dir = 2
@@ -34136,20 +34611,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"tXA" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Control Room";
-	req_access_txt = "19; 61"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "tXL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -34247,6 +34708,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"udA" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "uec" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34352,6 +34823,18 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"ueW" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "uff" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -34547,6 +35030,19 @@
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"ujV" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
 "uln" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -34654,6 +35150,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"unD" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "unN" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -34663,6 +35169,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"uoi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/shower{
+	pixel_y = 15
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "uoq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -34905,6 +35432,24 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"uCB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "uDC" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 8
@@ -35043,24 +35588,6 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/primary/central)
-"uHs" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "uHY" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
@@ -35282,6 +35809,15 @@
 /obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/plasteel/white,
 /area/security/checkpoint/medical)
+"uOT" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "uPE" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "armory";
@@ -35366,6 +35902,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"uRk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	freerange = 1;
+	name = "Station Intercom (Telecomms)";
+	pixel_y = 30
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "uRy" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -35451,6 +36000,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"uVw" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "uWu" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -35929,25 +36488,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"vkY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vlo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -35957,6 +36497,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"vlw" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine/longrange{
+	department = "Captain"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "vlL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4;
@@ -36093,6 +36647,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"vrE" = (
+/obj/machinery/camera/autoname,
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "vrH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
@@ -36122,6 +36681,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"vrX" = (
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "vsa" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
@@ -36349,6 +36914,29 @@
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"vym" = (
+/obj/machinery/button/door{
+	id = "stationawaygate";
+	name = "Gateway Access Shutter Control";
+	pixel_x = -1;
+	pixel_y = -24;
+	req_access_txt = "31"
+	},
+/obj/structure/table,
+/obj/item/radio/off{
+	pixel_y = 6
+	},
+/obj/item/radio/off{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/radio/off{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/radio/off,
+/turf/open/floor/plasteel,
+/area/gateway)
 "vyy" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/AI,
@@ -36403,6 +36991,9 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"vAL" = (
+/turf/open/space/basic,
+/area/space/nearstation)
 "vBo" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -36545,10 +37136,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vFN" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/gateway)
 "vFS" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -36559,19 +37146,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"vGR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "vHn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -36662,6 +37236,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"vOu" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "vOG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8;
@@ -36831,6 +37418,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
+"vWI" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/vending/cola/random,
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "vWJ" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
@@ -37052,6 +37652,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"wfc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "wgi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -37102,10 +37708,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"wii" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "wkE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1;
@@ -37190,6 +37792,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"wmf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "wmu" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -37273,6 +37881,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
+"wrO" = (
+/obj/structure/table,
+/obj/item/gun/syringe,
+/obj/item/clothing/neck/stethoscope,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "wrS" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -37354,6 +37974,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"wvO" = (
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "wvP" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -37842,16 +38469,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"wIA" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "wIK" = (
 /obj/item/assembly/prox_sensor{
 	pixel_x = -4;
@@ -38111,6 +38728,19 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"wRl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wRz" = (
 /obj/machinery/computer/shuttle/labor{
 	dir = 1
@@ -38145,6 +38775,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
+"wRL" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "wRU" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -38161,6 +38800,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"wSi" = (
+/obj/item/radio/intercom{
+	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -38207,6 +38852,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"wVG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "wVW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -38540,21 +39195,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"xmd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+"xmx" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 24
+/obj/item/radio/intercom{
+	pixel_x = 31;
+	pixel_y = -5
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/fore)
 "xmB" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -38635,17 +39285,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"xoE" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "xoU" = (
 /obj/machinery/light{
 	dir = 4
@@ -39084,6 +39723,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"xEI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "xFD" = (
 /obj/effect/landmark/start/chief_engineer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39164,15 +39824,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"xHQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "xHT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39419,6 +40070,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"xOe" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "xOf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -39572,16 +40234,6 @@
 	},
 /turf/closed/wall,
 /area/lawoffice)
-"xVY" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "xWt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -39846,14 +40498,6 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
-"yhT" = (
-/obj/structure/table,
-/obj/item/paper/fluff/holodeck/disclaimer,
-/obj/machinery/airalarm/directional/east{
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "yig" = (
 /obj/machinery/door/airlock{
 	name = "Unit 2"
@@ -47326,8 +47970,8 @@ umv
 aDY
 aEe
 aHm
-oBY
-mvc
+ejw
+aBM
 aaa
 aaa
 aaa
@@ -47529,7 +48173,7 @@ aEa
 gAb
 rXg
 rXU
-mvc
+aBM
 aaa
 aaa
 aaa
@@ -48124,7 +48768,7 @@ aDF
 aDF
 aDF
 aDF
-aDF
+qWV
 aDF
 aDF
 aDF
@@ -48321,17 +48965,17 @@ aaa
 aaa
 aaa
 aCU
-sVA
+lkC
 aDF
 aDF
 aDF
 aDF
-aDF
+wfc
 aDF
 aDF
 aDF
 aEQ
-cIo
+cra
 bDi
 aEb
 aBM
@@ -48528,7 +49172,7 @@ aDF
 aDF
 aDF
 aDF
-aDF
+wfc
 aDF
 aDF
 nyP
@@ -48730,7 +49374,7 @@ aCV
 aDF
 aDF
 aDF
-aDF
+wfc
 oGB
 aDF
 aDF
@@ -48932,7 +49576,7 @@ aFj
 aDF
 aDF
 eRK
-aDF
+wfc
 aDF
 aDF
 uhV
@@ -49134,7 +49778,7 @@ aFj
 aDF
 aDF
 aDF
-aDF
+wfc
 aDF
 aFR
 aGc
@@ -49336,9 +49980,9 @@ liE
 aDF
 aDF
 aDF
-aDF
-aDF
-cAL
+jqK
+ePN
+pAz
 ePN
 pSg
 aRy
@@ -50366,7 +51010,7 @@ aAL
 azf
 ibd
 aDi
-swX
+byb
 aax
 aaa
 aaa
@@ -52784,11 +53428,11 @@ avp
 mpb
 auD
 wJo
-syT
+uoi
 vEV
 wuV
 xNb
-qYA
+jXs
 aEw
 dZZ
 ayt
@@ -53384,7 +54028,7 @@ sEp
 fTz
 hFS
 ePK
-ecs
+qGY
 iOp
 ePK
 seM
@@ -53585,12 +54229,12 @@ wJO
 raz
 tqq
 eFY
-ezl
-iMG
-aGi
+ibJ
+bJL
+jCg
 vcr
-dgx
-dgx
+tXf
+wmf
 aBL
 aCm
 xFD
@@ -53788,11 +54432,11 @@ aKa
 aDr
 fXx
 ePK
-oqR
-xHQ
-tXA
-iMG
-eMp
+uRk
+mtx
+sQu
+wVG
+tPV
 aBL
 spU
 mbf
@@ -53977,7 +54621,7 @@ aAW
 qDU
 abM
 aqc
-asD
+qJr
 axO
 aWP
 aco
@@ -54390,9 +55034,9 @@ gkE
 pHY
 nJw
 aco
-aKx
-cNl
-fXx
+cRM
+nmS
+gcV
 ePK
 vfz
 ptK
@@ -55800,7 +56444,7 @@ aSr
 nYy
 act
 jeS
-aSy
+dmK
 cMA
 adA
 adH
@@ -55987,7 +56631,7 @@ abc
 abc
 rZL
 abc
-pNw
+jcK
 eBX
 aAW
 bgz
@@ -56011,7 +56655,7 @@ aDr
 lxB
 eZl
 bJh
-hAp
+crU
 gYv
 beT
 vMt
@@ -56209,7 +56853,7 @@ eMl
 fxu
 act
 vLm
-pIW
+xxn
 opL
 bPS
 pqi
@@ -56378,7 +57022,7 @@ ash
 thX
 vfM
 lLj
-kBW
+qhv
 aua
 aaa
 aaa
@@ -56583,7 +57227,7 @@ ydl
 uhX
 aua
 aaa
-aaa
+vAL
 aaa
 aaa
 eBX
@@ -56610,11 +57254,11 @@ act
 aKB
 aKK
 adU
-tze
+wrO
 act
 aWY
 aDr
-fXx
+sMJ
 eZl
 eZl
 eZl
@@ -56627,7 +57271,7 @@ vMt
 siP
 aZz
 aZz
-aZz
+tgr
 aZz
 bad
 aZz
@@ -56784,8 +57428,8 @@ fMM
 vTp
 nca
 wDq
-aaa
-aaa
+nMT
+nMT
 aaa
 aaa
 pRz
@@ -56986,9 +57630,9 @@ uJX
 iHx
 wRz
 wDq
-aaa
-nMT
-nMT
+tlz
+tlz
+tlz
 nMT
 pRz
 wcH
@@ -57041,7 +57685,7 @@ abe
 rqS
 vas
 bjl
-sXB
+iXj
 aea
 aed
 aed
@@ -57188,18 +57832,18 @@ fMM
 lcP
 uRL
 wDq
-nMT
-nMT
+kym
+sqe
+tlz
 aaa
-aaa
-pRz
-wcH
-abc
-abc
-abc
-abc
-abc
-xVY
+tEd
+kPU
+mqp
+mqp
+fWW
+mqp
+mkd
+lJJ
 eBX
 aAW
 tRJ
@@ -57390,18 +58034,18 @@ fMM
 mrM
 dUi
 wDq
-tlz
-tlz
-tlz
-aaa
-pRz
-nMn
-mqp
-mqp
-fWW
-mqp
-mkd
-ibb
+ykQ
+gSi
+gUb
+oms
+axc
+axc
+axc
+axc
+axc
+axc
+eBX
+eBX
 eBX
 aAW
 kTr
@@ -57418,13 +58062,13 @@ acy
 xKn
 nBj
 aKQ
-bwz
+kpv
 acy
 aKx
 aDr
 aUL
 aGN
-odT
+lNz
 aHq
 mGT
 aHs
@@ -57583,7 +58227,7 @@ sVo
 ban
 tgv
 aua
-pMU
+pdF
 rpo
 ePk
 sLk
@@ -57592,19 +58236,19 @@ sLk
 xgO
 dgD
 lUx
-tTF
-iHT
-tlz
-aaa
-axc
-axc
-axc
-axc
-axc
-axc
-eBX
-eBX
-eBX
+nNk
+vlw
+gUb
+aAW
+dPg
+aAW
+aAW
+aAW
+aAW
+aAW
+aAW
+aAW
+udA
 aAW
 kTr
 aaM
@@ -57794,21 +58438,21 @@ ofj
 jox
 mrv
 aua
-ykQ
-gSi
-tlz
-aaa
+gUb
+gUb
+gUb
+aAW
 axc
-seG
-dKl
-tUW
-awU
+axc
+axc
+axc
+axc
 axc
 axk
 axk
 axk
 axk
-kTr
+lmu
 ftt
 boN
 tkW
@@ -57993,18 +58637,18 @@ auc
 auc
 auc
 auc
-bhf
-pai
-aua
-lZZ
-ijx
-tlz
-aaa
+xEI
+gLP
+xOe
+aAW
+aAW
+pjU
+aAW
 axc
+seG
 dKl
-awY
-dKl
-aOk
+tUW
+ejK
 axc
 rgj
 qFO
@@ -58078,7 +58722,7 @@ yhb
 aNn
 mqW
 joZ
-aPz
+jHL
 aSF
 agb
 agb
@@ -58096,7 +58740,7 @@ agb
 agb
 agb
 enP
-joZ
+gZX
 oLM
 agb
 aSF
@@ -58166,14 +58810,14 @@ aaa
 aaa
 aaa
 aaa
-sZy
-sZy
-sZy
-aTu
-aTu
-sZy
-sZy
-aTu
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -58203,10 +58847,10 @@ awb
 awb
 awb
 awb
-tUW
 dKl
-seG
-lSb
+awY
+dKl
+aOk
 axc
 mfG
 axp
@@ -58226,7 +58870,7 @@ aKw
 gSc
 xyl
 lVq
-kRa
+vWI
 dGE
 qTY
 lsI
@@ -58368,14 +59012,14 @@ aaa
 aaa
 aaa
 aaa
-loP
-bxv
-kLe
-mbq
-oVY
-joi
-spB
-aTu
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 qiK
 qiK
@@ -58405,10 +59049,10 @@ kPx
 awB
 awl
 awb
-awT
-axa
-axg
-iqS
+tUW
+dKl
+seG
+lSb
 axc
 tnG
 rTH
@@ -58457,7 +59101,7 @@ qOT
 ugj
 oFm
 aeb
-sGy
+juX
 qta
 afd
 nNC
@@ -58574,10 +59218,10 @@ sZy
 sZy
 sZy
 aTu
-tyF
-wVW
-bCs
+aTu
 sZy
+sZy
+aTu
 nMT
 nMT
 nMT
@@ -58593,7 +59237,7 @@ uQi
 oOo
 vsf
 akD
-lhF
+oFB
 bNa
 tbo
 mxO
@@ -58607,10 +59251,10 @@ awt
 awC
 eBo
 awb
-lBA
-awU
-awU
-vFN
+bln
+beN
+axg
+hRf
 axc
 rFe
 axp
@@ -58657,7 +59301,7 @@ jfn
 mOH
 qkt
 lOO
-gNt
+unD
 aeb
 kAX
 tDL
@@ -58772,14 +59416,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+loP
+bxv
+kLe
+mbq
+oVY
+joi
+psm
 aTu
-jmK
-nXv
-jwC
-sZy
 aaa
 nMT
 aaa
@@ -58809,8 +59453,8 @@ akT
 awD
 awJ
 awb
-pIo
-axb
+tPF
+awU
 awU
 awU
 axc
@@ -58865,14 +59509,14 @@ iJD
 iMl
 aez
 vZE
-aLk
+eDJ
 aLo
 whB
 afp
 rSR
 aRs
 aBF
-bnx
+qlQ
 afo
 aOI
 aIm
@@ -58883,7 +59527,7 @@ aJw
 aIm
 agb
 vxG
-dli
+lhj
 aOa
 aaa
 xPw
@@ -58974,14 +59618,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 sZy
-wii
-qJt
-dbx
+sZy
+sZy
 aTu
+tyF
+wVW
+bCs
+sZy
 aaa
 nMT
 aaa
@@ -59001,7 +59645,7 @@ aup
 aup
 aup
 tpf
-gaH
+bxO
 akD
 eNM
 hrV
@@ -59014,7 +59658,7 @@ awb
 hwF
 hSN
 awU
-axi
+vym
 axc
 umI
 axp
@@ -59179,11 +59823,11 @@ aaa
 aaa
 aaa
 aaa
+szg
+jzc
+nXv
+jwC
 sZy
-wii
-wVW
-rmk
-aTu
 lEA
 lEA
 lEA
@@ -59216,7 +59860,7 @@ awb
 sBP
 axc
 wHf
-hik
+axc
 axc
 dPJ
 axk
@@ -59381,10 +60025,10 @@ aaa
 aaa
 aaa
 aaa
-aTu
-dxa
-wVW
-jfm
+sZy
+vrE
+qJt
+dbx
 aTu
 aXx
 aXx
@@ -59406,19 +60050,19 @@ ixh
 ixh
 wOj
 ome
-tDd
+enk
 yjm
 ixh
 hBP
 jwl
-ixh
-sYq
+fgF
+ueW
 mRq
 qMM
 wGh
 cUx
 ufC
-tPU
+pEV
 mKS
 run
 qJx
@@ -59426,15 +60070,15 @@ nxN
 tRj
 jqd
 wlF
-arn
-aUl
-aOQ
+fqv
+dDo
+fDI
 arn
 arn
 xCn
 oNv
 nIk
-xCn
+oXB
 oNv
 xCn
 oNv
@@ -59453,7 +60097,7 @@ jss
 vcZ
 nyq
 pIY
-dLu
+mDi
 ykt
 aah
 nvy
@@ -59467,8 +60111,8 @@ ugE
 dtr
 aqL
 bKV
-aKZ
-qbK
+jef
+gYV
 rVY
 eOu
 afR
@@ -59478,13 +60122,13 @@ iPf
 aKZ
 aDx
 aKZ
-sNz
+qPX
 aKY
 aKY
 aKY
 aKY
 rLt
-aKY
+lOc
 cpz
 dnf
 agb
@@ -59586,7 +60230,7 @@ sZy
 aTu
 ctu
 rkG
-uQP
+aYZ
 rii
 aac
 aac
@@ -59608,12 +60252,12 @@ aac
 aac
 aac
 vDI
-aac
+hzF
 wBN
 dox
 dox
 mfi
-dox
+bZU
 dox
 dox
 dox
@@ -59629,14 +60273,14 @@ ayW
 ugF
 aah
 aah
-aah
+tGC
 aah
 aah
 aah
 aHz
 aah
 aah
-aah
+tGC
 aah
 aah
 aah
@@ -59655,7 +60299,7 @@ ayW
 aah
 avY
 aah
-aah
+tGC
 aah
 tQH
 lDd
@@ -59670,7 +60314,7 @@ dtr
 aOT
 afR
 afR
-afR
+kJZ
 aNR
 aOT
 afR
@@ -59680,7 +60324,7 @@ aNW
 afR
 afR
 afR
-afR
+kJZ
 afR
 afR
 afR
@@ -59788,7 +60432,7 @@ vqv
 wdg
 qdr
 osc
-qGj
+jSk
 iNq
 bDO
 bDO
@@ -59838,7 +60482,7 @@ aZr
 jya
 aWt
 aWt
-aWt
+xhl
 aWt
 aWt
 aWt
@@ -59859,7 +60503,7 @@ aJF
 kKt
 iFn
 aZr
-kXX
+wRl
 aYn
 aXh
 htV
@@ -59870,9 +60514,9 @@ uIa
 fMt
 iRM
 aUK
+oOI
 aWw
-aWw
-aPM
+fmj
 aBb
 boL
 aEJ
@@ -59990,7 +60634,7 @@ sZy
 aTu
 tyF
 hOJ
-aYZ
+uQP
 rii
 soG
 aac
@@ -60012,12 +60656,12 @@ aac
 aac
 aac
 khy
-omS
+dzO
 oZB
 omS
 omS
 uuh
-omS
+dzO
 omS
 omS
 omS
@@ -60033,14 +60677,14 @@ aZn
 aah
 aah
 aah
-aah
+tGC
 aah
 aah
 aah
 aZn
 aah
 aah
-aah
+tGC
 aah
 aah
 aah
@@ -60059,7 +60703,7 @@ aZn
 aah
 aah
 aah
-aah
+tGC
 aah
 wpK
 aaA
@@ -60072,9 +60716,9 @@ tPe
 afR
 afR
 aOT
-afR
-afR
 aNV
+afR
+kJZ
 jyb
 afR
 afR
@@ -60084,7 +60728,7 @@ aQy
 afR
 afR
 afR
-afR
+kJZ
 afR
 afR
 jAR
@@ -60192,7 +60836,7 @@ aaa
 aTu
 fBJ
 kbs
-xoE
+tPT
 aTu
 aOF
 aOL
@@ -60211,15 +60855,15 @@ txC
 yfP
 acF
 mab
-acF
+xmx
 atU
 xOr
-acF
+uVw
 yfP
 acF
 aac
 bzD
-ckn
+pzD
 aft
 mZc
 aft
@@ -60235,14 +60879,14 @@ ezO
 afs
 afs
 afs
-hxd
+oGC
 kdc
 anv
 lvo
 aZn
 xoU
 aah
-aah
+tGC
 aah
 aah
 aah
@@ -60261,7 +60905,7 @@ xAn
 cFd
 wad
 mjB
-tRv
+nha
 rYw
 hsD
 llb
@@ -60276,7 +60920,7 @@ pIT
 aRb
 ajq
 ajq
-ajq
+hir
 ajq
 ajq
 aZm
@@ -60286,7 +60930,7 @@ aWU
 aOp
 kVh
 ajq
-sNP
+dEv
 ajq
 ajq
 aOT
@@ -60467,7 +61111,7 @@ aIT
 aIT
 aIT
 aaA
-aGl
+igo
 aVB
 wcL
 aDc
@@ -60686,7 +61330,7 @@ aiW
 aEd
 agn
 fBb
-aYw
+rvp
 agn
 rBz
 sio
@@ -60828,7 +61472,7 @@ kwn
 akI
 uxm
 aqx
-dLB
+pQC
 akC
 lMC
 jmn
@@ -60856,7 +61500,7 @@ aTd
 ati
 atl
 ati
-mUb
+arS
 asM
 aay
 aIe
@@ -60880,7 +61524,7 @@ arT
 agP
 kBY
 rWU
-aXJ
+ujV
 adt
 irp
 aiO
@@ -61105,7 +61749,7 @@ omU
 aaf
 dpB
 eMy
-dpB
+tFA
 aOa
 aOa
 aOa
@@ -61224,11 +61868,11 @@ eXA
 gAc
 apC
 apJ
-jgG
+iEz
 akk
 aml
 apz
-jUL
+jse
 akC
 vIQ
 cgV
@@ -61269,7 +61913,7 @@ kXn
 aIx
 ehe
 aIK
-aRX
+wvO
 aIT
 aIZ
 aJe
@@ -61315,7 +61959,7 @@ fPK
 aSF
 agb
 agb
-xXj
+tFj
 agb
 agb
 tsZ
@@ -61462,7 +62106,7 @@ aTd
 arS
 asT
 arS
-wIA
+vOu
 asM
 aay
 aIe
@@ -61478,7 +62122,7 @@ aIT
 aIT
 xsP
 arT
-arT
+dxw
 hWY
 arT
 arT
@@ -61821,13 +62465,13 @@ aaa
 aaa
 aaa
 amy
-klO
+brd
 akm
 aon
-anQ
+sQr
 anP
 bjn
-chu
+eaH
 alJ
 alJ
 wlQ
@@ -61840,13 +62484,13 @@ aov
 are
 jcX
 akE
-vGR
+qYL
 jmn
 jmn
 jmn
 jKL
 ari
-miM
+rVv
 jzX
 arq
 aal
@@ -61894,7 +62538,7 @@ aQL
 fHq
 lgM
 aUv
-aUv
+pqy
 aUv
 aJT
 aQg
@@ -62023,10 +62667,10 @@ xzM
 aaa
 aaa
 cuW
-anQ
+sQr
 akH
 aon
-anQ
+sQr
 anP
 eKw
 wkE
@@ -62279,7 +62923,7 @@ cXD
 qiB
 gUX
 vhO
-jCA
+myY
 aan
 aJb
 aJf
@@ -62307,7 +62951,7 @@ aSj
 kDz
 aMi
 aDj
-aWV
+rhD
 aiD
 pQQ
 aaf
@@ -62472,7 +63116,7 @@ oDo
 wgp
 qTJ
 arS
-aMA
+aOW
 aan
 aFb
 aIg
@@ -62497,8 +63141,8 @@ aAy
 rnV
 ydg
 agq
-eyR
-aif
+tvu
+dbv
 agu
 ain
 ajh
@@ -62645,7 +63289,7 @@ lNP
 chJ
 mJw
 gYN
-ltG
+blo
 ufm
 xbK
 vdl
@@ -62888,7 +63532,7 @@ aIR
 mMU
 aan
 aJg
-aJg
+abv
 bGT
 dqy
 arT
@@ -62912,7 +63556,7 @@ aWO
 rPE
 agG
 ahO
-ahO
+jwX
 ahO
 agG
 pQQ
@@ -63060,14 +63704,14 @@ sYe
 rZE
 vrs
 lIC
-lIC
+hxD
 rZE
 xUb
 aHK
 arJ
 arQ
 dUP
-hvu
+afr
 arw
 wly
 arw
@@ -63124,7 +63768,7 @@ aaB
 aaB
 aaf
 dpB
-kEW
+eMo
 aOa
 aOa
 xPw
@@ -63251,7 +63895,7 @@ fkb
 ktT
 rdb
 apL
-aqZ
+rLl
 arb
 alJ
 aZI
@@ -63332,7 +63976,7 @@ agb
 agb
 agb
 agb
-agb
+wSi
 agb
 agb
 aSF
@@ -63445,7 +64089,7 @@ akq
 alC
 alG
 aky
-bxi
+bWl
 uQH
 eMj
 foP
@@ -63679,7 +64323,7 @@ mOC
 arN
 eGK
 arw
-ozc
+nYa
 ejl
 atj
 atj
@@ -63717,7 +64361,7 @@ aJS
 agy
 ajt
 aZL
-aLI
+siZ
 agG
 eeB
 ahZ
@@ -63857,7 +64501,7 @@ acU
 ktT
 wuC
 apL
-aqZ
+rLl
 arb
 alJ
 lMC
@@ -63874,7 +64518,7 @@ uec
 tZb
 tZb
 tZb
-tZb
+fJe
 gtT
 arw
 vAc
@@ -64068,7 +64712,7 @@ cvK
 aTs
 fjw
 aHK
-wBG
+qbU
 aHK
 fKN
 fKN
@@ -64499,7 +65143,7 @@ aan
 uZr
 aIu
 aIz
-yhT
+bxh
 ivp
 cXR
 aan
@@ -64668,7 +65312,7 @@ iXd
 ara
 amK
 alJ
-lMC
+uCB
 aHK
 aHK
 nRY
@@ -64863,8 +65507,8 @@ alK
 fAX
 alK
 alK
-xmd
-vkY
+gYe
+mJy
 akx
 svc
 amG
@@ -64933,7 +65577,7 @@ aLN
 ahK
 bZo
 nDp
-ahR
+dkR
 ahL
 jQz
 aaB
@@ -65268,7 +65912,7 @@ oDw
 oDw
 oDw
 rys
-uHs
+hzE
 alJ
 amD
 aYD
@@ -65744,7 +66388,7 @@ jTY
 qYD
 aaf
 jQz
-aaB
+dTE
 aaB
 gmE
 aaa
@@ -65863,7 +66507,7 @@ amh
 iRe
 hkj
 cQq
-fmq
+rjS
 akt
 pdD
 aoX
@@ -66139,7 +66783,7 @@ dxw
 eBx
 xvt
 aAy
-aVS
+uOT
 iBp
 eLL
 aaf
@@ -66311,7 +66955,7 @@ auM
 huX
 mZD
 jIx
-hsw
+bUx
 qcc
 wsJ
 wsJ
@@ -66505,7 +67149,7 @@ yfW
 aTs
 asL
 rAH
-atb
+icM
 asL
 tDu
 kXr
@@ -66718,7 +67362,7 @@ rNy
 evP
 hhP
 nrM
-kSb
+hBH
 kSb
 fgL
 evP
@@ -66947,7 +67591,7 @@ aAy
 aAy
 aAy
 agz
-aVS
+uOT
 asw
 ago
 ayo
@@ -67147,7 +67791,7 @@ aaa
 agz
 rGk
 bWV
-eLL
+wRL
 ago
 ago
 asw
@@ -67769,7 +68413,7 @@ aHT
 aBr
 ays
 ays
-ays
+vrX
 agW
 ays
 duJ
@@ -68320,7 +68964,7 @@ aaa
 atT
 auB
 jwk
-pva
+rgR
 auM
 jwD
 wgq
@@ -68363,7 +69007,7 @@ ayg
 axI
 ayu
 ays
-mNp
+rdm
 ayV
 aKn
 aBn

--- a/_maps/midwaystation.json
+++ b/_maps/midwaystation.json
@@ -6,6 +6,6 @@
 	    "cargo": "cargo_box",
 	    "ferry": "ferry_fancy",
 		"whiteship": "whiteship_midway",
-	    "emergency": "emergency_box"
+	    "emergency": "emergency_midway"
     }
 }

--- a/_maps/shuttles/emergency_midway.dmm
+++ b/_maps/shuttles/emergency_midway.dmm
@@ -1,5 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
+"aa" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
@@ -8,23 +8,23 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"b" = (
+"ab" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"c" = (
+"ac" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"d" = (
+"ad" = (
 /obj/machinery/computer/crew{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"e" = (
+"ae" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
@@ -33,7 +33,7 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"f" = (
+"af" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
@@ -49,17 +49,17 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"g" = (
+"ag" = (
 /obj/machinery/computer/security{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"h" = (
+"ah" = (
 /obj/structure/closet/crate,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"j" = (
+"aj" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
@@ -75,31 +75,25 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"k" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"l" = (
+"al" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock";
 	req_access_txt = "2"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"m" = (
+"am" = (
 /obj/structure/closet,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"n" = (
+"an" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Cockpit";
 	req_access_txt = "19"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"o" = (
+"ao" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular{
 	pixel_x = 2;
@@ -109,84 +103,84 @@
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"p" = (
+"ap" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Infirmary"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"q" = (
+"aq" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"r" = (
+"ar" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"s" = (
+"as" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"u" = (
+"au" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"v" = (
+"av" = (
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"w" = (
+"aw" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"y" = (
+"ay" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"z" = (
+"az" = (
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"A" = (
+"aA" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"B" = (
+"aB" = (
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"C" = (
+"aC" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"D" = (
+"aD" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"E" = (
+"aE" = (
 /obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"F" = (
+"aF" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/shuttle/escape)
-"G" = (
+"aG" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"H" = (
+"aH" = (
 /obj/machinery/flasher{
 	id = "shuttle_flasher";
 	pixel_x = -24;
@@ -200,18 +194,18 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"J" = (
+"aJ" = (
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"K" = (
+"aK" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	use_power = 0
 	},
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"L" = (
+"aL" = (
 /obj/docking_port/mobile/emergency{
 	dwidth = 13;
 	height = 9;
@@ -223,322 +217,398 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"M" = (
+"aM" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"N" = (
+"aN" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"O" = (
+"aO" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"P" = (
+"aP" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Cargo"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"Q" = (
+"aQ" = (
 /obj/machinery/sleeper{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"R" = (
+"aR" = (
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"S" = (
+"aS" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"T" = (
+"aT" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"U" = (
+"aU" = (
 /obj/structure/shuttle/engine/heater,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"V" = (
+"aV" = (
 /obj/structure/table,
 /obj/machinery/recharger,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"W" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"X" = (
+"aX" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"Y" = (
+"aY" = (
 /turf/open/space/basic,
 /area/space)
-"Z" = (
+"aZ" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/space/basic,
 /area/shuttle/escape)
+"fJ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"nT" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"oX" = (
+/obj/structure/closet/crate,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"pZ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"uk" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Du" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Gz" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Rj" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"XH" = (
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 
 (1,1,1) = {"
-Y
-Y
-Y
-Y
-N
-N
-G
-u
-N
-G
-N
-G
-L
-G
-N
-G
-G
-l
-G
-G
-G
-G
-G
-G
-U
-Z
+aY
+aY
+aY
+aY
+aN
+aN
+aG
+au
+aN
+aG
+aN
+aG
+aL
+aG
+aN
+aG
+aG
+al
+aG
+aG
+aG
+aG
+aG
+aG
+aU
+aZ
 "}
 (2,1,1) = {"
-Y
-N
-N
-G
-G
-r
-r
-R
-r
-M
-M
-M
-R
-M
-M
-G
-H
-b
-b
-C
-G
-m
-B
-m
-U
-Z
+aY
+aN
+aN
+aG
+aG
+ar
+ar
+aR
+ar
+nT
+aM
+aM
+aR
+aM
+aM
+aG
+aH
+ab
+ab
+aC
+aG
+am
+aB
+am
+aU
+aZ
 "}
 (3,1,1) = {"
-N
-N
-d
-V
-G
-R
-R
-R
-R
-R
-R
-R
-R
-R
-R
-G
-D
-b
-b
-C
-G
-h
-B
-h
-G
-G
+aN
+aN
+ad
+aV
+aG
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+XH
+aG
+aD
+ab
+ab
+Gz
+aG
+oX
+aB
+ah
+aG
+aG
 "}
 (4,1,1) = {"
-N
-v
-O
-c
-G
-A
-A
-R
-A
-y
-y
-y
-R
-a
-a
-K
-G
-T
-G
-G
-G
-G
-P
-G
-G
-G
+aN
+av
+aO
+ac
+aG
+aA
+aA
+aR
+aA
+ay
+ay
+ay
+aR
+aa
+aa
+aK
+aG
+aT
+aG
+aG
+aG
+aG
+aP
+aG
+aG
+aG
 "}
 (5,1,1) = {"
-N
-J
-O
-R
-n
-R
-R
-R
-R
-R
-R
-R
-R
-e
-e
-f
-f
-R
-f
-j
-r
-r
-R
-r
-q
-N
+aN
+aJ
+aO
+aR
+an
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+ae
+ae
+af
+pZ
+aR
+af
+aj
+fJ
+ar
+aR
+ar
+aq
+aN
 "}
 (6,1,1) = {"
-N
-S
-O
-R
-G
-N
-p
-p
-N
-N
-X
-R
-R
-R
-R
-R
-R
-R
-R
-R
-R
-R
-R
-R
-q
-N
+aN
+aS
+aO
+XH
+aG
+aN
+ap
+ap
+aN
+aN
+aX
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aq
+aN
 "}
 (7,1,1) = {"
-N
-N
-g
-o
-G
-w
-z
-z
-w
-N
-X
-R
-R
-R
-R
-R
-R
-R
-R
-R
-R
-R
-R
-R
-G
-G
+aN
+aN
+ag
+ao
+aG
+aw
+az
+az
+aw
+aN
+aX
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aG
+aG
 "}
 (8,1,1) = {"
-Y
-N
-N
-G
-G
-E
-z
-k
-Q
-N
-W
-s
-s
-F
-F
-F
-F
-F
-A
-A
-A
-A
-A
-A
-U
-Z
+aY
+aN
+aN
+aG
+aG
+aE
+az
+Rj
+aQ
+aN
+Du
+as
+as
+aF
+aF
+aF
+aF
+aF
+uk
+aA
+aA
+aA
+aA
+aA
+aU
+aZ
 "}
 (9,1,1) = {"
-Y
-Y
-Y
-Y
-N
-N
-K
-G
-N
-N
-G
-G
-G
-G
-N
-N
-N
-N
-G
-G
-G
-N
-N
-N
-U
-Z
+aY
+aY
+aY
+aY
+aN
+aN
+aK
+aG
+aN
+aN
+aG
+aG
+aG
+aG
+aN
+aN
+aN
+aN
+aG
+aG
+aG
+aN
+aN
+aN
+aU
+aZ
 "}

--- a/_maps/shuttles/emergency_midway.dmm
+++ b/_maps/shuttles/emergency_midway.dmm
@@ -1,0 +1,544 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"b" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"c" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"d" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"e" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"f" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"g" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"h" = (
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"j" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"k" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"l" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"m" = (
+/obj/structure/closet,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"n" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"o" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/crowbar,
+/obj/item/storage/firstaid/fire,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"p" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Infirmary"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"q" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"r" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"s" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"u" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"v" = (
+/obj/machinery/computer/atmos_alert,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"w" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"y" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"z" = (
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"A" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"B" = (
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"C" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"D" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"E" = (
+/obj/machinery/stasis,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"F" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/purple,
+/area/shuttle/escape)
+"G" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"H" = (
+/obj/machinery/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/obj/machinery/button/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24;
+	pixel_y = -6
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"J" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"K" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"L" = (
+/obj/docking_port/mobile/emergency{
+	dwidth = 13;
+	height = 9;
+	name = "Midway emergency shuttle";
+	width = 26
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"M" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"N" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"O" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"P" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Cargo"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Q" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"R" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"S" = (
+/obj/machinery/computer/communications,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"T" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"U" = (
+/obj/structure/shuttle/engine/heater,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"V" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"W" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"X" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Y" = (
+/turf/open/space/basic,
+/area/space)
+"Z" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/space/basic,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+Y
+Y
+Y
+Y
+N
+N
+G
+u
+N
+G
+N
+G
+L
+G
+N
+G
+G
+l
+G
+G
+G
+G
+G
+G
+U
+Z
+"}
+(2,1,1) = {"
+Y
+N
+N
+G
+G
+r
+r
+R
+r
+M
+M
+M
+R
+M
+M
+G
+H
+b
+b
+C
+G
+m
+B
+m
+U
+Z
+"}
+(3,1,1) = {"
+N
+N
+d
+V
+G
+R
+R
+R
+R
+R
+R
+R
+R
+R
+R
+G
+D
+b
+b
+C
+G
+h
+B
+h
+G
+G
+"}
+(4,1,1) = {"
+N
+v
+O
+c
+G
+A
+A
+R
+A
+y
+y
+y
+R
+a
+a
+K
+G
+T
+G
+G
+G
+G
+P
+G
+G
+G
+"}
+(5,1,1) = {"
+N
+J
+O
+R
+n
+R
+R
+R
+R
+R
+R
+R
+R
+e
+e
+f
+f
+R
+f
+j
+r
+r
+R
+r
+q
+N
+"}
+(6,1,1) = {"
+N
+S
+O
+R
+G
+N
+p
+p
+N
+N
+X
+R
+R
+R
+R
+R
+R
+R
+R
+R
+R
+R
+R
+R
+q
+N
+"}
+(7,1,1) = {"
+N
+N
+g
+o
+G
+w
+z
+z
+w
+N
+X
+R
+R
+R
+R
+R
+R
+R
+R
+R
+R
+R
+R
+R
+G
+G
+"}
+(8,1,1) = {"
+Y
+N
+N
+G
+G
+E
+z
+k
+Q
+N
+W
+s
+s
+F
+F
+F
+F
+F
+A
+A
+A
+A
+A
+A
+U
+Z
+"}
+(9,1,1) = {"
+Y
+Y
+Y
+Y
+N
+N
+K
+G
+N
+N
+G
+G
+G
+G
+N
+N
+N
+N
+G
+G
+G
+N
+N
+N
+U
+Z
+"}

--- a/_maps/shuttles/whiteship_midway.dmm
+++ b/_maps/shuttles/whiteship_midway.dmm
@@ -1,27 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aa" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/bridge)
-"ai" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/bridge)
 "ao" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"aA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/russian,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/coridor)
 "aC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -29,10 +10,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/shuttle/abandoned/coridor)
-"aO" = (
-/obj/effect/decal/cleanable/blood,
+"aQ" = (
+/obj/machinery/computer/monitor{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
+/area/shuttle/abandoned/bridge)
 "aR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -42,14 +32,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/cargo)
-"ba" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
 "bb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/titanium,
@@ -73,16 +55,41 @@
 "bA" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/engine)
-"bH" = (
+"bC" = (
 /obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/coridor)
+"bU" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
+	designate_time = 100;
+	dir = 1;
+	view_range = 14;
+	x_offset = -4;
+	y_offset = -8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bridge)
 "cB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -90,6 +97,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/medbay)
+"cF" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/light/broken,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
+"cH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
 "cW" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -107,16 +139,35 @@
 "da" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/medbay)
-"dA" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+"dK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/atmospherics)
+/area/shuttle/abandoned/coridor)
+"dM" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/medbay)
+"dQ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/medbay)
 "dW" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
@@ -144,59 +195,81 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"eW" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+"eY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"fn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/medbay)
+/area/shuttle/abandoned/coridor)
+"fs" = (
+/obj/machinery/computer/shuttle/white_ship{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bridge)
+"fu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bridge)
 "fS" = (
 /obj/structure/window/reinforced{
 	layer = 2.9
 	},
 /turf/open/floor/engine/o2,
 /area/shuttle/abandoned/atmospherics)
-"fU" = (
-/obj/structure/table,
-/obj/item/radio/off{
-	pixel_x = 6;
-	pixel_y = 14
+"gb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/button/door{
-	id = "whiteship_windows";
-	name = "Windows Blast Door Control";
-	pixel_x = -22;
-	pixel_y = -6
-	},
-/obj/machinery/button/door{
-	id = "whiteship_bridge";
-	name = "Bridge Blast Door Control";
-	pixel_x = -22;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/bridge)
-"fV" = (
-/obj/machinery/light/broken{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
-"gc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
+"gq" = (
+/obj/machinery/light/broken,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/medbay)
 "gu" = (
 /obj/machinery/door/airlock/command{
 	name = "Bridge"
@@ -215,51 +288,41 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"he" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
+"gF" = (
+/obj/machinery/processor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/atmospherics)
+/area/shuttle/abandoned/crew)
 "hg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"ht" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"hm" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
-/obj/machinery/light/broken{
-	dir = 1
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/coridor)
-"hy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/coridor)
+/area/shuttle/abandoned/medbay)
 "hE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/shuttle/abandoned/coridor)
-"hL" = (
-/obj/structure/table,
-/obj/item/healthanalyzer,
-/obj/item/storage/firstaid/o2,
+"hU" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/medbay)
+/area/shuttle/abandoned/cargo)
 "hY" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/bridge)
@@ -286,13 +349,25 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"iT" = (
+"iS" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 1;
 	name = "right side output"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/atmospherics)
+"iZ" = (
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/crew)
 "jb" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/crew)
@@ -302,6 +377,21 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"jN" = (
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/cargo)
 "kf" = (
@@ -315,18 +405,22 @@
 	},
 /turf/open/floor/engine/n2,
 /area/shuttle/abandoned/atmospherics)
-"km" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+"ku" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
 "kC" = (
@@ -349,44 +443,22 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/bridge)
-"li" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
-"lx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-8"
+"lc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
-"lL" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
-"lM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/coridor)
-"lN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
 "lT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -394,19 +466,50 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"lY" = (
+"lU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/light/broken{
-	dir = 1
+/obj/machinery/light/broken,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/medbay)
+"mb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
 "mw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/cargo)
+"mB" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/components/trinary/filter,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/atmospherics)
 "mD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -414,29 +517,42 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
-"nq" = (
-/obj/structure/closet/secure_closet/freezer/fridge/open,
-/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat{
-	pixel_x = -3;
-	pixel_y = 3
+"mJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/condiment/flour{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/condiment/flour{
-	pixel_x = -3;
-	pixel_y = 3
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
+"nb" = (
+/obj/machinery/light/broken{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bridge)
+"nx" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
 "ny" = (
@@ -472,18 +588,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/atmospherics)
-"oo" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
-	},
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/atmospherics)
 "oC" = (
 /obj/structure/closet/firecloset/full{
 	anchored = 1
@@ -493,6 +597,49 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
+"oD" = (
+/obj/structure/table,
+/obj/item/radio/off{
+	pixel_x = 6;
+	pixel_y = 14
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/door{
+	id = "whiteship_windows";
+	name = "Windows Blast Door Control";
+	pixel_x = -22;
+	pixel_y = -6
+	},
+/obj/machinery/button/door{
+	id = "whiteship_bridge";
+	name = "Bridge Blast Door Control";
+	pixel_x = -22;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bridge)
+"oM" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
 "pd" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -511,6 +658,28 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/shuttle/abandoned/atmospherics)
+"pm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"pt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/russian,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
 "pv" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -518,23 +687,17 @@
 	},
 /turf/open/floor/engine/n2,
 /area/shuttle/abandoned/atmospherics)
-"pB" = (
-/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
-	designate_time = 100;
-	dir = 1;
-	view_range = 14;
-	x_offset = -4;
-	y_offset = -8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/bridge)
-"pO" = (
-/obj/machinery/computer/monitor{
+"pD" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/cargo)
 "pP" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -544,20 +707,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"pU" = (
-/obj/machinery/processor,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
-"pZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/coridor)
 "qi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -566,21 +715,46 @@
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
 "qr" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+	name = "left side output"
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/light/broken,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/atmospherics)
-"qx" = (
-/obj/machinery/hydroponics/constructable,
+"qz" = (
+/obj/structure/table,
+/obj/item/healthanalyzer,
+/obj/item/storage/firstaid/o2,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
+/area/shuttle/abandoned/medbay)
+"qG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
 "qL" = (
 /obj/machinery/button/door{
 	id = "whiteship_port";
@@ -608,13 +782,6 @@
 	},
 /turf/open/floor/engine/o2,
 /area/shuttle/abandoned/atmospherics)
-"qZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/medbay)
 "rf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
@@ -624,34 +791,109 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"rz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
-"rK" = (
-/turf/open/floor/engine,
-/area/shuttle/abandoned/coridor)
-"sd" = (
+"ri" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/broken{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
+"ry" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
+"rC" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bridge)
+"rK" = (
+/turf/open/floor/engine,
+/area/shuttle/abandoned/coridor)
+"rQ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
+"rV" = (
+/obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bridge)
 "se" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/coridor)
-"sH" = (
-/obj/machinery/computer/crew,
-/obj/effect/decal/cleanable/dirt/dust,
+"sy" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 6
+	},
+/obj/item/kitchen/knife{
+	pixel_x = 16
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 8
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/donkpockets,
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "sN" = (
 /obj/docking_port/mobile{
 	callTime = 250;
@@ -672,9 +914,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/cargo)
-"sS" = (
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/medbay)
 "sZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
@@ -700,24 +939,15 @@
 /mob/living/simple_animal/hostile/russian,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"tq" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+"tu" = (
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/medbay)
 "tw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /obj/machinery/advanced_airlock_controller{
 	dir = 8;
 	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"tx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/cargo)
@@ -732,12 +962,45 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/shuttle/abandoned/atmospherics)
-"uS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+"uc" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/crew)
+"ud" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"uA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
@@ -745,38 +1008,54 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"vs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/coridor)
-"vD" = (
+"uZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/light/broken,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
+"vw" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/item/gun/energy/laser/retro,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bridge)
+"vD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
 "vE" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"vK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/bridge)
-"vV" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/medbay)
 "vZ" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -792,11 +1071,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
-"wt" = (
-/obj/machinery/suit_storage_unit/atmos,
+"wA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
+/area/shuttle/abandoned/coridor)
 "wT" = (
 /obj/machinery/door/airlock/atmos{
 	name = "atmospherics Tank"
@@ -809,6 +1103,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/atmospherics)
+"xa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
 "xm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -818,23 +1126,18 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/abandoned/coridor)
-"xx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/light/broken{
+"xp" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"xH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"xJ" = (
-/obj/structure/chair,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
+/area/shuttle/abandoned/medbay)
 "xP" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -856,15 +1159,38 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/cargo)
-"yf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"ya" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
-"yn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+"ye" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
@@ -884,36 +1210,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/cargo)
-"yC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/coridor)
 "yF" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/atmospherics)
-"yJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"zt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/coridor)
-"zl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/broken,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
 "zv" = (
@@ -922,6 +1238,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
+"zx" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/medbay)
 "zz" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -929,49 +1258,87 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/medbay)
-"zJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+"zO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"Al" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
-"Aj" = (
-/obj/structure/table,
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/shovel/spade,
-/obj/item/cultivator,
-/obj/item/plant_analyzer,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
 "An" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"AB" = (
-/turf/open/floor/engine/o2,
-/area/shuttle/abandoned/atmospherics)
-"AD" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/components/trinary/filter,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/atmospherics)
-"AN" = (
+"At" = (
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
+"Ax" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/atmospherics)
+"AB" = (
+/turf/open/floor/engine/o2,
 /area/shuttle/abandoned/atmospherics)
 "AU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
@@ -979,14 +1346,40 @@
 	},
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/atmospherics)
-"Bu" = (
-/obj/structure/table,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
+"AV" = (
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/atmospherics)
+"AZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/crew)
+"BJ" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/bridge)
 "BQ" = (
@@ -1016,24 +1409,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"Cs" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 6
-	},
-/obj/item/kitchen/knife{
-	pixel_x = 16
-	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = 8
-	},
-/obj/item/storage/box/drinkingglasses{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
 "Cz" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -1044,20 +1419,24 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
+"CG" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/crew)
 "CS" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/coridor)
 "Dk" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/cargo)
-"Dy" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/coridor)
 "DC" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 1
@@ -1090,6 +1469,22 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
+"DX" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
 "Eh" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
@@ -1100,6 +1495,23 @@
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/atmospherics)
+"EE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
 "EF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -1109,8 +1521,31 @@
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/medbay)
 "EN" = (
-/obj/structure/sink{
-	pixel_y = 20
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
+"Fn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
@@ -1121,25 +1556,80 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
+"Gd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
+"Gg" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/crew)
 "Gn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"Go" = (
+"GX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
-"GE" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/item/gun/energy/laser/retro,
+"HR" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/coridor)
+"Ie" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/crew)
 "Ih" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -1162,6 +1652,58 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
+"IC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
+"ID" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/crew)
+"IL" = (
+/obj/structure/table,
+/obj/item/gps{
+	gpstag = "NTREC1";
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/megaphone{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bridge)
+"Jp" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/crew)
 "JI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1172,30 +1714,26 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
-"JP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+"Ka" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/coridor)
-"JY" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/coridor)
-"Kg" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/medbay)
+"Kr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
 "KM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -1210,26 +1748,63 @@
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/atmospherics)
-"KX" = (
+"KS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
-"Lo" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/medbay)
-"Ls" = (
-/obj/machinery/suit_storage_unit/atmos,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
-"LG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+"Lg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/coridor)
+"Lj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/russian,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
+"Lv" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/crew)
 "LR" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 1
@@ -1237,10 +1812,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/atmospherics)
-"Ml" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
 "Mp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -1260,23 +1831,34 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
+"ME" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
 "ML" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
-"MM" = (
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/bridge)
-"MW" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light/broken{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
@@ -1287,9 +1869,37 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"Nm" = (
+"Ne" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/cargo)
+"Ng" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
 "Ns" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1298,6 +1908,39 @@
 "Nz" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/cargo)
+"Oi" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/light/broken,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/atmospherics)
+"Om" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/medbay)
 "OF" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -1333,6 +1976,22 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
+"OS" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/brute,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/medbay)
 "OW" = (
 /obj/machinery/door/airlock/atmos{
 	name = "atmospherics Tank"
@@ -1345,19 +2004,6 @@
 "OZ" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/medbay)
-"Pw" = (
-/obj/structure/table,
-/obj/item/gps{
-	gpstag = "NTREC1";
-	pixel_x = -9;
-	pixel_y = 7
-	},
-/obj/item/megaphone{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/bridge)
 "PP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -1379,21 +2025,51 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
-"Qt" = (
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/cargo)
 "Qz" = (
 /obj/item/storage/belt/utility,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"QT" = (
-/obj/machinery/computer/shuttle/white_ship{
+"QM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/coridor)
+"QT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
 "QU" = (
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
@@ -1403,13 +2079,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/medbay)
-"Rn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/mob/living/simple_animal/hostile/russian,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/coridor)
 "Rr" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/weldingtool/largetank,
@@ -1419,10 +2088,62 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
+"Rt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
 "Ry" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/bridge)
+"RF" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
+"RQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
 "RR" = (
 /turf/open/floor/engine/n2,
 /area/shuttle/abandoned/atmospherics)
@@ -1430,6 +2151,25 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/bridge)
+"Sd" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 8
+	},
+/obj/machinery/light/broken,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/atmospherics)
 "Sk" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/bridge)
@@ -1440,41 +2180,75 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/medbay)
-"Tj" = (
+"Sz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light/broken,
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/medbay)
-"Tu" = (
+/area/shuttle/abandoned/bridge)
+"SE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"SQ" = (
 /obj/structure/window/reinforced{
 	dir = 8;
 	layer = 2.9
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/filter,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/atmospherics)
-"TF" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+"SU" = (
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
+"Td" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light/broken{
+	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/medbay)
-"TJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/area/shuttle/abandoned/crew)
+"TG" = (
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/light/broken,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/coridor)
+/area/shuttle/abandoned/cargo)
+"TM" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bridge)
 "TN" = (
 /obj/structure/rack,
 /obj/item/clothing/head/welding{
@@ -1493,6 +2267,17 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
+"TS" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/atmospherics)
 "Uh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1502,6 +2287,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/bridge)
+"Um" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/crew)
+"Un" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned/engine)
 "Uv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -1512,21 +2315,56 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/medbay)
-"UE" = (
+"Ux" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/medbay)
-"UI" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
-"UM" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/brute,
+"UF" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/meat/slab/synthmeat{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/flour{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/flour{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/medbay)
+/area/shuttle/abandoned/crew)
+"Vb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
 "Vh" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering"
@@ -1534,22 +2372,29 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/engine)
-"Vj" = (
-/obj/machinery/atmospherics/components/trinary/mixer/flipped{
-	name = "left side output"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/atmospherics)
 "Vk" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/bridge)
-"VF" = (
-/obj/machinery/light/broken,
+"Vt" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/medbay)
+"Vv" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/cargo)
 "VS" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -1559,20 +2404,31 @@
 /obj/item/storage/box/lights/tubes,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
+"Wi" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bridge)
 "Wn" = (
 /obj/structure/shuttle/engine/propulsion/left{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
-"WA" = (
+"Wt" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/atmospherics)
@@ -1585,6 +2441,62 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
+"Xb" = (
+/obj/machinery/computer/crew,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bridge)
+"Xe" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/atmospherics)
+"Xu" = (
+/obj/structure/table,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/crew)
+"XQ" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/atmospherics)
 "Yj" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -1594,6 +2506,21 @@
 	},
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/engine)
+"Yw" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/crew)
 "YG" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -1628,6 +2555,26 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/coridor)
+"Zz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/coridor)
 "ZE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -1639,14 +2586,25 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"ZQ" = (
-/obj/structure/chair/comfy/shuttle{
+"ZN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/coridor)
 "ZY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -1804,15 +2762,15 @@ Zn
 (7,1,1) = {"
 bA
 bA
-Kg
+Un
 lT
 MX
 lT
 Vh
-LG
-JY
-gc
-lM
+xa
+HR
+zt
+uA
 ny
 ZE
 Mp
@@ -1834,8 +2792,8 @@ bA
 bA
 bA
 CS
-ht
-pZ
+ZN
+uZ
 CS
 bA
 bA
@@ -1858,8 +2816,8 @@ Zn
 Zn
 Zn
 se
-aA
-yf
+Lj
+Ng
 se
 Zn
 Zn
@@ -1882,8 +2840,8 @@ yt
 yt
 Zn
 Zv
-yJ
-yf
+Gd
+Ng
 Zv
 Zn
 jb
@@ -1906,15 +2864,15 @@ RR
 yt
 Zn
 Zv
-KX
-yC
+KS
+Zz
 Zv
 Zn
 bb
-UI
-MW
-qx
-qx
+ID
+Td
+Jp
+Ie
 jb
 Zn
 Zn
@@ -1930,15 +2888,15 @@ kf
 yt
 Zn
 Zv
-vs
-yf
+ku
+Ng
 Zv
 Zn
 jb
-EN
+iZ
 mD
 Mr
-Aj
+Xu
 jb
 Zn
 Zn
@@ -1947,22 +2905,22 @@ Zn
 "}
 (13,1,1) = {"
 oi
-Tu
-AD
-AD
-qr
+XQ
+SQ
+mB
+Oi
 AU
 Zn
 se
-yJ
-yf
+vD
+mJ
 se
 Zn
 jb
-aO
+Ux
 WL
 yq
-ba
+Gg
 pd
 Zn
 Zn
@@ -1971,22 +2929,22 @@ Zn
 "}
 (14,1,1) = {"
 xP
-Vj
+qr
 yF
 DC
-he
+AV
 Er
 td
 CS
-yJ
-yf
+EN
+qG
 CS
 pd
 dW
-xJ
+uc
 OF
 zv
-Cs
+sy
 pd
 Zn
 Zn
@@ -1995,22 +2953,22 @@ Zn
 "}
 (15,1,1) = {"
 xP
-iT
+iS
 Eh
 LR
-AN
+Xe
 wT
 JI
 OW
-zJ
-lx
+gb
+QM
 Ik
 ML
 wh
-rz
+Fn
 Qj
 yq
-pU
+gF
 pd
 Zn
 Zn
@@ -2019,22 +2977,22 @@ Zn
 "}
 (16,1,1) = {"
 oi
-WA
-dA
-dA
-oo
+Ax
+TS
+Wt
+Sd
 KP
 td
 CS
-yJ
-vD
+dK
+IC
 CS
 pd
 dW
-lL
+Yw
 qi
 yq
-nq
+UF
 pd
 Zn
 Zn
@@ -2050,15 +3008,15 @@ tP
 yt
 Zn
 se
-JP
-zl
+Al
+At
 se
 Zn
 jb
 yq
 xW
 Mr
-yq
+Lv
 pd
 Zn
 Zn
@@ -2074,15 +3032,15 @@ DS
 yt
 Zn
 Zv
-hy
-vD
+Vb
+Rt
 Zv
 Zn
 jb
-li
-fV
-lN
-li
+Um
+nx
+AZ
+CG
 jb
 Zn
 Zn
@@ -2098,8 +3056,8 @@ yt
 yt
 Zn
 Zv
-hy
-vD
+Lg
+RQ
 Zv
 Zn
 jb
@@ -2122,8 +3080,8 @@ Zn
 Zn
 Zn
 Zv
-yn
-uS
+rQ
+ye
 Zv
 Zn
 Zn
@@ -2146,8 +3104,8 @@ Nz
 Nz
 Zn
 Zv
-yJ
-yf
+eY
+DX
 Zv
 Zn
 OZ
@@ -2163,22 +3121,22 @@ Zn
 "}
 (22,1,1) = {"
 Nz
-Ls
-xH
-xH
-Qt
+TG
+pm
+Kr
+pD
 Nz
 Zn
 se
-yJ
-Rn
+lc
+pt
 se
 Zn
 OZ
-Lo
-sS
-sS
-UM
+Om
+tu
+dQ
+OS
 zz
 Zn
 Zn
@@ -2189,18 +3147,18 @@ Zn
 Dk
 xX
 Nz
-xx
-Nm
+ud
+SU
 Dk
 xX
 CS
-hy
-vD
+QT
+EE
 CS
 zz
 da
-sS
-VF
+dQ
+gq
 OZ
 zz
 da
@@ -2213,18 +3171,18 @@ Zn
 sN
 tw
 jo
-eW
-tx
+zO
+SE
 yw
 aR
 DR
-Dy
-km
+RF
+ME
 KM
 cB
 EF
-qZ
-fn
+Ka
+hm
 QV
 Uv
 Ss
@@ -2237,18 +3195,18 @@ Zn
 Dk
 xX
 mw
-lY
-bH
+Ne
+oM
 Dk
 xX
 CS
-sd
-TJ
+wA
+cF
 CS
 zz
 da
-TF
-Tj
+xp
+lU
 OZ
 zz
 da
@@ -2259,22 +3217,22 @@ Zn
 "}
 (26,1,1) = {"
 Nz
-wt
-xH
-Nm
-Ml
+jN
+cH
+hU
+Vv
 Nz
 Zn
 se
-yJ
-Go
+ya
+mb
 se
 Zn
 OZ
-vV
-UE
-sS
-hL
+zx
+dM
+Vt
+qz
 zz
 Zn
 Zn
@@ -2290,8 +3248,8 @@ Nz
 Nz
 Zn
 se
-hy
-vD
+ri
+bC
 se
 Zn
 OZ
@@ -2314,8 +3272,8 @@ Zn
 Zn
 Zn
 se
-yJ
-yf
+ry
+GX
 se
 Zn
 Zn
@@ -2360,12 +3318,12 @@ Zn
 Zn
 Zn
 hY
-hY
-fU
-ai
-tq
-Bu
-hY
+Sk
+oD
+fu
+rC
+rV
+Sk
 hY
 Zn
 Zn
@@ -2384,12 +3342,12 @@ Zn
 Zn
 Zn
 kH
-MM
+nb
 RT
 Vk
 Zs
-vK
-MM
+Sz
+BJ
 kH
 Zn
 Zn
@@ -2408,12 +3366,12 @@ Zn
 Zn
 Zn
 kH
-sH
-aa
+Xb
+Wi
 ig
 Ry
-ZQ
-pB
+TM
+bU
 kH
 Zn
 Zn
@@ -2433,10 +3391,10 @@ Zn
 Zn
 kH
 kH
-pO
-Pw
-GE
-QT
+aQ
+IL
+vw
+fs
 kH
 kH
 Zn

--- a/waspstation/code/datums/shuttles.dm
+++ b/waspstation/code/datums/shuttles.dm
@@ -15,3 +15,9 @@
 	name = "Packedstation emergency shuttle"
 	credit_cost = 1000
 	description = "Despite the name, this shuttle has a more open central seating area, and still complete with a brig and medbay."
+
+/datum/map_template/shuttle/emergency/midway
+	suffix = "midway"
+	name = "Midwaystation emergency shuttle"
+	credit_cost = 1000
+	description = "This shuttle is long and made with a long open area with chairs on the side."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Finaly adds an emergency shuttle to midway. so now pepole can stop complaining that the box shuttle dosent line upp.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now the airlocks on midways escape should line upp with the airlocks on the shuttle. and if not scream att me
also fixes a few problems pepole reported about midway
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: NT has recently bought the shuttle that was used by the pervius owners of midway station and is going to start using it as standard for transfering crew
 from the station
![image](https://user-images.githubusercontent.com/57943634/100614437-6e6f0a00-3316-11eb-8103-17384c0d1268.png)


fix: Adds more intercoms to midway
fix: adds a conection between maint and the bridge for ditional movment around the maint coridor
fix: things some things that should be on walls have been moved to the walls on midway

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
