### PR TITLE
makes tatp explosion scale with reaction volume, buffs the everliving hell out of RDX

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -46,7 +46,7 @@
 	results = list(/datum/reagent/rdx= 2)
 	required_reagents = list(/datum/reagent/phenol = 2, /datum/reagent/toxin/acid/nitracid = 1, /datum/reagent/acetone_oxide = 1 )
 	required_temp = 404
-	strengthdiv = 8
+	strengthdiv = 6 //rdx deserves better than being just about equal to nitrous
 
 /datum/chemical_reaction/reagent_explosion/rdx/on_reaction(datum/reagents/holder, created_volume)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
@@ -57,15 +57,15 @@
 /datum/chemical_reaction/reagent_explosion/rdx_explosion
 	required_reagents = list(/datum/reagent/rdx = 1)
 	required_temp = 474
-	strengthdiv = 8
+	strengthdiv = 6
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion2 //makes rdx unique , on its own it is a good bomb, but when combined with liquid electricity it becomes truly destructive
 	required_reagents = list(/datum/reagent/rdx = 1 , /datum/reagent/consumable/liquidelectricity = 1)
-	strengthdiv = 4
+	strengthdiv = 3
 	modifier = 2
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion2/on_reaction(datum/reagents/holder, created_volume)
-	var/fire_range = round(created_volume/100)
+	var/fire_range = round(created_volume/50)
 	var/turf/T = get_turf(holder.my_atom)
 	for(var/turf/turf in range(fire_range,T))
 		new /obj/effect/hotspot(turf)
@@ -74,11 +74,11 @@
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion3
 	required_reagents = list(/datum/reagent/rdx = 1 , /datum/reagent/teslium = 1)
-	modifier = 4
-	strengthdiv = 4
+	modifier = 6
+	strengthdiv = 3 
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion3/on_reaction(datum/reagents/holder, created_volume)
-	var/fire_range = round(created_volume/50)
+	var/fire_range = round(created_volume/25) // I saw why edge has such a hardon for RDX
 	var/turf/T = get_turf(holder.my_atom)
 	for(var/turf/turf in range(fire_range,T))
 		new /obj/effect/hotspot(turf)
@@ -91,9 +91,11 @@
 	required_temp = 450
 	strengthdiv = 3
 
-/datum/chemical_reaction/reagent_explosion/tatp/update_info()
-	required_temp = 450 + rand(-49,49)  //this gets loaded only on round start
+/datum/chemical_reaction/reagent_explosion/tatp/New()
+	SSticker.OnRoundstart(CALLBACK(src,.proc/UpdateInfo)) //method used by secret sauce.
 
+/datum/chemical_reaction/reagent_explosion/tatp/proc/UpdateInfo() //note to the future: find the PR that refactors this so that we can port more of https://github.com/tgstation/tgstation/pull/50775
+	required_temp = 450 + rand(-49,49)  //this gets loaded only on round start
 
 /datum/chemical_reaction/reagent_explosion/tatp/on_reaction(datum/reagents/holder, created_volume)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
@@ -106,13 +108,16 @@
 	required_temp = 550 // this makes making tatp before pyro nades, and extreme pain in the ass to make
 	strengthdiv = 3
 
+/datum/chemical_reaction/reagent_explosion/tatp_explosion/New() //did i mention i have no idea what i am doing? - zeta
+	SSticker.OnRoundstart(CALLBACK(src,.proc/UpdateInfo))
+
 /datum/chemical_reaction/reagent_explosion/tatp_explosion/on_reaction(datum/reagents/holder, created_volume)
 	var/strengthdiv_adjust = created_volume / ( 2100 / initial(strengthdiv))
 	strengthdiv = max(initial(strengthdiv) - strengthdiv_adjust + 1.5 ,1.5) //Slightly better than nitroglycerin
 	. = ..()
 	return
 
-/datum/chemical_reaction/reagent_explosion/tatp_explosion/update_info()
+/datum/chemical_reaction/reagent_explosion/tatp_explosion/proc/UpdateInfo()
 	required_temp = 550 + rand(-49,49)
 
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -91,10 +91,7 @@
 	required_temp = 450
 	strengthdiv = 3
 
-/datum/chemical_reaction/reagent_explosion/tatp/New()
-	SSticker.OnRoundstart(CALLBACK(src,.proc/UpdateInfo)) //method used by secret sauce.
-
-/datum/chemical_reaction/reagent_explosion/tatp/proc/UpdateInfo()
+/datum/chemical_reaction/reagent_explosion/tatp/update_info()
 	required_temp = 450 + rand(-49,49)  //this gets loaded only on round start
 
 
@@ -109,11 +106,13 @@
 	required_temp = 550 // this makes making tatp before pyro nades, and extreme pain in the ass to make
 	strengthdiv = 3
 
-/datum/chemical_reaction/reagent_explosion/tatp_explosion/New()
-	SSticker.OnRoundstart(CALLBACK(src,.proc/UpdateInfo))
+/datum/chemical_reaction/reagent_explosion/tatp_explosion/on_reaction(datum/reagents/holder, created_volume)
+	var/strengthdiv_adjust = created_volume / ( 2100 / initial(strengthdiv))
+	strengthdiv = max(initial(strengthdiv) - strengthdiv_adjust + 1.5 ,1.5) //Slightly better than nitroglycerin
+	. = ..()
+	return
 
-
-/datum/chemical_reaction/reagent_explosion/tatp_explosion/proc/UpdateInfo()
+/datum/chemical_reaction/reagent_explosion/tatp_explosion/update_info()
 	required_temp = 550 + rand(-49,49)
 
 


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/50775 <- partial port of this

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

tatp scales with reaction volume now
RDX is as powerful as meth when triggered normally and shits fire Everywhere when triggered with electricity

## Why It's Good For The Game

it is funny

## Changelog
:cl:
:tweak: tatp scales with reaction volume now
:tweak: rdx is funnier
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
