### PR TITLE
Adds Carp Spawners to Galaxy and Packed

### DIFF
--- a/_maps/map_files/GalaxyStation/Galaxystation.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation.dmm
@@ -20760,6 +20760,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/crew_quarters/dorms)
+"yib" = (
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/space)
 "yiJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -41084,6 +41088,7 @@ aaa
 aaa
 aaa
 aaa
+yib
 aaa
 aaa
 aaa
@@ -41092,8 +41097,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -41330,6 +41334,7 @@ aaa
 aaa
 aaa
 aaa
+yib
 aaa
 aaa
 aaa
@@ -41358,8 +41363,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -42140,7 +42144,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -43124,7 +43128,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -44201,7 +44205,7 @@ aIA
 aIA
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -45692,7 +45696,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -46772,7 +46776,7 @@ aIA
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -47234,7 +47238,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -49086,7 +49090,7 @@ aqT
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -51608,7 +51612,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -51657,7 +51661,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -54483,7 +54487,7 @@ aqT
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -57053,7 +57057,7 @@ aqT
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -59060,7 +59064,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -62400,7 +62404,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -62705,7 +62709,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -64245,7 +64249,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -64724,7 +64728,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -65265,7 +65269,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -66276,7 +66280,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa
@@ -66543,7 +66547,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+yib
 aaa
 aaa
 aaa

--- a/_maps/map_files/MidwayStation/MidwayStation.dmm
+++ b/_maps/map_files/MidwayStation/MidwayStation.dmm
@@ -19767,7 +19767,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)

--- a/_maps/map_files/MidwayStation/MidwayStation.dmm
+++ b/_maps/map_files/MidwayStation/MidwayStation.dmm
@@ -29623,12 +29623,6 @@
 /turf/open/space/basic,
 /area/space)
 "piK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -39771,17 +39765,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wqo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8

--- a/_maps/map_files/PackedStation/PackedStation.dmm
+++ b/_maps/map_files/PackedStation/PackedStation.dmm
@@ -15,9 +15,7 @@
 /turf/open/space,
 /area/space)
 "aac" = (
-/obj/effect/landmark{
-	name = "carpspawn"
-	},
+/obj/effect/landmark/carpspawn,
 /turf/open/space,
 /area/space)
 "aae" = (
@@ -19527,6 +19525,10 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/science/research)
+"kHc" = (
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/space)
 "kIt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -54770,7 +54772,7 @@ aaa
 aaa
 aaa
 aaa
-bZC
+kHc
 ajd
 ajd
 ajd
@@ -58345,7 +58347,7 @@ ajd
 ajd
 ajd
 ajd
-bZC
+kHc
 aaa
 aaa
 aaa
@@ -63315,7 +63317,7 @@ aaa
 aaa
 aaa
 aaa
-aac
+kHc
 aaa
 aaa
 aaa
@@ -64236,7 +64238,7 @@ ajd
 ajd
 ajd
 ajd
-bZC
+kHc
 ajd
 ajd
 ajd
@@ -79400,7 +79402,7 @@ aaa
 aaa
 aaa
 aaa
-aac
+kHc
 aaa
 aaa
 aaa
@@ -84066,7 +84068,7 @@ ajd
 ajd
 ajd
 ajd
-bZC
+kHc
 ajd
 ajd
 ajd
@@ -88946,7 +88948,7 @@ ajd
 ajd
 ajd
 ajd
-bZC
+kHc
 ajd
 ajd
 ajd
@@ -89783,7 +89785,7 @@ aaa
 aaa
 aaa
 aaa
-aac
+kHc
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds carp spawners to galaxy (not lv2) and packed (which had landmarks but not carp)
![image](https://user-images.githubusercontent.com/56616002/101921192-a0a92300-3bc4-11eb-9688-6dc8a3621ec1.png)


## Why It's Good For The Game

makes it so lone ops can spawn

## Changelog
:cl:
add: Added Carp Spawners (aka lone ops)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
