### PR TITLE
Replace deprecated PHP syntax in webhook processor (TG#55546)

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -965,7 +965,7 @@ function checkchangelog($payload, $compile = true) {
 
 function game_server_send($addr, $port, $str) {
 	// All queries must begin with a question mark (ie "?players")
-	if($str{0} != '?') $str = ('?' . $str);
+	if($str[0] != '?') $str = ('?' . $str);
 	
 	/* --- Prepare a packet to send to the server (based on a reverse-engineered packet structure) --- */
 	$query = "\x00\x83" . pack('n', strlen($str) + 6) . "\x00\x00\x00\x00\x00" . $str . "\x00";
@@ -995,23 +995,23 @@ function game_server_send($addr, $port, $str) {
 	socket_close($server); // we don't need this anymore
 	
 	if($result != "") {
-		if($result{0} == "\x00" || $result{1} == "\x83") { // make sure it's the right packet format
+		if($result[0] == "\x00" || $result[1] == "\x83") { // make sure it's the right packet format
 			
 			// Actually begin reading the output:
-			$sizebytes = unpack('n', $result{2} . $result{3}); // array size of the type identifier and content
+			$sizebytes = unpack('n', $result[2] . $result[3]); // array size of the type identifier and content
 			$size = $sizebytes[1] - 1; // size of the string/floating-point (minus the size of the identifier byte)
 			
-			if($result{4} == "\x2a") { // 4-byte big-endian floating-point
-				$unpackint = unpack('f', $result{5} . $result{6} . $result{7} . $result{8}); // 4 possible bytes: add them up together, unpack them as a floating-point
+			if($result[4] == "\x2a") { // 4-byte big-endian floating-point
+				$unpackint = unpack('f', $result[5] . $result[6] . $result[7] . $result[8]); // 4 possible bytes: add them up together, unpack them as a floating-point
 				return $unpackint[1];
 			}
-			else if($result{4} == "\x06") { // ASCII string
+			else if($result[4] == "\x06") { // ASCII string
 				$unpackstr = ""; // result string
 				$index = 5; // string index
 				
 				while($size > 0) { // loop through the entire ASCII string
 					$size--;
-					$unpackstr .= $result{$index}; // add the string position to return string
+					$unpackstr .= $result[$index]; // add the string position to return string
 					$index++;
 				}
 				return $unpackstr;


### PR DESCRIPTION
## About The Pull Request
```PHP Fatal error: Array and string offset access syntax with curly braces is no longer supported in ./tools/WebhookProcessor/github_webhook_processor.php on line 972``` on line 17 of the Run Linters job of the CI Suite workflow.

(Port of tgstation/tgstation#55546)

## Why It's Good For The Game
Something, something the PHP version updated to 7.x and dropped curly brackets support.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->


## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
