### PR TITLE
Add code of conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Code of Conduct
+In order to foster a more healthy, productive and friendly contributing environment, the following code is in effect on this repository and all Development category channels on Discord/IRC.
+
+
+## Rules
+The following conduct may result in a warning being logged against your account:
+* Low-effort comments. ('No.')
+* Derogatory comments.
+* Trolling.
+* Inappropriate content.
+* Comments on pull requests not addressing technical or code-related issues.
+	* Comments expressing general attitude towards or criticism of the change, giving constructive feedback on non-technical aspects, or discussing balance should be made in appropriate non-repo channels, such as the forum, IRC, or Discord.
+	* The same rule applies to sprite, sound, or map contributions, though there the definition of "technical" will be interpreted rather broadly.
+	* The following are exempt from this rule: 
+		* The PR's author(s).
+		* Maintainers, or other staff members with the right to approve or veto the pull request.
+	* Emote reactions to pull requests are exempt. Comments on issue reports are exempt so long as they remain on topic.
+* Issuing commits, editing wiki pages, commenting, or opening bug reports in bad faith.
+	* The Head Coder and Maintainers are obligated to assume good faith until evidence otherwise surfaces.
+    * Examples:
+	    * Opening a PR you do not personally want merged. 
+		    * Exceptions exist on a case-by-case basis for opening PRs on behalf of other people, but they MUST sponsor the PR and be willing to argue in its defense as would any other contributor)
+		* Opening a PR changing, removing or adding features as a political statement to protest a change you do not like.
+		* Repeatedly attempting to compel Maintainers to block a PR you do not agree with.
+		    * This includes over the course of several PRs.
+* Disobeying development team members' instructions to cease a line of discussion or move discussion elsewhere.
+* Any other conduct deemed unhealthy or unhelpful as discussed on a case-by-case basis among the development team.
+
+The following conduct is unacceptable and will result in up to three strikes, depending on severity as determined by the Head Developer:
+* Derogatory, bigoted or prejudiced language based on race, ethnicity, sex, gender, sexuality, religion, disability, nationality or any other identifiable group.
+* Personal or political attacks.
+* Public or private harassment.
+
+
+## Warnings and Punishments
+Accumulating three warnings will result in a repository ban. The Maintainers issuing the ban may optionally ban the violating contributor from development channels in Discord for the duration of their repository ban.
+Warnings expire in six months from the date of warning.
+**Severe violations of this code of conduct may result in community or game server bans.**
+
+* The first issued ban against your account will result in a **one week ban**, which may be appealed after four days.
+* The second issued ban against your account will result in a **one month ban**, which may be appealed after two weeks.
+* The third issued ban against your account will result in a **permanent ban**, which may be appealed after one month.
+* Every subsequent ban will result in a permanent ban until appeal as described above.
+    * Fully serving or successfully appealing a ban will remove the oldest warning, resulting in two.
+
+
+## Developer Responsibilities
+The Head Coder has the responsiblity to:
+* Clarify the standards of acceptable behaviour
+* Handle the appeals process for all issued bans
+
+All Maintainers have the responsibility to:
+* Take appropriate and fair corrective action in response to any instances of unacceptable behaviour
+* Properly log all corrective action they take in the relevant thread
+
+All Maintainers have the right to: 
+* Remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct
+* Issue warnings in accordance with the Code of Conduct (except in the cases elaborated in the second section of the Rules category, which require conference with the Head Coder)
+* Temporarily ban any contributor from Discord development channels for behaviour not aligned to this Code of Conduct, for a period up to three days
+    * Any such ban issued will be accompanied by a warning, and will be logged
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the Head Coder on Discord. The Head Coder will review and investigate all complaints, and will respond in a way that they deem appropriate to the circumstances. The Head Coder is obligated to maintain confidentiality with regard to the reporter of an incident.
+
+Maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by the Head Coder.
+
+
+## Modifications
+Modifications to this code of conduct may be made by any contributor by way of a pull request, and will be considered by the development staff. Any accepted modifications will be announced in the Discord.
+
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Space Station 13 is a paranoia-laden round-based roleplaying game set against th
 
 [Policy configuration system](.github/POLICYCONFIG.md)
 
+[Following the Code of Conduct](.github/CODE_OF_CONDUCT.md)
+
 ## CODEBASE CREDITS
 
 * /tg/, for the codebase


### PR DESCRIPTION
This adds a code of conduct adapted from Baystation12's CoC (which is further adapted from the Contributor Covenant), with some terms swapped out for our codebase.

This helps make enforcing the professionalism of the repository much easier to do and clearly outlines what is and isn't acceptable.