### PR TITLE
Bureaucratic Error Balance - Min Pop, Heads Protected

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -37,7 +37,7 @@
 	else	// Adds/removes a random amount of job slots from all jobs.
 		for(var/job in jobs)
 			var/datum/job/current = job
-			if(current.title in blacklisted)
+			if(current.title in blacklisted || current.title == SSjob.overflow_role)
 				continue
 			var/ran = rand(-2,4)
 			current.total_positions = max(current.total_positions + ran, 0)

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -3,16 +3,29 @@
 	typepath = /datum/round_event/bureaucratic_error
 	max_occurrences = 1
 	weight = 5
+	min_players = 10 //Wasp Edit - Bureaucracy Nerf
 
 /datum/round_event/bureaucratic_error
 	announceWhen = 1
+	//Wasp Start - Bureaucracy Nerf
+	//these jobs can't be reopened, and AI can't have multiple latejoins anyway, so the error will not close them
+	var/list/blacklisted = list(
+		"AI",
+		"Assistant",
+		"Cyborg",
+		"Captain",
+		"Head of Personnel",
+		"Head of Security",
+		"Chief Engineer",
+		"Research Director",
+		"Chief Medical Officer") //Wasp End
 
 /datum/round_event/bureaucratic_error/announce(fake)
 	priority_announce("A recent bureaucratic error in the Organic Resources Department may result in personnel shortages in some departments and redundant staffing in others.", "Paperwork Mishap Alert")
 
 /datum/round_event/bureaucratic_error/start()
 	var/list/jobs = SSjob.occupations.Copy()
-	if(prob(33))	// Only allows latejoining as a single role. Add latejoin AI bluespace pods for fun later.
+	if(prob(5))	// Only allows latejoining as a single role. Add latejoin AI bluespace pods for fun later. Wasp Edit - Bureaucracy Nerf
 		var/datum/job/overflow = pick_n_take(jobs)
 		overflow.spawn_positions = -1
 		overflow.total_positions = -1 // Ensures infinite slots as this role. Assistant will still be open for those that cant play it.
@@ -24,7 +37,7 @@
 	else	// Adds/removes a random amount of job slots from all jobs.
 		for(var/job in jobs)
 			var/datum/job/current = job
-			if(current.title == "AI" || current.title == SSjob.overflow_role) // AI currently doesnt support latejoining past one total.
+			if(current.title in blacklisted)
 				continue
 			var/ran = rand(-2,4)
 			current.total_positions = max(current.total_positions + ran, 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This does three things
-Makes the probability of bureaucratic error turning the station into a single job 1 in 20, rather than 1 in 3. For discussion, remember that the event can only naturally happen once per round, meaning the game can't just keep rolling.
-Disallows heads from being affected by the event, as head roles cannot have their positions opened in job management, which previously created unobtainable roles even if someone tried to fix it.
-Enforces a minimum population of 10 players, ensuring that the round is active enough that someone should be there to fix it when it happens.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: centcomm interns are now less catastrophically damaging to station manifests
balance: the teller's pen will not fall on an understaffed station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
