### PR TITLE
Cam fixes, Blood banks, and Arrival fancy-ing

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -21554,28 +21554,8 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"bDB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/smartfridge/organ,
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/medical/sleeper)
 "bDC" = (
 /obj/machinery/computer/operating{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
-"bDD" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -28
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -22074,11 +22054,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"bFJ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "bFK" = (
 /obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/plasteel/white,
@@ -28044,13 +28019,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"clp" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology Test Chamber";
-	network = list("xeno","rd")
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "cls" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -29537,30 +29505,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"cCp" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood/AMinus,
-/obj/item/reagent_containers/blood/BMinus{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/blood/BPlus{
-	pixel_x = 1;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OPlus{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/APlus,
-/obj/item/reagent_containers/blood/random,
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
 "cCq" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
@@ -30002,6 +29946,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"cLZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cMk" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -30627,6 +30577,14 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
+"dbM" = (
+/obj/machinery/chem_dispenser,
+/obj/machinery/camera{
+	c_tag = "Chemistry - Factory West";
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "dbR" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -32771,6 +32729,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
+"eGZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "eHj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35755,13 +35719,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/pharmacy)
-"gZG" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/medical/sleeper)
 "gZY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -38477,14 +38434,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"jox" = (
-/obj/machinery/chem_dispenser,
-/obj/machinery/camera{
-	c_tag = "Engineering Storage";
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "jpi" = (
 /obj/machinery/door/airlock{
 	name = "Unit 3"
@@ -39595,6 +39544,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"khZ" = (
+/obj/machinery/smartfridge/bloodbank/preloaded,
+/turf/closed/wall,
+/area/medical/sleeper)
 "kip" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -39847,6 +39800,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
+"kqI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "kqX" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -39971,6 +39930,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"kwW" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "kxF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -43249,6 +43216,13 @@
 	},
 /turf/open/space,
 /area/engine/atmos)
+"mLY" = (
+/obj/machinery/camera{
+	c_tag = "Chemistry - Factory East";
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "mMp" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -43642,6 +43616,14 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"nad" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "nan" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Integrity Restorer";
@@ -43926,6 +43908,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/cafeteria,
 /area/engine/atmos)
+"nhO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "nhR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45101,6 +45089,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"nWG" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "nXi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -46491,6 +46484,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"oTI" = (
+/obj/effect/landmark/carpspawn,
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space/nearstation)
 "oTP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -46638,13 +46636,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"oZc" = (
-/obj/machinery/camera{
-	c_tag = "Chapel South";
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "oZT" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/machinery/light/small{
@@ -49410,6 +49401,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"rbp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "rcD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50965,6 +50962,12 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/storage/tech)
+"ssH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "stb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -51110,10 +51113,6 @@
 /obj/item/shovel/spade,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"syg" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "syj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -51563,6 +51562,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"sQx" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_range = 3;
+	name = "Docking Beacon";
+	picked_color = "Burgundy"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "sQE" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -53126,6 +53136,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"ubb" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "ubM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -55210,6 +55224,13 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
+"vub" = (
+/obj/machinery/camera{
+	c_tag = "Chemistry - Factory Mid";
+	network = list("ss13")
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "vut" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -55452,6 +55473,13 @@
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"vCo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/smartfridge/organ,
+/turf/closed/wall,
+/area/medical/sleeper)
 "vCF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -56293,6 +56321,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
+"wfm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "wfM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57233,6 +57267,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wPn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/medical/sleeper)
 "wPo" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -59001,6 +59043,32 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"ygM" = (
+/mob/living/simple_animal/hostile/retaliate/bat{
+	desc = "A fierce companion for any person of power, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine.";
+	emote_hear = list("chitters");
+	faction = list("spiders");
+	harm_intent_damage = 3;
+	health = 200;
+	icon_dead = "guard_dead";
+	icon_gib = "guard_dead";
+	icon_living = "guard";
+	icon_state = "guard";
+	maxHealth = 250;
+	max_co2 = 5;
+	max_tox = 2;
+	melee_damage_lower = 15;
+	melee_damage_upper = 20;
+	min_oxy = 5;
+	movement_type = 1;
+	name = "Sergeant Araneus";
+	real_name = "Sergeant Araneus";
+	response_help_continuous = "pets";
+	response_help_simple = "pet";
+	turns_per_move = 10
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/hos)
 "ygX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -64152,7 +64220,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+sEJ
 aaa
 aaa
 aaa
@@ -65178,6 +65246,11 @@ aaa
 aaa
 aaa
 aaa
+sQx
+aaa
+aaa
+aaa
+sQx
 aaa
 aaa
 aaa
@@ -65190,12 +65263,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sEJ
 aaa
 aaa
 aaa
@@ -65429,23 +65497,23 @@ aaa
 aaa
 aaa
 aaa
+sQx
+aaa
+sQx
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
+sQx
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sQx
 aaa
 aaa
 aaa
@@ -65686,23 +65754,23 @@ aaa
 aaa
 aaa
 aaa
+gXs
+aaa
+gXs
 aaa
 aaa
+gXs
+rVN
+gXs
+gXs
+gXs
+rVN
+gXs
 aaa
 aaa
+gXs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -65942,25 +66010,25 @@ aaa
 aaa
 aaa
 aaa
+rVN
+rVN
+aaa
+rVN
+rVN
+gXs
+gXs
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
-aaa
+gXs
+gXs
+rVN
+rVN
+gXs
+aag
+rVN
 aaa
 aaa
 aaa
@@ -66199,6 +66267,12 @@ aaa
 aaa
 aaa
 aaa
+ssH
+nhO
+aaa
+nhO
+rbp
+gXs
 aaa
 aaa
 aaa
@@ -66206,18 +66280,12 @@ aaa
 aaa
 aaa
 aaa
+gXs
+ssH
+nhO
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nhO
+rbp
 aaa
 aaa
 aaa
@@ -66456,10 +66524,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cLZ
 aaa
 cpe
 aaa
+ubb
 aaa
 aaa
 aaa
@@ -66469,12 +66538,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cLZ
 aaa
 cwV
 aaa
-aaa
+ubb
 aaa
 aaa
 aaa
@@ -66712,16 +66780,14 @@ aaa
 aaa
 aaa
 aae
-aaf
+aoV
+gXs
 aaa
 aaa
 aaa
+gXs
 aaa
-aaa
-aaa
-aae
-aaa
-aaa
+aoV
 aaa
 aaa
 aaa
@@ -66729,9 +66795,11 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
@@ -66969,7 +67037,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aoV
+gXs
+aaa
+aaa
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -66979,16 +67052,11 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -67226,7 +67294,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aoV
+gXs
+aaa
+aaa
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -67236,16 +67309,11 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -67483,26 +67551,26 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaa
-aaa
-cqq
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aoV
+gXs
 aaa
 cqq
 aaa
+gXs
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gXs
+aaa
+cqq
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -67740,7 +67808,7 @@ aaf
 aaf
 aaf
 aaa
-aaf
+aoV
 arB
 asE
 cyb
@@ -88522,7 +88590,7 @@ aaa
 aaa
 aaa
 aaa
-syg
+aaf
 aaf
 aaa
 aaf
@@ -92128,7 +92196,7 @@ aaf
 lim
 abU
 act
-acu
+ygM
 acu
 rky
 abq
@@ -92898,7 +92966,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaf
 aaa
 aaf
 hsQ
@@ -92974,7 +93042,7 @@ byZ
 bzI
 bAX
 bCF
-bDB
+wPn
 bFB
 bvd
 dAI
@@ -93148,13 +93216,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+aaf
+aag
+aag
+aag
+aag
+aaf
 aaf
 aaf
 aaf
@@ -93919,11 +93987,11 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aag
-aag
-aag
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aag
@@ -94002,8 +94070,8 @@ bvh
 bzS
 bBc
 bCJ
-gZG
-cCp
+buk
+nWG
 bvd
 mRC
 bLK
@@ -94176,11 +94244,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+aaf
+aag
+aag
+aag
 aag
 aaf
 aaf
@@ -94257,9 +94325,9 @@ bvj
 bvj
 bvj
 bvj
-bvd
+vCo
 yaZ
-bvj
+khZ
 bvj
 bvd
 mRC
@@ -94516,8 +94584,8 @@ bvh
 bCG
 bBd
 bFw
-bDD
-bFJ
+kwW
+nad
 bvd
 mRC
 bzs
@@ -94700,11 +94768,11 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -94957,11 +95025,11 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -95214,11 +95282,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cLZ
 aaa
 aqG
 aaa
-aaa
+ubb
 aaa
 aaa
 aaa
@@ -95471,11 +95539,11 @@ aaa
 aaa
 aaa
 aaa
+wfm
+eGZ
 aaa
-aaa
-aaa
-aaa
-aaa
+eGZ
+kqI
 aaa
 aaa
 aaa
@@ -95728,11 +95796,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aae
-aaa
-aaa
-aaa
+rVN
+oTI
+gXs
+rVN
+rVN
 aaa
 aaa
 aaa
@@ -95986,9 +96054,9 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -96243,9 +96311,9 @@ aaa
 aaa
 aaa
 aaa
+sQx
 aaa
-aaa
-aaa
+sQx
 aaa
 aaa
 aaa
@@ -98403,7 +98471,7 @@ ckl
 clk
 xfL
 vQQ
-jox
+dbM
 nEk
 djq
 hTU
@@ -100713,7 +100781,7 @@ rGg
 rGg
 chp
 mtK
-clp
+vub
 mSR
 cnf
 bip
@@ -104570,7 +104638,7 @@ hxt
 cOT
 bip
 bip
-oZc
+mLY
 hpH
 bip
 mtK

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -29946,12 +29946,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"cLZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "cMk" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -30340,6 +30334,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"cUx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/smartfridge/organ,
+/turf/closed/wall,
+/area/medical/sleeper)
 "cUX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -30475,6 +30476,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"cZc" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dac" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30577,14 +30582,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
-"dbM" = (
-/obj/machinery/chem_dispenser,
-/obj/machinery/camera{
-	c_tag = "Chemistry - Factory West";
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "dbR" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -32729,12 +32726,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
-"eGZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "eHj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34655,6 +34646,12 @@
 "gjl" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
+"gjq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "gkh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -39544,10 +39541,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"khZ" = (
-/obj/machinery/smartfridge/bloodbank/preloaded,
-/turf/closed/wall,
-/area/medical/sleeper)
 "kip" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -39800,12 +39793,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
-"kqI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "kqX" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -39930,14 +39917,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"kwW" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "kxF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -41443,6 +41422,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"lFc" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "lFk" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -42604,6 +42591,12 @@
 "mtK" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
+"muA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "muB" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -43105,6 +43098,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"mIv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "mJc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43216,13 +43215,6 @@
 	},
 /turf/open/space,
 /area/engine/atmos)
-"mLY" = (
-/obj/machinery/camera{
-	c_tag = "Chemistry - Factory East";
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "mMp" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -43616,14 +43608,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"nad" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "nan" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Integrity Restorer";
@@ -43770,6 +43754,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"ndA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "ndO" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
@@ -43908,12 +43898,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/cafeteria,
 /area/engine/atmos)
-"nhO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "nhR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45089,11 +45073,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"nWG" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
 "nXi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -45769,6 +45748,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"ots" = (
+/obj/machinery/camera{
+	c_tag = "Chemistry - Factory East";
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "otZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -46030,6 +46016,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"oGu" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon{
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_range = 3;
+	name = "Docking Beacon";
+	picked_color = "Burgundy"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "oGP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46484,11 +46481,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"oTI" = (
-/obj/effect/landmark/carpspawn,
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
 "oTP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -49401,12 +49393,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"rbp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "rcD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -49746,6 +49732,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"rpN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/medical/sleeper)
 "rqo" = (
 /obj/machinery/computer/atmos_control/toxinsmix{
 	dir = 4
@@ -50031,6 +50025,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"rzb" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "rzt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -50078,6 +50077,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"rBA" = (
+/mob/living/simple_animal/hostile/retaliate/bat{
+	desc = "A fierce companion for any person of power, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine.";
+	emote_hear = list("chitters");
+	faction = list("spiders");
+	harm_intent_damage = 3;
+	health = 200;
+	icon_dead = "guard_dead";
+	icon_gib = "guard_dead";
+	icon_living = "guard";
+	icon_state = "guard";
+	maxHealth = 250;
+	max_co2 = 5;
+	max_tox = 2;
+	melee_damage_lower = 15;
+	melee_damage_upper = 20;
+	min_oxy = 5;
+	movement_type = 1;
+	name = "Sergeant Araneus";
+	real_name = "Sergeant Araneus";
+	response_help_continuous = "pets";
+	response_help_simple = "pet";
+	turns_per_move = 10
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/hos)
 "rBL" = (
 /obj/machinery/door/window/westleft{
 	name = "Delivery Desk";
@@ -50962,12 +50987,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/storage/tech)
-"ssH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "stb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -51399,6 +51418,14 @@
 	},
 /turf/open/floor/engine/airless,
 /area/escapepodbay)
+"sJy" = (
+/obj/machinery/chem_dispenser,
+/obj/machinery/camera{
+	c_tag = "Chemistry - Factory West";
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "sJN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51433,6 +51460,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"sMG" = (
+/obj/machinery/smartfridge/bloodbank/preloaded,
+/turf/closed/wall,
+/area/medical/sleeper)
 "sMV" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -51562,17 +51593,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"sQx" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon{
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_range = 3;
-	name = "Docking Beacon";
-	picked_color = "Burgundy"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "sQE" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -51731,6 +51751,12 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
+"sWE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "sXC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -52525,6 +52551,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"tzj" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "tzn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -53091,6 +53125,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"tZd" = (
+/obj/machinery/camera{
+	c_tag = "Chemistry - Factory Mid";
+	network = list("ss13")
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "tZh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -53136,10 +53177,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"ubb" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "ubM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -55224,13 +55261,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
-"vub" = (
-/obj/machinery/camera{
-	c_tag = "Chemistry - Factory Mid";
-	network = list("ss13")
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "vut" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -55473,13 +55503,6 @@
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"vCo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/smartfridge/organ,
-/turf/closed/wall,
-/area/medical/sleeper)
 "vCF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -56321,12 +56344,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
-"wfm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "wfM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56544,6 +56561,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
+"wop" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "woZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57267,14 +57290,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"wPn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/medical/sleeper)
 "wPo" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -58881,6 +58896,12 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"xZR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "xZT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -59043,32 +59064,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"ygM" = (
-/mob/living/simple_animal/hostile/retaliate/bat{
-	desc = "A fierce companion for any person of power, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine.";
-	emote_hear = list("chitters");
-	faction = list("spiders");
-	harm_intent_damage = 3;
-	health = 200;
-	icon_dead = "guard_dead";
-	icon_gib = "guard_dead";
-	icon_living = "guard";
-	icon_state = "guard";
-	maxHealth = 250;
-	max_co2 = 5;
-	max_tox = 2;
-	melee_damage_lower = 15;
-	melee_damage_upper = 20;
-	min_oxy = 5;
-	movement_type = 1;
-	name = "Sergeant Araneus";
-	real_name = "Sergeant Araneus";
-	response_help_continuous = "pets";
-	response_help_simple = "pet";
-	turns_per_move = 10
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "ygX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -65246,11 +65241,11 @@ aaa
 aaa
 aaa
 aaa
-sQx
+oGu
 aaa
 aaa
 aaa
-sQx
+oGu
 aaa
 aaa
 aaa
@@ -65497,13 +65492,9 @@ aaa
 aaa
 aaa
 aaa
-sQx
+oGu
 aaa
-sQx
-aaa
-aaa
-aaa
-gXs
+oGu
 aaa
 aaa
 aaa
@@ -65511,9 +65502,13 @@ gXs
 aaa
 aaa
 aaa
-sQx
+gXs
 aaa
-sQx
+aaa
+aaa
+oGu
+aaa
+oGu
 aaa
 aaa
 aaa
@@ -66267,11 +66262,11 @@ aaa
 aaa
 aaa
 aaa
-ssH
-nhO
+gjq
+muA
 aaa
-nhO
-rbp
+muA
+sWE
 gXs
 aaa
 aaa
@@ -66281,11 +66276,11 @@ aaa
 aaa
 aaa
 gXs
-ssH
-nhO
+gjq
+muA
 aaa
-nhO
-rbp
+muA
+sWE
 aaa
 aaa
 aaa
@@ -66524,11 +66519,11 @@ aaa
 aaa
 aaa
 aaa
-cLZ
+xZR
 aaa
 cpe
 aaa
-ubb
+cZc
 aaa
 aaa
 aaa
@@ -66538,11 +66533,11 @@ aaa
 aaa
 aaa
 aaa
-cLZ
+xZR
 aaa
 cwV
 aaa
-ubb
+cZc
 aaa
 aaa
 aaa
@@ -92196,7 +92191,7 @@ aaf
 lim
 abU
 act
-ygM
+rBA
 acu
 rky
 abq
@@ -93042,7 +93037,7 @@ byZ
 bzI
 bAX
 bCF
-wPn
+rpN
 bFB
 bvd
 dAI
@@ -94071,7 +94066,7 @@ bzS
 bBc
 bCJ
 buk
-nWG
+rzb
 bvd
 mRC
 bLK
@@ -94325,9 +94320,9 @@ bvj
 bvj
 bvj
 bvj
-vCo
+cUx
 yaZ
-khZ
+sMG
 bvj
 bvd
 mRC
@@ -94584,8 +94579,8 @@ bvh
 bCG
 bBd
 bFw
-kwW
-nad
+lFc
+tzj
 bvd
 mRC
 bzs
@@ -95282,11 +95277,11 @@ aaa
 aaa
 aaa
 aaa
-cLZ
+xZR
 aaa
 aqG
 aaa
-ubb
+cZc
 aaa
 aaa
 aaa
@@ -95539,11 +95534,11 @@ aaa
 aaa
 aaa
 aaa
-wfm
-eGZ
+mIv
+ndA
 aaa
-eGZ
-kqI
+ndA
+wop
 aaa
 aaa
 aaa
@@ -95791,13 +95786,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
+sEJ
 aaa
 aaa
 aaa
 aaa
 rVN
-oTI
+aag
 gXs
 rVN
 rVN
@@ -96311,9 +96306,9 @@ aaa
 aaa
 aaa
 aaa
-sQx
+oGu
 aaa
-sQx
+oGu
 aaa
 aaa
 aaa
@@ -98471,7 +98466,7 @@ ckl
 clk
 xfL
 vQQ
-dbM
+sJy
 nEk
 djq
 hTU
@@ -100781,7 +100776,7 @@ rGg
 rGg
 chp
 mtK
-vub
+tZd
 mSR
 cnf
 bip
@@ -104638,7 +104633,7 @@ hxt
 cOT
 bip
 bip
-mLY
+ots
 hpH
 bip
 mtK

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -62547,19 +62547,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"dtQ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
 "dtR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -64118,23 +64105,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"dyG" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
 "dyH" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -64194,25 +64164,6 @@
 	dir = 8
 	},
 /obj/machinery/smartfridge/organ,
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
-"dyK" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 26;
-	use_power = 0
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "dyN" = (
@@ -94565,6 +94516,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"kLh" = (
+/obj/machinery/smartfridge/bloodbank/preloaded,
+/turf/closed/wall,
+/area/medical/surgery)
 "kLl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -107727,6 +107682,24 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"pke" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 26;
+	use_power = 0
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "pkx" = (
 /obj/machinery/light_switch{
 	pixel_x = -26;
@@ -118689,6 +118662,27 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/space,
 /area/engine/atmos)
+"teZ" = (
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "tfj" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hall5";
@@ -120374,6 +120368,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"tEK" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "tFb" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
@@ -181223,7 +181226,7 @@ dnF
 rDM
 dnF
 dsM
-dma
+kLh
 ggM
 dma
 dma
@@ -181480,10 +181483,10 @@ dnG
 dnG
 slY
 dsN
-dtQ
+tEK
 fWS
 dxl
-dyG
+teZ
 dma
 dBs
 dCP
@@ -182511,7 +182514,7 @@ dsR
 dtU
 kLl
 dxp
-dyK
+pke
 dma
 wgk
 dCR

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -6243,6 +6243,28 @@
 	},
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"aMv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/power/apc{
+	areastring = "/area/medical/surgery";
+	dir = 4;
+	name = "Surgery APC";
+	pixel_x = 24
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "aMw" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/emitter,
@@ -7494,6 +7516,17 @@
 /obj/item/storage/box/beakers,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"aTQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/smartfridge/bloodbank/preloaded,
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "aUa" = (
 /turf/closed/wall,
 /area/gateway)
@@ -7801,17 +7834,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
-"aVB" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
 "aVC" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -11202,27 +11224,6 @@
 	dir = 1
 	},
 /area/hallway/primary/port)
-"bjN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/surgery";
-	dir = 4;
-	name = "Surgery APC";
-	pixel_x = 24
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
 "bjV" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -115458,7 +115459,7 @@ sPy
 hAc
 mLn
 nsQ
-aVB
+aTQ
 xAR
 add
 bTW
@@ -115715,7 +115716,7 @@ sPy
 fSq
 iSz
 bqf
-bjN
+aMv
 xAR
 aaO
 bTW

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -33288,18 +33288,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"crn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/medical/surgery)
 "cro" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -33614,13 +33602,6 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/medical/surgery)
-"csn" = (
-/obj/item/radio/intercom{
-	pixel_y = -30
-	},
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel,
 /area/medical/surgery)
 "cso" = (
 /obj/structure/bed/roller,
@@ -35348,6 +35329,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"cyi" = (
+/obj/item/radio/intercom{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/medical/surgery)
 "cyn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -66671,6 +66658,14 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"obx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/medical/surgery)
 "obE" = (
 /obj/machinery/door/airlock/security{
 	aiControlDisabled = 1;
@@ -67157,6 +67152,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"omy" = (
+/obj/machinery/smartfridge/bloodbank/preloaded,
+/turf/closed/wall,
+/area/medical/surgery)
 "omB" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -107202,8 +107201,8 @@ cmk
 cnq
 iiz
 uwC
-crn
-csn
+obx
+cyi
 cia
 cdl
 gFK
@@ -107459,7 +107458,7 @@ cia
 cia
 cia
 kXq
-cia
+omy
 cia
 cia
 ceu

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -23685,23 +23685,6 @@
 	},
 /turf/closed/wall,
 /area/medical/surgery)
-"bIo" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
 "bIp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -24450,22 +24433,6 @@
 "bKD" = (
 /obj/structure/bed,
 /turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
-"bKE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bKF" = (
 /obj/structure/table/optable,
@@ -44586,6 +44553,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"jJz" = (
+/obj/machinery/smartfridge/bloodbank/preloaded,
+/turf/closed/wall,
+/area/medical/surgery)
 "jJD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -44908,6 +44879,26 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
+"jZn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "jZr" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -47303,6 +47294,18 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"lLb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "lLi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -94721,7 +94724,7 @@ bFU
 bFU
 bIn
 dtg
-bFU
+jJz
 bFU
 bFU
 bFU
@@ -94976,9 +94979,9 @@ bDx
 bEH
 bFU
 bFU
-bIo
+jZn
 bJu
-bKE
+lLb
 bLM
 bMN
 bFU


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the Camera labeling for Box chem factory.
Replaces the blood freezer from all surgery on all maps with a blood bank I forgot to map months ago, and yes, it contains lightbulb people blood (also put a missing synthflesh beaker in Kilo surgery box), but since it is a "chemical" and not a "blood" it doesn't explicitly say it in the fridge, but it is there. 
Fancys up the Arrival / Sec pod space similar to Citadels, because I like it.

## Why It's Good For The Game

Correct cameras, good. 
Actually using the asset I made months ago, good.
Fancier space, good.

![image](https://user-images.githubusercontent.com/6519623/100842909-8db98480-3447-11eb-9563-58ad7cbd49d8.png)


## Changelog
:cl:
add: Added the missing roundstart Synthflesh beaker to Kilo surgery in the surplus limb box.
add: Space around Arrivals and Security escape pods on Boxstation is a little fancier to show it's a docking area.
tweak: Blood freezer boxes replaced with Blood bank machine on maps that didn't have it (Basically, everything but Packed.)
fix: Chem factory cameras on Box properly labeled. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
