### PR TITLE
removes memento mori from lavaland loots

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -13,7 +13,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,28)
+	var/loot = rand(1,27)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)
@@ -77,8 +77,6 @@
 		if(27)
 			new /obj/item/borg/upgrade/modkit/lifesteal(src)
 			new /obj/item/bedsheet/cult(src)
-		if(28)
-			new /obj/item/clothing/neck/necklace/memento_mori(src)
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc


### PR DESCRIPTION
## About The Pull Request
removes memento mori form the loot pool
## Why It's Good For The Game
because its lame and broken and useless outside of having a holopara which is also stupid
## Changelog
:cl:s
del: Memento mori is no longer in the tendril loot pool
/:cl:
