### PR TITLE
Map Maintenance

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -2,45 +2,6 @@
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
-"aab" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"aac" = (
-/obj/machinery/requests_console{
-	department = "Bar";
-	departmentType = 2;
-	pixel_x = 30;
-	receive_ore_updates = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Bar";
-	dir = 8
-	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "aae" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -215,7 +176,7 @@
 /obj/machinery/computer/bookmanagement,
 /obj/structure/table,
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -384,7 +345,7 @@
 "abn" = (
 /obj/structure/rack,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
@@ -699,7 +660,7 @@
 	department = "Head of Security's Desk";
 	departmentType = 5;
 	name = "Head of Security RC";
-	pixel_y = 30
+	pixel_y = -32
 	},
 /obj/item/radio/intercom{
 	dir = 4;
@@ -817,7 +778,7 @@
 /area/crew_quarters/heads/hos)
 "acs" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -30
+	pixel_y = -30
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Security's Office";
@@ -1155,24 +1116,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"adl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/screwdriver{
-	pixel_y = 7
-	},
-/obj/machinery/requests_console{
-	department = "EVA";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
 "adn" = (
 /obj/structure/chair{
 	dir = 1
@@ -1220,16 +1163,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/head_of_personnel)
-"adx" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/vending/tool,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "ady" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -1726,7 +1659,7 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_x = -30
+	pixel_y = -32
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Control Room";
@@ -1983,8 +1916,7 @@
 /area/security/prison)
 "afJ" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 1;
-	pixel_y = -27
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -2093,7 +2025,7 @@
 /obj/item/pen,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
@@ -2214,7 +2146,7 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_y = 30
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -2552,7 +2484,7 @@
 "ahu" = (
 /obj/item/storage/box/bodybags,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+	pixel_y = -30
 	},
 /obj/item/reagent_containers/syringe{
 	name = "steel point"
@@ -2571,6 +2503,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"ahv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/construction)
 "ahw" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 4
@@ -2703,7 +2645,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2836,25 +2778,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"air" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/wood,
-/area/lawoffice)
 "ais" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -3050,7 +2980,7 @@
 "aje" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -3060,18 +2990,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"ajh" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/structure/closet/secure_closet/courtroom,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
-/obj/item/gavelhammer,
-/turf/open/floor/plasteel,
-/area/security/courtroom)
 "aji" = (
 /obj/structure/chair{
 	name = "Judge"
@@ -3148,7 +3066,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -3587,15 +3505,6 @@
 "akI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"akJ" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -4193,6 +4102,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"amU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "amV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -4392,8 +4309,7 @@
 /area/security/courtroom)
 "anX" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/camera{
 	c_tag = "Courtroom South";
@@ -4519,14 +4435,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aoB" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aoC" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/red,
@@ -4538,8 +4446,7 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
@@ -4813,19 +4720,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"aqb" = (
-/obj/machinery/button/door{
-	id = "kanyewest";
-	name = "Privacy Shutters";
-	pixel_y = 24
-	},
-/obj/item/storage/briefcase,
-/obj/structure/rack,
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
 "aqc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -4981,40 +4875,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"aqW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light_switch{
-	pixel_x = -27
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/vacant_room/commissary)
-"aqY" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Law office";
-	pixel_x = -32
-	},
-/obj/machinery/vending/wardrobe/law_wardrobe,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/lawoffice)
 "aqZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -5303,7 +5163,7 @@
 "asl" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /obj/structure/filingcabinet/employment,
 /turf/open/floor/wood,
@@ -5821,7 +5681,7 @@
 "aug" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -6006,7 +5866,7 @@
 "auS" = (
 /obj/machinery/requests_console{
 	department = "Crew Quarters";
-	pixel_y = 30
+	pixel_y = -32
 	},
 /obj/machinery/camera{
 	c_tag = "Dormitory North"
@@ -6024,7 +5884,7 @@
 /area/crew_quarters/dorms)
 "auU" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6112,19 +5972,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"avk" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "avl" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6509,6 +6359,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"awQ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "awS" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -7091,7 +6953,7 @@
 /area/maintenance/starboard/fore)
 "aAd" = (
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -7219,8 +7081,7 @@
 /area/hydroponics/garden)
 "aAS" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
@@ -7380,7 +7241,7 @@
 /area/storage/primary)
 "aBS" = (
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit,
@@ -7503,19 +7364,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aCq" = (
-/obj/structure/table/wood,
-/obj/machinery/requests_console{
-	department = "Theatre";
-	name = "theatre RC";
-	pixel_x = -32
-	},
-/obj/item/reagent_containers/food/snacks/baguette,
-/obj/item/toy/dummy,
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/theatre)
 "aCr" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
@@ -7686,18 +7534,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"aDb" = (
-/obj/structure/table,
-/obj/item/wirecutters,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "aDc" = (
 /obj/machinery/computer/card,
 /obj/machinery/light{
@@ -7723,7 +7559,7 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_y = 30
+	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -7765,7 +7601,7 @@
 	},
 /obj/machinery/requests_console{
 	department = "Tool Storage";
-	pixel_y = 30
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -7775,15 +7611,6 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel,
-/area/storage/primary)
-"aDm" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aDn" = (
@@ -8063,6 +7890,24 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"aEA" = (
+/obj/machinery/computer/crew,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	dir = 1;
+	name = "Chief Medical Officer RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "aEB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -8401,8 +8246,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/light_switch{
-	pixel_x = 6;
-	pixel_y = -25
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -8599,7 +8443,7 @@
 "aGf" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
@@ -8618,12 +8462,6 @@
 	pixel_y = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
-"aGl" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "aGm" = (
@@ -8734,6 +8572,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aGI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "aGO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -8745,7 +8593,7 @@
 /obj/machinery/requests_console{
 	department = "Chapel";
 	departmentType = 2;
-	pixel_y = 30
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -8809,7 +8657,7 @@
 /area/chapel/office)
 "aHg" = (
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = -23
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Office"
@@ -9321,36 +9169,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"aIQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aIR" = (
 /obj/structure/sign/map/right{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"aIS" = (
-/obj/structure/table/glass,
-/obj/item/hatchet,
-/obj/item/cultivator,
-/obj/item/crowbar,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/plant_analyzer,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "aIT" = (
 /obj/item/storage/bag/plants/portaseeder,
 /obj/structure/table/glass,
@@ -9359,8 +9183,7 @@
 	pixel_x = 29
 	},
 /obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = -25
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -9415,7 +9238,7 @@
 /area/storage/primary)
 "aJg" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_y = -30
 	},
 /obj/machinery/light{
 	dir = 4
@@ -9552,15 +9375,6 @@
 /obj/item/stack/spacecash/c100,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aJF" = (
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "aJG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/button/crematorium{
@@ -9823,15 +9637,6 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"aKJ" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "aKK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/closet/secure_closet/hydroponics,
@@ -9868,20 +9673,6 @@
 /obj/machinery/vending/classicbeats,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"aKO" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "aKP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -9928,7 +9719,7 @@
 /area/crew_quarters/kitchen)
 "aKW" = (
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -10075,16 +9866,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port/fore)
-"aLv" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aLw" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -10133,8 +9914,7 @@
 /area/hallway/primary/port)
 "aLI" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = 30
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -10189,7 +9969,7 @@
 /area/hallway/primary/central)
 "aLR" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10316,7 +10096,7 @@
 /area/crew_quarters/kitchen)
 "aMm" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -10359,8 +10139,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = -31
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10427,7 +10206,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10810,16 +10589,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aOo" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "aOp" = (
 /obj/machinery/camera{
 	c_tag = "Port Hallway 3";
@@ -10900,15 +10669,6 @@
 /obj/item/toy/beach_ball/holoball,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"aOQ" = (
-/obj/machinery/requests_console{
-	department = "Hydroponics";
-	departmentType = 2;
-	pixel_y = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
 "aOR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -11404,16 +11164,6 @@
 "aQE" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"aQF" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "aQG" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -11468,13 +11218,6 @@
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aQP" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "aQQ" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
@@ -11507,15 +11250,6 @@
 /obj/machinery/vending/modularpc,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aQZ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel,
-/area/storage/art)
 "aRa" = (
 /turf/open/floor/plasteel,
 /area/storage/art)
@@ -11687,8 +11421,7 @@
 /area/crew_quarters/bar)
 "aRy" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -11815,13 +11548,6 @@
 /obj/machinery/navbeacon/wayfinding,
 /turf/open/floor/engine/cult,
 /area/library)
-"aRR" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
 "aRS" = (
 /turf/open/floor/carpet,
 /area/chapel/main)
@@ -11831,18 +11557,6 @@
 	},
 /turf/open/floor/engine,
 /area/escapepodbay)
-"aRV" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/storage/tools)
 "aRW" = (
 /obj/machinery/camera{
 	c_tag = "Escape Podbay";
@@ -11893,7 +11607,7 @@
 /area/crew_quarters/locker)
 "aSl" = (
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = -23
 	},
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
@@ -12178,7 +11892,7 @@
 /area/crew_quarters/bar)
 "aTb" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -12187,14 +11901,6 @@
 	dir = 8;
 	name = "Library Desk Door";
 	req_access_txt = "37"
-	},
-/turf/open/floor/wood,
-/area/library)
-"aTd" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
-/obj/machinery/light_switch{
-	pixel_y = 28
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -12748,14 +12454,6 @@
 /obj/item/pen/red,
 /turf/open/floor/wood,
 /area/vacant_room/office)
-"aUU" = (
-/obj/structure/closet/wardrobe/grey,
-/obj/machinery/requests_console{
-	department = "Locker Room";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "aUV" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -12888,7 +12586,7 @@
 /obj/machinery/processor,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -13058,15 +12756,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"aWm" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -28
-	},
-/turf/open/floor/wood,
-/area/vacant_room/office)
 "aWn" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/clothing/shoes/jackboots,
@@ -13163,7 +12852,7 @@
 	department = "Bridge";
 	departmentType = 5;
 	name = "Bridge RC";
-	pixel_y = -30
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13253,16 +12942,6 @@
 /area/crew_quarters/bar)
 "aXm" = (
 /obj/effect/landmark/start/cook,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"aXn" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/machinery/requests_console{
-	department = "Kitchen";
-	departmentType = 2;
-	pixel_x = 30
-	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aXo" = (
@@ -13447,13 +13126,6 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/warehouse)
-"aYe" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/locker)
 "aYf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13582,7 +13254,7 @@
 /area/crew_quarters/bar)
 "aYJ" = (
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -13700,13 +13372,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"aZd" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/wood,
-/area/library)
 "aZf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -13740,15 +13405,6 @@
 	dir = 4
 	},
 /turf/open/floor/engine/airless,
-/area/escapepodbay)
-"aZm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
 /area/escapepodbay)
 "aZn" = (
 /obj/structure/table/wood,
@@ -13834,7 +13490,7 @@
 /area/bridge/meeting_room)
 "aZz" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
@@ -13848,16 +13504,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aZC" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "aZE" = (
 /turf/closed/wall,
 /area/quartermaster/storage)
@@ -13960,7 +13606,7 @@
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -13970,7 +13616,7 @@
 /area/crew_quarters/bar)
 "bac" = (
 /obj/machinery/newscaster{
-	pixel_y = -28
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -14025,18 +13671,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"bal" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "bam" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14116,15 +13750,6 @@
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"baG" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -14377,18 +14002,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/chapel/main)
-"bbG" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/exit)
 "bbM" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/structure/table/wood,
@@ -14530,20 +14143,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"bcs" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bct" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "bcv" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -14968,12 +14574,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ber" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bes" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue,
@@ -15055,7 +14655,7 @@
 /area/quartermaster/sorting)
 "beH" = (
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/red{
@@ -15065,8 +14665,7 @@
 /area/hallway/secondary/exit)
 "beI" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -15144,7 +14743,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /obj/structure/table/reinforced,
 /obj/item/stack/wrapping_paper{
@@ -15255,7 +14854,7 @@
 	department = "Bridge";
 	departmentType = 5;
 	name = "Bridge RC";
-	pixel_y = -30
+	pixel_y = -32
 	},
 /obj/machinery/light,
 /turf/open/floor/wood,
@@ -15334,6 +14933,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"bfJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "bfK" = (
 /turf/closed/wall,
 /area/security/checkpoint/medical)
@@ -15565,7 +15174,7 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = -30
+	pixel_y = -32
 	},
 /obj/machinery/light{
 	dir = 8
@@ -15592,7 +15201,7 @@
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
@@ -15661,17 +15270,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bgS" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Captain's Desk";
-	departmentType = 5;
-	name = "Captain RC";
-	pixel_x = -30
-	},
-/obj/structure/filingcabinet,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "bgT" = (
 /obj/machinery/computer/communications{
 	dir = 8
@@ -15705,13 +15303,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"bgY" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bha" = (
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
@@ -15724,16 +15315,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/pharmacy)
-"bhc" = (
-/obj/machinery/camera{
-	c_tag = "Chemistry"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
 "bhd" = (
@@ -15777,23 +15358,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
-"bhj" = (
-/obj/machinery/camera{
-	c_tag = "Security Post - Medbay"
-	},
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/medical)
 "bhk" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -15824,7 +15388,7 @@
 "bhl" = (
 /obj/structure/filingcabinet,
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -15873,20 +15437,6 @@
 /area/engine/engineering)
 "bhw" = (
 /obj/machinery/computer/rdconsole/robotics,
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
-"bhx" = (
-/obj/machinery/requests_console{
-	department = "Robotics";
-	departmentType = 2;
-	name = "Robotics RC";
-	pixel_y = 30;
-	receive_ore_updates = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bhA" = (
@@ -16044,7 +15594,7 @@
 /area/quartermaster/storage)
 "bid" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
@@ -16133,22 +15683,6 @@
 /obj/item/melee/chainofcommand,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"bio" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/machinery/requests_console{
-	department = "Chemistry";
-	departmentType = 2;
-	pixel_x = -30;
-	receive_ore_updates = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/pharmacy)
 "bip" = (
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -16410,7 +15944,7 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_y = 30
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -16432,16 +15966,6 @@
 /obj/machinery/cell_charger,
 /obj/item/radio/intercom{
 	pixel_y = 20
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"bjq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = 30
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -16488,16 +16012,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"bjF" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
-/obj/machinery/keycard_auth{
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "bjG" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -16672,18 +16186,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"bkn" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 27
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "bko" = (
 /obj/machinery/light{
 	dir = 4
@@ -16721,7 +16223,7 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = -30;
+	pixel_y = -32;
 	receive_ore_updates = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -16798,7 +16300,7 @@
 "bkC" = (
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/light_switch{
-	pixel_x = 25
+	pixel_y = -23
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -16839,7 +16341,7 @@
 /area/quartermaster/office)
 "bkO" = (
 /obj/machinery/light_switch{
-	pixel_x = 28
+	pixel_y = -23
 	},
 /obj/item/screwdriver{
 	pixel_y = 10
@@ -16864,7 +16366,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -16896,14 +16398,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
-"ble" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "blf" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes,
@@ -17220,7 +16714,7 @@
 /area/crew_quarters/heads/captain)
 "bmB" = (
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -17299,21 +16793,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
-"bmJ" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1485;
-	listening = 0;
-	name = "Station Intercom (Medbay)";
-	pixel_y = -30
-	},
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bmK" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
@@ -17448,24 +16927,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"bnj" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/cable_coil,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "bnm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -17559,15 +17020,6 @@
 /obj/machinery/computer/cargo/request,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"bnJ" = (
-/obj/machinery/firealarm{
-	pixel_y = 27
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "bnK" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -17590,45 +17042,9 @@
 /area/hallway/primary/central)
 "bnO" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/head_of_personnel)
-"bnP" = (
-/obj/machinery/button/flasher{
-	id = "foflash";
-	pixel_x = 6;
-	pixel_y = 36
-	},
-/obj/machinery/button/door{
-	id = "head_of_personnel";
-	name = "Privacy Shutters Control";
-	pixel_x = 6;
-	pixel_y = 25;
-	req_access_txt = "57"
-	},
-/obj/machinery/button/door{
-	id = "foqueue";
-	name = "Queue Shutters Control";
-	pixel_x = -4;
-	pixel_y = 25;
-	req_access_txt = "57"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = 36
-	},
-/obj/machinery/pdapainter,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/head_of_personnel)
 "bnQ" = (
@@ -17722,7 +17138,7 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
-	pixel_x = 30
+	pixel_y = -32
 	},
 /obj/machinery/light,
 /mob/living/simple_animal/bot/cleanbot{
@@ -17809,7 +17225,7 @@
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/crowbar,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_y = -30
 	},
 /obj/item/radio/headset/headset_sci{
 	pixel_x = -3
@@ -18055,7 +17471,7 @@
 "bpu" = (
 /obj/structure/bed/roller,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -18084,19 +17500,6 @@
 "bpE" = (
 /turf/closed/wall,
 /area/science/explab)
-"bpH" = (
-/obj/structure/table/glass,
-/obj/item/folder/white,
-/obj/item/radio/headset/headset_medsci,
-/obj/machinery/requests_console{
-	department = "Genetics";
-	name = "Genetics Requests Console";
-	pixel_y = 30
-	},
-/obj/item/storage/pill_bottle/mutadone,
-/obj/item/storage/pill_bottle/mannitol,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "bpI" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/blue{
@@ -18276,13 +17679,13 @@
 /area/quartermaster/storage)
 "bqn" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bqo" = (
 /obj/machinery/light_switch{
-	pixel_x = -27
+	pixel_y = -23
 	},
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel,
@@ -18550,19 +17953,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"brO" = (
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_x = -30
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Office";
-	dir = 4
-	},
-/obj/machinery/rnd/production/techfab/department/cargo,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "brS" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/head_of_personnel)
@@ -18617,21 +18007,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/teleporter)
-"bsj" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 1
-	},
-/obj/structure/table,
-/obj/item/beacon,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/teleporter)
 "bsk" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /obj/machinery/light{
 	dir = 1
@@ -18833,19 +18211,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"btf" = (
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_x = -30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/computer/cargo/request{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bth" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -18888,15 +18253,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"btt" = (
-/obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/item/folder/yellow,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "btu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -18980,8 +18336,7 @@
 /area/engine/gravity_generator)
 "btP" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19003,7 +18358,7 @@
 /area/medical/medbay/central)
 "btS" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19039,16 +18394,6 @@
 	dir = 5
 	},
 /area/science/research)
-"btX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "btZ" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -19082,7 +18427,7 @@
 	department = "Head of Personnel's Desk";
 	departmentType = 5;
 	name = "Head of Personnel RC";
-	pixel_y = -30
+	pixel_y = -32
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office";
@@ -19321,6 +18666,27 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel,
 /area/medical/genetics)
+"bvv" = (
+/obj/structure/table,
+/obj/effect/turf_decal/bot,
+/obj/item/storage/box/disks_nanite{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/item/nanite_scanner{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/nanite_remote{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/nanite)
 "bvw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -19328,25 +18694,6 @@
 "bvx" = (
 /turf/closed/wall/r_wall,
 /area/science/research)
-"bvy" = (
-/obj/machinery/camera{
-	c_tag = "Genetics Research";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "bvA" = (
 /obj/structure/sign/warning/securearea,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19367,26 +18714,6 @@
 	dir = 6
 	},
 /area/science/research)
-"bvF" = (
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_x = -30
-	},
-/obj/machinery/computer/bounty{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "bvH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -19466,6 +18793,30 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"bvW" = (
+/obj/machinery/button/door{
+	id = "Biohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = -5;
+	pixel_y = 28;
+	req_access_txt = "47"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 6;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "bvX" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay South";
@@ -19659,44 +19010,19 @@
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
-"bwK" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bwL" = (
 /obj/machinery/door/window/eastleft{
 	name = "Cloning Recovery"
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
-"bwN" = (
-/obj/machinery/light_switch{
-	pixel_x = 8;
-	pixel_y = 28
-	},
-/obj/machinery/button/door{
-	id = "Biohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -5;
-	pixel_y = 28;
-	req_access_txt = "47"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"bwX" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/science)
+/area/hallway/secondary/entry)
 "bwZ" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -19931,7 +19257,7 @@
 "byn" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20021,7 +19347,7 @@
 /area/quartermaster/miningdock)
 "byH" = (
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20087,7 +19413,7 @@
 /area/security/checkpoint/supply)
 "byN" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -20095,7 +19421,7 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_y = -30
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -20145,17 +19471,9 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"byV" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "byW" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20211,7 +19529,7 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
-	pixel_y = 30
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -20285,7 +19603,7 @@
 /obj/item/storage/box/bodybags,
 /obj/item/pen,
 /obj/machinery/firealarm{
-	pixel_y = -24
+	pixel_y = -26
 	},
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning Lab";
@@ -20315,7 +19633,7 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_y = -28
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -20410,13 +19728,6 @@
 	dir = 5
 	},
 /area/science/research)
-"bzF" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "bzH" = (
 /obj/structure/table,
 /obj/item/hemostat,
@@ -20532,25 +19843,12 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bAr" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
-"bAs" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bAt" = (
@@ -20611,27 +19909,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"bAE" = (
-/obj/machinery/camera{
-	c_tag = "Security Post - Science";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science)
 "bAH" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -20780,7 +20057,7 @@
 	pixel_x = 30
 	},
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/camera{
 	c_tag = "Security Post - Cargo";
@@ -20920,12 +20197,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"bBJ" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bBK" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -20947,23 +20218,6 @@
 /obj/machinery/computer/med_data,
 /obj/machinery/airalarm{
 	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
-"bBP" = (
-/obj/machinery/computer/crew,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer RC";
-	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -21014,16 +20268,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"bBU" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "bBV" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
@@ -21109,7 +20353,7 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_y = -30
+	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -21413,7 +20657,7 @@
 /area/science/storage)
 "bDf" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_y = -23
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -21447,23 +20691,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"bDk" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/pen,
-/obj/machinery/requests_console{
-	department = "Mining";
-	pixel_x = -30
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "bDl" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -21478,15 +20709,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bDp" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bDq" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -21599,16 +20821,6 @@
 "bDJ" = (
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
-/turf/open/floor/plasteel,
-/area/janitor)
-"bDK" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/machinery/camera{
-	c_tag = "Custodial Closet"
-	},
-/obj/vehicle/ridden/janicart,
 /turf/open/floor/plasteel,
 /area/janitor)
 "bDL" = (
@@ -21965,7 +21177,7 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
-	pixel_x = 30
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -22022,19 +21234,6 @@
 "bFG" = (
 /obj/structure/chair{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
-"bFH" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch{
-	pixel_x = 28
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -22234,7 +21433,7 @@
 /obj/machinery/requests_console{
 	department = "Janitorial";
 	departmentType = 1;
-	pixel_y = -29
+	pixel_y = -32
 	},
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel,
@@ -22553,7 +21752,7 @@
 "bIc" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 1
@@ -22983,7 +22182,7 @@
 /area/storage/tech)
 "bJn" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_y = -23
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -23016,21 +22215,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bJz" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bJA" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23610,7 +22794,7 @@
 "bMm" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -23631,15 +22815,6 @@
 /area/science/xenobiology)
 "bMo" = (
 /obj/machinery/smartfridge/extract/preloaded,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"bMp" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/item/extinguisher,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -23731,13 +22906,6 @@
 /area/medical/virology)
 "bMK" = (
 /turf/closed/wall,
-/area/engine/atmos)
-"bMP" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMQ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -24192,24 +23360,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bOW" = (
-/obj/machinery/computer/atmos_control{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/engine/atmos)
 "bOX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -24430,7 +23580,7 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_y = -30;
+	pixel_y = -32;
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -24627,19 +23777,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"bQE" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bQF" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/plasteel/white,
@@ -24781,23 +23918,8 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
-"bRM" = (
-/obj/structure/table,
-/obj/machinery/light_switch{
-	pixel_x = -23
-	},
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bRN" = (
 /turf/closed/wall,
-/area/medical/virology)
-"bRO" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bRQ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -24925,35 +24047,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bST" = (
-/obj/machinery/doorButtons/airlock_controller{
-	idExterior = "virology_airlock_exterior";
-	idInterior = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_x = 8;
-	pixel_y = 22;
-	req_access_txt = "39"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"bSU" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bSY" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/plasteel/white,
@@ -25134,17 +24227,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"bUc" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Telecomms Admin";
-	departmentType = 5;
-	name = "Telecomms RC";
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/tcommsat/computer)
 "bUd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -25316,13 +24398,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"bVb" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/tcommsat/computer)
 "bVc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -25595,7 +24670,7 @@
 /obj/machinery/requests_console{
 	department = "Virology";
 	name = "Virology Requests Console";
-	pixel_x = -32
+	pixel_y = -32
 	},
 /obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
@@ -25974,21 +25049,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"bXP" = (
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
-	},
-/obj/structure/closet/secure_closet/security/engine,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "bXU" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
@@ -26183,14 +25243,6 @@
 "bYH" = (
 /turf/closed/wall,
 /area/engine/break_room)
-"bYI" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bYK" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -26347,21 +25399,6 @@
 /area/tcommsat/computer)
 "bZy" = (
 /turf/open/floor/plasteel,
-/area/engine/break_room)
-"bZz" = (
-/obj/machinery/light_switch{
-	pixel_x = -23
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
 /area/engine/break_room)
 "bZL" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
@@ -27003,6 +26040,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"cdz" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "cdD" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
 	dir = 8
@@ -27303,26 +26350,12 @@
 /area/maintenance/aft)
 "cfZ" = (
 /obj/machinery/light_switch{
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"cgc" = (
-/obj/machinery/requests_console{
-	department = "Chemistry";
-	departmentType = 2;
-	pixel_x = -30;
-	receive_ore_updates = 1
-	},
-/obj/item/wrench,
-/obj/item/wrench,
-/obj/structure/rack,
-/obj/item/construction/plumbing,
-/obj/item/construction/plumbing,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "cgd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27606,7 +26639,7 @@
 "ciH" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -27660,33 +26693,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cjg" = (
-/obj/machinery/computer/card/minor/ce{
+"cjn" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 3;
-	name = "Chief Engineer RC";
-	pixel_x = -32
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
 	},
-/obj/machinery/camera{
-	c_tag = "Chief Engineer's Office";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cjo" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plasteel,
@@ -27969,7 +26985,7 @@
 "clh" = (
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -31
+	pixel_y = -30
 	},
 /obj/machinery/computer/turbine_computer{
 	dir = 1;
@@ -28236,15 +27252,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"cmX" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/construction)
 "cmY" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/light/small{
@@ -28352,6 +27359,13 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cow" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cox" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -28359,26 +27373,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"coH" = (
-/obj/structure/table,
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/item/stack/sheet/metal/five,
-/obj/item/circuitboard/machine/paystand,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/item/stack/cable_coil/random/five,
-/turf/open/floor/plasteel,
-/area/vacant_room/commissary)
 "coS" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser{
@@ -28777,33 +27771,26 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
-"ctT" = (
-/obj/machinery/requests_console{
-	department = "Engineering";
-	departmentType = 4;
-	name = "Engineering RC";
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cuf" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/service)
 "cuj" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
+"cur" = (
+/obj/machinery/button/door{
+	id = "kanyewest";
+	name = "Privacy Shutters";
+	pixel_y = 24
+	},
+/obj/item/storage/briefcase,
+/obj/structure/rack,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "cuE" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
@@ -29705,6 +28692,19 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"cHu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cHC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -30451,8 +29451,7 @@
 	pixel_y = 27
 	},
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -31;
-	pixel_y = 33
+	pixel_y = -30
 	},
 /obj/machinery/button/door{
 	id = "AI Door";
@@ -30567,7 +29566,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -31169,24 +30168,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
-"dxx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "dxy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -31279,21 +30260,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"dAM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
 "dBf" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Incinerator Access";
@@ -31550,18 +30516,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"dLA" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 5
-	},
-/area/science/research)
 "dLU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -31652,6 +30606,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"dNK" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "dOe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -31801,6 +30764,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"dUJ" = (
+/obj/structure/chair/office/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "dUV" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Bow Solar Access";
@@ -31992,6 +30966,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"edC" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "edD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32007,6 +30991,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"eeo" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "efi" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -32379,6 +31370,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"esc" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "ese" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -32795,6 +31793,16 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
+"eKG" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "eLi" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -33024,7 +32032,7 @@
 "eVL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = -23
 	},
 /obj/machinery/light{
 	dir = 1
@@ -33147,6 +32155,24 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"fcN" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "fdv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -33395,6 +32421,17 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
+"fmp" = (
+/obj/machinery/camera{
+	c_tag = "Chemistry"
+	},
+/obj/machinery/chem_heater,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/pharmacy)
 "fmJ" = (
 /obj/effect/landmark/observer_start,
 /obj/effect/turf_decal/plaque{
@@ -33592,7 +32629,7 @@
 /area/engine/engineering)
 "fsN" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -33869,7 +32906,7 @@
 	},
 /obj/item/storage/box/evidence,
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -30
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -33923,6 +32960,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"fCU" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fDT" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -33961,26 +33005,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"fEu" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/closet/wardrobe/engineering_yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fEA" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/air_sensor/atmos/air_tank,
@@ -34073,7 +33097,7 @@
 "fJJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -34138,6 +33162,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fLJ" = (
+/obj/structure/table/glass,
+/obj/item/hatchet,
+/obj/item/cultivator,
+/obj/item/crowbar,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/plant_analyzer,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "fNe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -34232,6 +33273,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"fRC" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/machinery/requests_console{
+	department = "Kitchen";
+	departmentType = 2;
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "fRG" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -34385,20 +33437,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"gcq" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "AI";
-	departmentType = 5;
-	pixel_y = 28
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "gct" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -34421,7 +33459,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /obj/machinery/camera{
 	c_tag = "Toxins Lab West";
@@ -34601,6 +33639,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"gim" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gip" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -34644,6 +33689,17 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"gjk" = (
+/obj/machinery/camera{
+	c_tag = "Custodial Closet"
+	},
+/obj/vehicle/ridden/janicart,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "gjl" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
@@ -34673,18 +33729,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"gkv" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gky" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -34988,6 +34032,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gum" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "gvl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -34997,6 +34051,13 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"gvU" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "gvW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -35238,7 +34299,7 @@
 "gBR" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35530,6 +34591,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"gPQ" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/bookmanagement,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood,
+/area/library)
 "gPT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -35626,6 +34696,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"gTt" = (
+/obj/item/wrench,
+/obj/item/wrench,
+/obj/structure/rack,
+/obj/item/construction/plumbing,
+/obj/item/construction/plumbing,
+/obj/machinery/requests_console{
+	department = "Chemistry";
+	departmentType = 2;
+	dir = 8;
+	pixel_x = -32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "gUw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35696,6 +34781,26 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"gYM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "gZo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -35721,6 +34826,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
+"hac" = (
+/obj/machinery/camera{
+	c_tag = "Genetics Research";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "hax" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -35744,14 +34867,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/security/processing)
-"haX" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "hbl" = (
 /obj/machinery/igniter{
 	id = "Incinerator"
@@ -35771,18 +34886,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"hcb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/emcloset,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "hcm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red,
@@ -36293,6 +35396,25 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"hsh" = (
+/obj/machinery/computer/atmos_control{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	dir = 4;
+	name = "Atmos RC";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/engine/atmos)
 "hsQ" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -36333,6 +35455,14 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"hut" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "huW" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -36347,6 +35477,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"hvL" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "hwb" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=CHE";
@@ -36535,22 +35675,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"hCR" = (
+/obj/machinery/camera{
+	c_tag = "Cargo Office";
+	dir = 4
+	},
+/obj/machinery/rnd/production/techfab/department/cargo,
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "hDv" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"hDH" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
 "hDS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -37013,6 +36156,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"hZW" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "iaW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37227,6 +36378,16 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ilQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "imm" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
@@ -37258,11 +36419,11 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+	pixel_y = -30
 	},
 /obj/machinery/disposal/bin,
 /obj/machinery/light_switch{
-	pixel_y = 26
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
@@ -37371,6 +36532,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"its" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/baguette,
+/obj/item/toy/dummy,
+/obj/machinery/requests_console{
+	department = "Theatre";
+	dir = 8;
+	name = "theatre RC";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
 "itG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -37595,6 +36770,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"iFC" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "iFK" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -37650,6 +36838,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"iHQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "iHT" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light{
@@ -37920,6 +37122,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"iVQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "iWN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -38346,7 +37556,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -38589,7 +37799,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -38604,16 +37814,25 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply,
 /turf/closed/wall,
 /area/maintenance/fore)
-"jwT" = (
-/obj/machinery/light_switch{
-	pixel_y = 26
+"jwS" = (
+/obj/structure/closet/secure_closet/security/engine,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	dir = 1;
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/security/checkpoint/engineering)
 "jyo" = (
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -38792,7 +38011,7 @@
 /obj/structure/chair/office/light,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -39042,6 +38261,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"jMD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "jNk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -39078,6 +38311,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"jNM" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Chemistry";
+	departmentType = 2;
+	dir = 8;
+	pixel_x = -32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/pharmacy)
 "jOg" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -39104,16 +38354,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jOS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jOW" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -39711,6 +38951,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"kou" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/vending/tool,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "koI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40016,7 +39267,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -40032,33 +39283,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"kBX" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = 27;
-	pixel_y = -10
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "kCk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -40107,6 +39331,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"kCT" = (
+/obj/structure/closet/wardrobe/grey,
+/obj/machinery/requests_console{
+	department = "Locker Room";
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"kDz" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/sign/poster/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "kDM" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -40321,6 +39561,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"kLI" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "kMh" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -40675,6 +39929,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"lai" = (
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "lat" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40754,6 +40020,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ldn" = (
+/obj/machinery/computer/card/minor/ce{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Chief Engineer's Office";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 3;
+	dir = 8;
+	name = "Chief Engineer RC";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "ldt" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/security/glass{
@@ -40906,12 +40200,41 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"lht" = (
+/obj/structure/table/glass,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "lhu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"lhH" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "lhS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -41159,34 +40482,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"lqV" = (
-/obj/machinery/power/apc{
-	areastring = "/area/storage/tools";
-	dir = 1;
-	name = "Auxiliary Tool Storage APC";
-	pixel_y = 24
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/rods/fifty,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/storage/tools)
 "lrg" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/white,
@@ -41203,6 +40498,20 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
+"ltk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/cargo/request{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	dir = 8;
+	name = "Medbay RC";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "ltD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -41221,7 +40530,7 @@
 /area/bridge)
 "luW" = (
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/machinery/light{
 	dir = 1
@@ -41287,6 +40596,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lxT" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/storage/art)
 "lzH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41363,19 +40682,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"lCW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/light_switch{
-	pixel_x = -23
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
 "lDW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -41581,6 +40887,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
+"lLg" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "lLp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -41909,31 +41224,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"lXr" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/engineering";
-	dir = 8;
-	name = "Engineering Security APC";
-	pixel_x = -24
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "lXv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -42011,6 +41301,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"lZt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
+/area/science/research)
 "lZH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/landmark/event_spawn,
@@ -42129,6 +41432,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"mcU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/break_room)
 "mdc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -42255,7 +41574,7 @@
 /area/maintenance/port/fore)
 "mgs" = (
 /obj/machinery/light_switch{
-	pixel_x = 25
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 9
@@ -42389,8 +41708,7 @@
 	department = "Research Director's Desk";
 	departmentType = 5;
 	name = "Research Director RC";
-	pixel_x = -2;
-	pixel_y = 30;
+	pixel_y = -32;
 	receive_ore_updates = 1
 	},
 /turf/open/floor/carpet/purple,
@@ -42592,6 +41910,16 @@
 "mtK" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
+"muc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "muA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42807,7 +42135,7 @@
 /area/security/processing)
 "mBY" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_y = -30
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -43093,6 +42421,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mIb" = (
+/obj/machinery/keycard_auth{
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "mIi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -43132,6 +42471,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"mJM" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/exit)
 "mKe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43162,7 +42513,7 @@
 "mKO" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
@@ -43306,6 +42657,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"mOn" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "mOC" = (
 /obj/machinery/camera{
 	c_tag = "Engineering SMES";
@@ -43353,6 +42719,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mQF" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/tcommsat/computer)
 "mRc" = (
 /obj/machinery/power/apc{
 	areastring = "/area/engine/break_room";
@@ -43513,6 +42887,36 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"mWI" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"mWU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "mXb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43593,6 +42997,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"mYQ" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "mYT" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Construction Area";
@@ -43692,6 +43103,32 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
+"nbK" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/engineering";
+	dir = 8;
+	name = "Engineering Security APC";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "nbP" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -43924,15 +43361,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"nik" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "nju" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -44693,6 +44121,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"nFD" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/vending/wardrobe/law_wardrobe,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/requests_console{
+	department = "Law office";
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "nFI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -44782,15 +44226,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"nKn" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "nKq" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -44924,6 +44359,28 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
+"nPv" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/requests_console{
+	department = "Engineering";
+	departmentType = 4;
+	dir = 1;
+	name = "Engineering RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nPy" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -44941,7 +44398,7 @@
 	department = "Atmospherics";
 	departmentType = 4;
 	name = "Atmos RC";
-	pixel_x = -30
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
@@ -44965,7 +44422,7 @@
 /area/hallway/secondary/exit)
 "nQI" = (
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_y = -23
 	},
 /obj/structure/closet/secure_closet/chemical,
 /obj/item/radio/headset/headset_med,
@@ -45033,7 +44490,7 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
@@ -45074,6 +44531,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"nWG" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "nXi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -45130,7 +44594,7 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = 30;
+	pixel_y = -32;
 	receive_ore_updates = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45680,20 +45144,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"oqk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "oqu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -45727,6 +45177,14 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"osD" = (
+/obj/structure/closet/bombcloset,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "osV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45933,6 +45391,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"oBf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/screwdriver{
+	pixel_y = 7
+	},
+/obj/machinery/requests_console{
+	department = "EVA";
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "oBu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -46248,6 +45725,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"oMa" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "oMN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -46639,16 +46126,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"pbp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 8
-	},
-/area/science/research)
 "pbt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -46718,6 +46195,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"pgI" = (
+/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pgP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46744,6 +46241,15 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"phx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "phK" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -48141,8 +47647,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -48170,6 +47675,18 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/head_of_personnel)
+"qhf" = (
+/obj/structure/filingcabinet,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
+	dir = 8;
+	name = "Captain RC";
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "qhX" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/effect/landmark/blobstart,
@@ -48362,6 +47879,26 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"qnO" = (
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "virology_airlock_exterior";
+	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = 8;
+	pixel_y = 22;
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -5;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "qoq" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -48417,19 +47954,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qqp" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qqz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -48595,7 +48119,7 @@
 /area/science/research)
 "qtE" = (
 /obj/machinery/firealarm{
-	pixel_y = 25
+	pixel_y = -26
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48615,6 +48139,20 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
+"qvp" = (
+/obj/structure/table/glass,
+/obj/item/folder/white,
+/obj/item/radio/headset/headset_medsci,
+/obj/item/storage/pill_bottle/mutadone,
+/obj/item/storage/pill_bottle/mannitol,
+/obj/machinery/requests_console{
+	department = "Genetics";
+	dir = 1;
+	name = "Genetics Requests Console";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "qvE" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Science EVA";
@@ -48710,7 +48248,7 @@
 /area/maintenance/central)
 "qyd" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/security/prison";
@@ -48866,13 +48404,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"qDP" = (
-/obj/structure/closet/bombcloset,
-/obj/machinery/light_switch{
-	pixel_x = -23
-	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
 "qDR" = (
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/bot_white,
@@ -48890,15 +48421,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"qEC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+"qET" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	dir = 8;
+	pixel_x = -26
 	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "qEU" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49078,6 +48607,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/head_of_personnel)
+"qOd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/locker)
 "qOu" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
@@ -49181,6 +48718,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qRt" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"qRK" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "qRW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -49761,6 +49320,36 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
+"rri" = (
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for the engineering security doors.";
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_x = -24;
+	pixel_y = -6;
+	req_access_txt = "10"
+	},
+/obj/item/radio/off,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "rrm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -49860,6 +49449,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"rti" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
+/area/science/research)
 "rtj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -50104,6 +49703,16 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"rBE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/wood,
+/area/library)
 "rBL" = (
 /obj/machinery/door/window/westleft{
 	name = "Delivery Desk";
@@ -50230,6 +49839,13 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"rKh" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "rKj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50346,6 +49962,21 @@
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rPE" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "AI";
+	departmentType = 5;
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "rPX" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -50397,6 +50028,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"rSx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rSI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -50417,6 +50062,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"rTp" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "rTN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -50449,6 +50101,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"rVu" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "rVF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -50733,6 +50393,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"sia" = (
+/obj/machinery/camera{
+	c_tag = "Bar";
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/requests_console{
+	department = "Bar";
+	departmentType = 2;
+	dir = 4;
+	pixel_x = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "sin" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -50811,19 +50493,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"skP" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "slQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -51047,6 +50716,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"svm" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/pen,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Mining";
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "svZ" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/tile/blue,
@@ -51274,6 +50957,16 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
+"sBB" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "sCZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -51419,6 +51112,34 @@
 	},
 /turf/open/floor/engine/airless,
 /area/escapepodbay)
+"sIY" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23;
+	pixel_y = -8
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "sJy" = (
 /obj/machinery/chem_dispenser,
 /obj/machinery/camera{
@@ -51829,6 +51550,21 @@
 "tav" = (
 /turf/closed/wall,
 /area/vacant_room/commissary)
+"taX" = (
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1485;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
+	pixel_y = -30
+	},
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "tbv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -51854,13 +51590,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"tcf" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "tcn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/atmos/glass{
@@ -51879,11 +51608,42 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
+"tdZ" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/five,
+/obj/item/circuitboard/machine/paystand,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/item/stack/cable_coil/random/five,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "tek" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"teA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/requests_console{
+	department = "Hydroponics";
+	departmentType = 2;
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "teE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -51928,6 +51688,43 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"tgm" = (
+/obj/machinery/button/flasher{
+	id = "foflash";
+	pixel_x = 6;
+	pixel_y = 36
+	},
+/obj/machinery/button/door{
+	id = "head_of_personnel";
+	name = "Privacy Shutters Control";
+	pixel_x = 6;
+	pixel_y = 25;
+	req_access_txt = "57"
+	},
+/obj/machinery/button/door{
+	id = "foqueue";
+	name = "Queue Shutters Control";
+	pixel_x = -4;
+	pixel_y = 25;
+	req_access_txt = "57"
+	},
+/obj/machinery/pdapainter,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 36
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/head_of_personnel)
 "tgz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51949,27 +51746,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"tgJ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "tgP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -52086,6 +51862,24 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/fore)
+"tiH" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "tiO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -52305,7 +52099,7 @@
 "tqp" = (
 /obj/structure/table,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -52478,6 +52272,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"tvY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "tvZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -52664,6 +52467,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"tCT" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "tDz" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Storage";
@@ -52921,6 +52733,19 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"tNu" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "tOl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -53164,6 +52989,25 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"tZY" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"uak" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Telecomms Admin";
+	departmentType = 5;
+	dir = 4;
+	name = "Telecomms RC";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/tcommsat/computer)
 "uaM" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/carrot,
@@ -53215,15 +53059,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"uea" = (
+"udD" = (
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/stack/cable_coil,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	dir = 4;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/science/robotics/lab)
 "uek" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+	pixel_y = -30
 	},
 /obj/structure/closet/crate,
 /obj/item/target/syndicate,
@@ -53912,6 +53768,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"uzX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uAo" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -53987,6 +53856,19 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"uEs" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/storage/tools)
 "uEM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/cable{
@@ -53999,15 +53881,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"uFt" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "uFJ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
@@ -54154,7 +54027,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -54520,17 +54393,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"uUb" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/sign/poster/contraband{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "uUE" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -54594,8 +54460,7 @@
 /area/maintenance/fore/secondary)
 "uWu" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -54811,6 +54676,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"vcF" = (
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/wood,
+/area/library)
 "vcJ" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 3";
@@ -54818,6 +54689,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"vdt" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "vdU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -54970,27 +54851,6 @@
 /obj/effect/turf_decal/atmos/air,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"viu" = (
-/obj/structure/table,
-/obj/effect/turf_decal/bot,
-/obj/item/storage/box/disks_nanite{
-	pixel_x = 10;
-	pixel_y = 5
-	},
-/obj/item/nanite_scanner{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/item/nanite_remote{
-	pixel_x = -10;
-	pixel_y = 10
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/white,
-/area/science/nanite)
 "vjm" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -55078,6 +54938,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"vnl" = (
+/obj/structure/table,
+/obj/item/beacon,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/teleporter)
 "vnu" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -55089,6 +54961,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"vnz" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "vnJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable{
@@ -55689,6 +55569,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"vKb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "vKx" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -56160,6 +56050,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"waV" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "waW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -56261,25 +56165,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"wcG" = (
-/obj/structure/table/glass,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "wcT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -56294,6 +56179,24 @@
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
+"wdq" = (
+/obj/machinery/camera{
+	c_tag = "Security Post - Medbay"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/medical)
 "wdH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
@@ -56345,6 +56248,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
+"wfy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
 "wfM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56610,6 +56529,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"wqZ" = (
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wrp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -56628,6 +56554,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wru" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "wrE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56899,6 +56834,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"wCb" = (
+/obj/structure/closet/secure_closet/courtroom,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
+	},
+/obj/item/gavelhammer,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "wCh" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -56906,6 +56854,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wCj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "wCq" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -56950,17 +56909,6 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
-"wDO" = (
-/obj/structure/chair/office/light,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "wDR" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/nanite_chamber,
@@ -57105,6 +57053,17 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
+"wIv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/emcloset,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "wIV" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -57123,6 +57082,16 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"wJo" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "wJL" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -57532,6 +57501,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"xbe" = (
+/obj/machinery/camera{
+	c_tag = "Security Post - Science";
+	dir = 4;
+	network = list("ss13","rd")
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "xbm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -57583,6 +57574,21 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"xcz" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
+/obj/machinery/requests_console{
+	department = "Robotics";
+	departmentType = 2;
+	dir = 1;
+	name = "Robotics RC";
+	pixel_y = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "xdh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -57646,6 +57652,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
+"xfz" = (
+/obj/structure/table,
+/obj/item/wirecutters,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "xfF" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
@@ -57826,6 +57845,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"xoc" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "xon" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57935,7 +57969,7 @@
 "xra" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -58284,19 +58318,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"xDS" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "xEu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -58332,35 +58353,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"xFG" = (
-/obj/item/screwdriver{
-	pixel_y = 10
+"xFp" = (
+/obj/machinery/computer/bounty{
+	dir = 4
 	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_x = -24;
-	pixel_y = -6;
-	req_access_txt = "10"
-	},
-/obj/item/radio/off,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light_switch{
-	pixel_x = -27;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	dir = 8;
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
+/area/quartermaster/qm)
 "xFP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
@@ -58454,6 +58467,34 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
+"xHP" = (
+/obj/machinery/power/apc{
+	areastring = "/area/storage/tools";
+	dir = 1;
+	name = "Auxiliary Tool Storage APC";
+	pixel_y = 24
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/rods/fifty,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/storage/tools)
 "xHS" = (
 /turf/template_noop,
 /area/template_noop)
@@ -58544,6 +58585,16 @@
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"xJu" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/item/extinguisher,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "xJM" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/nanite_programmer,
@@ -58562,21 +58613,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"xJX" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "xKf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -58612,6 +58648,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"xMd" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xMf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/navbeacon/wayfinding,
@@ -58668,7 +58711,7 @@
 /area/science/research)
 "xOg" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58793,6 +58836,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"xVk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "xVK" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58848,6 +58907,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"xYf" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "xYi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -71672,7 +71741,7 @@ azz
 azz
 azz
 azz
-aLv
+vKb
 aBH
 azz
 aym
@@ -71919,7 +71988,7 @@ amC
 bcT
 iZD
 kVF
-xJX
+wfy
 dhg
 xcu
 dhg
@@ -71940,7 +72009,7 @@ wEv
 aRM
 exs
 hvl
-baG
+muc
 ayl
 xKf
 bcD
@@ -72452,7 +72521,7 @@ naW
 czK
 aUO
 aUy
-aWm
+vdt
 aUO
 aUQ
 czK
@@ -73983,7 +74052,7 @@ azF
 azF
 azF
 azF
-aIQ
+bwX
 aKk
 aLC
 aNg
@@ -75011,7 +75080,7 @@ aDg
 aAQ
 vyA
 aHz
-aIS
+fLJ
 aKn
 aLE
 aLE
@@ -76048,7 +76117,7 @@ aPA
 aQO
 aSh
 aTw
-aUU
+kCT
 aWn
 aXQ
 hpS
@@ -76302,13 +76371,13 @@ aLE
 dLn
 aOl
 aPA
-uea
+nWG
 aQN
 aQN
 aUn
 aTy
 aWy
-aYe
+qOd
 aZw
 aZw
 bbq
@@ -76557,7 +76626,7 @@ rmD
 jbg
 kry
 vYy
-aOo
+wru
 aPA
 aQQ
 aQN
@@ -76806,7 +76875,7 @@ ayx
 atO
 lWY
 aBQ
-aDb
+xfz
 aDo
 aFY
 aDo
@@ -76816,7 +76885,7 @@ aLE
 dLn
 aOn
 aPA
-aQP
+vnz
 aQN
 aTx
 aUV
@@ -77834,7 +77903,7 @@ atJ
 atO
 eLZ
 aBQ
-aDm
+lhH
 aDo
 aDo
 aDo
@@ -78374,7 +78443,7 @@ cPi
 aZE
 aZE
 aZE
-bkn
+tNu
 gwb
 bjr
 bmb
@@ -78397,7 +78466,7 @@ aaa
 aaa
 aaa
 bCq
-uUb
+kDz
 bCq
 hWY
 bCq
@@ -79411,7 +79480,7 @@ bjr
 bjr
 bub
 bxu
-bvF
+xFp
 bzP
 bAS
 bxu
@@ -79900,7 +79969,7 @@ aLN
 dLn
 aOl
 aPF
-aQZ
+lxT
 aRa
 aTF
 aPG
@@ -79914,7 +79983,7 @@ bdS
 bdU
 ckQ
 gjl
-bjq
+eKG
 bjr
 bjr
 gwb
@@ -80948,8 +81017,8 @@ bmf
 vCK
 boN
 bqo
-brO
-btt
+hCR
+tCT
 buE
 bvZ
 bxu
@@ -81214,7 +81283,7 @@ kXG
 bBT
 bGm
 bCo
-bDk
+svm
 agv
 byE
 bAZ
@@ -81514,7 +81583,7 @@ cjJ
 cQP
 aop
 btG
-wDO
+dUJ
 eHM
 iDq
 gMh
@@ -81963,7 +82032,7 @@ tav
 xtO
 aYi
 nzH
-aqW
+mWU
 bbQ
 bLG
 tav
@@ -81984,7 +82053,7 @@ bGi
 cBB
 bAZ
 bGm
-bzF
+esc
 tzX
 bGm
 jcx
@@ -82206,15 +82275,15 @@ aBe
 aDj
 aER
 aFX
-nKn
+sBB
 wTj
 qXw
 pRi
 wIl
 cUk
 aPQ
-lqV
-aRV
+xHP
+uEs
 aSW
 tav
 ouv
@@ -82731,7 +82800,7 @@ izA
 aSc
 hSc
 tav
-coH
+tdZ
 avr
 avr
 bbT
@@ -83258,7 +83327,7 @@ bfR
 bKF
 bNH
 aZK
-bnJ
+qRK
 bty
 bbR
 bbR
@@ -83751,7 +83820,7 @@ aqR
 aqR
 aqR
 arP
-aLI
+fCU
 mry
 aki
 aRh
@@ -83982,7 +84051,7 @@ aai
 aai
 ajt
 mBJ
-akJ
+edC
 alr
 vfs
 amL
@@ -84504,8 +84573,8 @@ aiX
 anz
 aov
 aph
-air
-aqY
+lai
+nFD
 arU
 tiG
 hhs
@@ -84590,7 +84659,7 @@ ccw
 ccw
 ccw
 ccw
-gkv
+cHu
 wit
 cBO
 cgR
@@ -84779,7 +84848,7 @@ aEZ
 aEZ
 aEZ
 ayL
-uFt
+mWI
 edR
 aOE
 jOW
@@ -85104,7 +85173,7 @@ mHH
 mHH
 fyg
 ccw
-qqp
+uzX
 wit
 cps
 cpX
@@ -85288,7 +85357,7 @@ dtO
 emD
 hUN
 liB
-adl
+oBf
 idQ
 liB
 isT
@@ -85314,7 +85383,7 @@ aZP
 sRB
 ndT
 bmo
-bnP
+tgm
 adv
 bqA
 vNq
@@ -85322,7 +85391,7 @@ btB
 buM
 bwi
 bmr
-aMm
+xMd
 edR
 aJq
 bCs
@@ -85540,7 +85609,7 @@ dtc
 aph
 jTj
 axy
-qEC
+gum
 lRV
 azW
 lRV
@@ -85873,7 +85942,7 @@ hFo
 hFo
 cig
 cig
-fEu
+pgI
 oef
 qEt
 ryl
@@ -86075,7 +86144,7 @@ aVe
 erN
 aYq
 aZO
-aZC
+wCj
 baK
 bbC
 bbC
@@ -86864,9 +86933,9 @@ cRx
 dBB
 cRx
 cuj
-jOS
+ilQ
 edR
-byV
+aLI
 bCs
 bAM
 bFa
@@ -86889,14 +86958,14 @@ bOM
 bQd
 bQP
 bSt
-bUc
-bVb
+uak
+mQF
 xju
 cei
 bVJ
 mXb
 ccw
-oqk
+rSx
 sOf
 nVv
 uTS
@@ -87331,7 +87400,7 @@ any
 anz
 aov
 apd
-aqb
+cur
 jYO
 arZ
 kNm
@@ -87378,7 +87447,7 @@ jAg
 vHG
 cIG
 cuj
-nik
+cjn
 edR
 aJq
 bCs
@@ -87393,7 +87462,7 @@ bCs
 cjo
 bJu
 bSx
-cmX
+ahv
 bSz
 bNI
 bUD
@@ -87415,7 +87484,7 @@ iZM
 ecB
 cig
 cig
-ctT
+nPv
 cgR
 xHS
 xHS
@@ -87850,7 +87919,7 @@ anw
 anw
 anw
 iFB
-skP
+iFC
 sJN
 axC
 ayY
@@ -87905,7 +87974,7 @@ bHk
 bHR
 bIe
 bFd
-bJz
+mOn
 bRp
 cav
 bSA
@@ -88364,7 +88433,7 @@ anA
 asa
 atd
 anA
-avk
+wJo
 sRC
 axE
 ayZ
@@ -88388,7 +88457,7 @@ tGX
 kAQ
 clg
 cva
-gcq
+rPE
 fKJ
 cva
 cva
@@ -88412,7 +88481,7 @@ bBs
 jAA
 dqb
 bCp
-bDp
+tvY
 bFq
 cIm
 bHl
@@ -88428,7 +88497,7 @@ bQg
 bQg
 bQg
 bQg
-bYI
+rVu
 fFm
 bHP
 cbt
@@ -88696,7 +88765,7 @@ cfb
 cfF
 cfb
 cik
-cjg
+ldn
 cjU
 cfb
 clM
@@ -88943,7 +89012,7 @@ bVO
 bWO
 bXK
 pjA
-bZz
+mcU
 caw
 bYH
 sOA
@@ -89385,7 +89454,7 @@ alC
 vKx
 anw
 anz
-aoB
+rKh
 aod
 lzH
 arf
@@ -89438,7 +89507,7 @@ aJq
 edR
 aXf
 bCv
-bDK
+gjk
 bFi
 bGE
 bCv
@@ -89678,7 +89747,7 @@ hiF
 bdi
 bei
 bfy
-bgS
+qhf
 bik
 aZV
 aZV
@@ -89724,7 +89793,7 @@ nfl
 cbp
 ccj
 llY
-kBX
+sIY
 qsD
 gOP
 ude
@@ -89937,18 +90006,18 @@ bek
 bfB
 bgU
 bdk
-bjF
+mIb
 blc
 bmz
 bnY
 bpk
 bqJ
-bsj
+vnl
 qWE
 btd
 bwr
 bqH
-aMm
+xMd
 edR
 bBv
 hrE
@@ -89980,7 +90049,7 @@ bZu
 cfb
 cfb
 tjC
-dxx
+fcN
 cfb
 cfb
 cfb
@@ -90187,7 +90256,7 @@ aVr
 sDt
 aYq
 aZW
-xDS
+jMD
 bej
 bej
 bdj
@@ -90218,7 +90287,7 @@ bKy
 bLK
 bMK
 whB
-bOW
+hsh
 wNV
 txA
 bRx
@@ -90226,8 +90295,8 @@ sUV
 bUI
 wPl
 bWQ
-lXr
-xFG
+nbK
+rri
 cmp
 bTi
 caA
@@ -90483,7 +90552,7 @@ bMK
 kYO
 bVS
 bWQ
-bXP
+jwS
 cBI
 bRS
 bTH
@@ -90747,7 +90816,7 @@ bTG
 caA
 aam
 adt
-adx
+kou
 adM
 adX
 aeu
@@ -91258,7 +91327,7 @@ tVz
 cbA
 gno
 olz
-tcf
+hut
 mKO
 hyU
 rol
@@ -91432,7 +91501,7 @@ ahd
 nwW
 clS
 abp
-ajh
+wCb
 ajM
 akw
 alb
@@ -91457,7 +91526,7 @@ aAh
 aDO
 szs
 aFi
-aGl
+eeo
 aBy
 aBy
 aAh
@@ -91490,7 +91559,7 @@ kIb
 buZ
 buZ
 bqH
-byN
+wqZ
 wDk
 uus
 ljH
@@ -91501,7 +91570,7 @@ bHX
 qDG
 bKE
 bLP
-bMP
+amU
 bIG
 bJB
 qra
@@ -91994,7 +92063,7 @@ aYG
 aYG
 aYG
 aYG
-ble
+iVQ
 bmE
 bmE
 bpn
@@ -92505,7 +92574,7 @@ bcp
 edR
 beq
 aJq
-bgY
+gim
 aJq
 aJq
 iTJ
@@ -93020,7 +93089,7 @@ wzp
 ddj
 bfF
 nQI
-bio
+jNM
 bgF
 blf
 bmF
@@ -93286,7 +93355,7 @@ nju
 jbE
 qmI
 bLX
-btf
+ltk
 bui
 bvi
 bww
@@ -93510,13 +93579,13 @@ oAg
 oda
 aZN
 arj
-aCq
+its
 aDR
 aFl
 aGD
 aHZ
 aCr
-aKJ
+oMa
 aMr
 aMr
 aOH
@@ -93533,7 +93602,7 @@ aYV
 hfE
 aYV
 bfF
-bhc
+fmp
 owD
 bgP
 jVL
@@ -93788,7 +93857,7 @@ bab
 aJC
 aYV
 hfE
-ber
+bcv
 bfF
 bhb
 owD
@@ -94279,7 +94348,7 @@ avz
 avz
 axU
 azm
-tgJ
+gYM
 arj
 aCr
 gzU
@@ -94565,7 +94634,7 @@ bhf
 bhh
 bhh
 bhh
-bmJ
+taX
 bof
 bpu
 bqP
@@ -95315,7 +95384,7 @@ alP
 ezD
 aIc
 aJC
-aKO
+xoc
 aMw
 aNI
 aMw
@@ -95598,7 +95667,7 @@ boi
 bpw
 bhh
 eMR
-btX
+phx
 bvj
 bwG
 uLj
@@ -96347,10 +96416,10 @@ aKz
 mjr
 aND
 aJC
-aab
+tiH
 aRg
 aQc
-aac
+sia
 aQc
 aXk
 aQc
@@ -96374,7 +96443,7 @@ bvh
 bwH
 bxS
 bzh
-bAs
+awQ
 bvj
 bCL
 bxO
@@ -96613,7 +96682,7 @@ aJI
 oWN
 aJI
 aJI
-bcs
+mYQ
 hfE
 aYV
 bfK
@@ -96874,7 +96943,7 @@ aYV
 hfE
 aYV
 bfK
-bhj
+wdq
 biw
 bhs
 xcb
@@ -97158,8 +97227,8 @@ bof
 bNd
 bIJ
 bPo
-bQE
-bRM
+waV
+dNK
 bOr
 bTZ
 mRC
@@ -97658,7 +97727,7 @@ bst
 nAh
 bhh
 bhh
-bwK
+cdz
 bhh
 bhh
 bhh
@@ -97673,7 +97742,7 @@ bNd
 bOn
 bOr
 bOr
-bRO
+rTp
 bSQ
 bTZ
 xdn
@@ -98174,7 +98243,7 @@ bwL
 bxX
 fxa
 bua
-bBJ
+gvU
 bhh
 bBn
 bof
@@ -98188,7 +98257,7 @@ bNd
 bNd
 bNd
 bNd
-bSU
+bfJ
 bUb
 bVa
 bWf
@@ -98445,7 +98514,7 @@ bIK
 bPq
 bLd
 bNd
-bST
+qnO
 bOr
 bOr
 bOr
@@ -98459,7 +98528,7 @@ cbM
 cdJ
 hTU
 hof
-cgc
+gTt
 qBr
 ciF
 cjw
@@ -98665,7 +98734,7 @@ aRH
 aVz
 aVz
 aVH
-aXn
+fRC
 aYN
 aJI
 bbz
@@ -99181,7 +99250,7 @@ aUi
 aVJ
 aOX
 aYP
-bal
+qRt
 bam
 aYV
 hfE
@@ -99193,7 +99262,7 @@ bkb
 bhm
 snw
 qsH
-bpH
+qvp
 fbD
 uvN
 tiO
@@ -99430,7 +99499,7 @@ vCF
 aKD
 aMs
 aNL
-aOQ
+teA
 aQf
 aRE
 aSQ
@@ -99716,7 +99785,7 @@ kcE
 bvw
 gWr
 ljx
-bBP
+aEA
 bCZ
 bEk
 bFG
@@ -100233,7 +100302,7 @@ ljx
 bBQ
 bDa
 bEl
-bFH
+kLI
 bHb
 bIw
 bBN
@@ -100484,7 +100553,7 @@ bpK
 bpK
 bvu
 eTY
-bvy
+hac
 ljx
 ljx
 bBN
@@ -100516,7 +100585,7 @@ cdN
 hTU
 bip
 mSR
-haX
+cow
 ciH
 xYA
 hpH
@@ -102267,7 +102336,7 @@ mpK
 tGd
 aFu
 aFu
-bcv
+tZY
 aXq
 bfU
 neg
@@ -102543,7 +102612,7 @@ yit
 ogS
 kjl
 bAA
-bBU
+lLg
 bDb
 bEm
 bEm
@@ -103046,7 +103115,7 @@ xOQ
 gzB
 kOI
 irh
-lCW
+iHQ
 bos
 bpR
 bqc
@@ -103281,7 +103350,7 @@ pUl
 aFu
 aHd
 aIx
-aJF
+rBE
 aLh
 aIt
 aNV
@@ -103299,7 +103368,7 @@ aYV
 aXq
 bds
 bfV
-bhx
+xcz
 biL
 bkm
 cHO
@@ -103570,7 +103639,7 @@ btP
 xTe
 byi
 bzz
-bAE
+xbe
 bBY
 bDc
 bEo
@@ -103826,7 +103895,7 @@ box
 btS
 xTe
 byi
-bwN
+bvW
 vhN
 bCa
 bDc
@@ -104573,12 +104642,12 @@ aFw
 aPh
 aQs
 aFu
-aTd
+gPQ
 aUE
 aVT
 aYW
 aYW
-aZd
+vcF
 aFu
 aYV
 aXq
@@ -104588,7 +104657,7 @@ rWU
 biP
 bko
 blE
-bnj
+udD
 bov
 bpU
 brq
@@ -104607,7 +104676,7 @@ oju
 bGY
 bGY
 bJN
-bMp
+xJu
 bNp
 bOx
 bPI
@@ -104837,7 +104906,7 @@ iDt
 reu
 aCR
 aCR
-bcs
+mYQ
 aXq
 aYV
 bfX
@@ -105086,7 +105155,7 @@ aMX
 aFw
 aFz
 aFz
-aRR
+qET
 aTe
 aUG
 aFz
@@ -105119,13 +105188,13 @@ nCH
 bDl
 emP
 bFQ
-dLA
+lZt
 vpE
 bIb
 bID
 btW
 bPK
-qDP
+osD
 xqn
 ruQ
 lVe
@@ -105138,7 +105207,7 @@ dYq
 inM
 wDR
 oVW
-viu
+bvv
 xJM
 qdJ
 lFS
@@ -105618,7 +105687,7 @@ bkr
 blH
 bnm
 jdD
-pbp
+rti
 doL
 qZf
 jrF
@@ -106400,7 +106469,7 @@ daR
 tsY
 thZ
 bvK
-jwT
+hZW
 shI
 jBj
 bFT
@@ -107415,7 +107484,7 @@ fvY
 cbc
 vSb
 kyi
-wcG
+lht
 lEi
 cPs
 boB
@@ -107446,7 +107515,7 @@ gSU
 qIb
 jrd
 mJc
-hDH
+xYf
 eGI
 cOe
 cou
@@ -107663,7 +107732,7 @@ aVW
 aXD
 aZj
 nQy
-bbG
+mJM
 aPq
 bdy
 beH
@@ -107906,7 +107975,7 @@ aaf
 aaa
 aHq
 afE
-aZm
+aGI
 jhv
 giS
 inr
@@ -108190,7 +108259,7 @@ oNw
 nPH
 bgc
 bgc
-dAM
+xVk
 kBb
 gHj
 bpE
@@ -108419,7 +108488,7 @@ atS
 aaf
 aaa
 aHq
-aQF
+hvL
 cBl
 cBl
 fjH
@@ -108679,7 +108748,7 @@ aHq
 aRL
 mvb
 mvb
-hcb
+wIv
 aOd
 aOc
 aPs

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -255,7 +255,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/head/welding,
@@ -480,6 +480,17 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
+"acw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -31;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "acF" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -636,17 +647,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"ado" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room/council)
 "adr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -792,24 +792,6 @@
 "aeB" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
-/area/construction/mining/aux_base)
-"aeC" = (
-/obj/machinery/requests_console{
-	department = "Construction";
-	name = "Construction RC";
-	pixel_y = 32
-	},
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aeE" = (
 /obj/structure/table/reinforced,
@@ -1053,7 +1035,7 @@
 	req_access_txt = "32;47;48"
 	},
 /obj/machinery/light_switch{
-	pixel_x = -38
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
@@ -1339,28 +1321,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"ahD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "ahF" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -1382,6 +1342,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"ahI" = (
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen,
+/obj/item/radio,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/teleporter)
 "ahO" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -1549,24 +1523,6 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/starboard/fore)
-"aiq" = (
-/obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1984,23 +1940,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
-"ajy" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "ajz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -2350,7 +2289,7 @@
 /area/hallway/secondary/entry)
 "akk" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -2389,7 +2328,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/effect/turf_decal/delivery,
@@ -2661,8 +2600,7 @@
 /area/maintenance/starboard/fore)
 "ala" = (
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2741,7 +2679,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/grimy,
 /area/vacant_room/office)
@@ -2752,39 +2690,9 @@
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/grimy,
 /area/vacant_room/office)
-"alm" = (
-/obj/structure/table/wood,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/grimy,
-/area/vacant_room/office)
 "aln" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
-/turf/open/floor/plasteel/grimy,
-/area/vacant_room/office)
-"alo" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/vacant_room/office)
-"alp" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/vacant_room/office)
-"alq" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/grimy,
 /area/vacant_room/office)
 "alr" = (
@@ -2826,24 +2734,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"alw" = (
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
 "alx" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
@@ -2852,22 +2742,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
-"alz" = (
-/obj/structure/filingcabinet/security,
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint)
 "alB" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
@@ -3078,8 +2952,7 @@
 /area/vacant_room/office)
 "aml" = (
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3136,8 +3009,7 @@
 /area/hallway/secondary/entry)
 "amv" = (
 /obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3405,12 +3277,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"amZ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/grimy,
-/area/vacant_room/office)
 "ana" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -4603,7 +4469,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/grimy,
 /area/vacant_room/office)
@@ -4611,15 +4477,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light/small,
 /obj/structure/sign/poster/official/work_for_a_future{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/grimy,
-/area/vacant_room/office)
-"aqd" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/newscaster{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -4683,7 +4540,7 @@
 "aql" = (
 /obj/structure/filingcabinet/medical,
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -4714,7 +4571,7 @@
 "aqo" = (
 /obj/machinery/light,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -4737,7 +4594,7 @@
 "aqr" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4920,7 +4777,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
@@ -4931,7 +4788,7 @@
 /area/crew_quarters/electronic_marketing_den)
 "aqO" = (
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/light/small,
 /obj/effect/turf_decal/tile/neutral{
@@ -4980,7 +4837,7 @@
 "aqU" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/item/folder/red,
 /obj/item/lighter,
@@ -6113,7 +5970,7 @@
 /area/engine/atmospherics_engine)
 "auZ" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -6332,31 +6189,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"avC" = (
-/obj/structure/closet/l3closet/janitor,
-/obj/machinery/requests_console{
-	department = "Custodial Closet";
-	name = "Custodial RC";
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Custodial Closet";
-	name = "service camera"
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "avD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/status_display/evac{
@@ -6376,45 +6208,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"avE" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/stack/packageWrap,
-/obj/item/crowbar,
-/obj/item/hand_labeler,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "avF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"avG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/toilet/auxiliary)
 "avH" = (
 /obj/structure/urinal{
 	pixel_y = 28
@@ -7317,7 +7116,7 @@
 "ayb" = (
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/auxiliary)
@@ -7738,29 +7537,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"azf" = (
-/obj/machinery/disposal/bin,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "azh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8091,7 +7867,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -8102,7 +7878,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/machinery/light/small,
 /obj/effect/turf_decal/bot,
@@ -8114,7 +7890,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/machinery/light/small,
 /obj/effect/landmark/start/assistant,
@@ -8134,13 +7910,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aAt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
-/turf/open/floor/plating,
-/area/quartermaster/warehouse)
 "aAu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -8415,7 +8184,7 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_y = -27
+	pixel_x = 27
 	},
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/yellow{
@@ -8838,14 +8607,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"aCo" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/atmospherics_engine)
 "aCp" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -9211,16 +8972,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aDN" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aDO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset,
@@ -9415,15 +9166,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden/abandoned)
-"aEH" = (
-/obj/structure/table/wood,
-/obj/item/folder,
-/obj/item/pen,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/grimy,
-/area/hallway/secondary/service)
 "aEI" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -9500,19 +9242,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"aES" = (
-/obj/structure/table/wood,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/item/storage/box/beanbag,
-/obj/item/gun/ballistic/shotgun/doublebarrel,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "aET" = (
 /obj/structure/sign/poster/random,
 /turf/closed/wall,
@@ -9544,32 +9273,6 @@
 /obj/machinery/vending/boozeomat,
 /obj/machinery/status_display/evac{
 	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"aEX" = (
-/obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Bar Counter";
-	name = "Bar RC";
-	pixel_y = 32;
-	receive_ore_updates = 1
-	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/reagent_containers/glass/rag,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -9664,22 +9367,6 @@
 "aFr" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"aFt" = (
-/obj/structure/table/reinforced,
-/obj/item/tank/internals/plasma,
-/obj/machinery/light/small,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmospherics_engine)
 "aFw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -9949,8 +9636,7 @@
 "aGc" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24;
-	pixel_y = 32
+	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10039,25 +9725,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"aGl" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "aGm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
@@ -10101,22 +9768,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aGs" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aGt" = (
@@ -10167,30 +9818,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
-"aGw" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 38
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -10514,7 +10141,7 @@
 /area/crew_quarters/bar)
 "aHE" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -10715,20 +10342,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
-"aIy" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = 24
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aIA" = (
@@ -11093,6 +10706,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"aJQ" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "aJV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/atmospherics,
@@ -11200,14 +10821,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
-"aKm" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "aKn" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -11272,23 +10885,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"aKy" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar/atrium)
 "aKz" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/tile/red{
@@ -11572,26 +11168,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
-"aLp" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmospherics_engine)
-"aLq" = (
-/obj/structure/closet/radiation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/atmospherics_engine)
 "aLr" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -11624,7 +11200,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -11681,25 +11257,6 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"aLK" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar/atrium)
 "aLL" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -12419,6 +11976,19 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"aNR" = (
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "aNX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -12471,7 +12041,7 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -12570,26 +12140,6 @@
 	icon_state = "wood-broken2"
 	},
 /area/crew_quarters/abandoned_gambling_den/secondary)
-"aOv" = (
-/obj/structure/dresser,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
 "aOw" = (
 /obj/structure/table/wood,
 /obj/item/instrument/eguitar,
@@ -12616,33 +12166,6 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/crate/wooden/toy,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
-"aOz" = (
-/obj/structure/table/wood,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/item/flashlight/lamp/bananalamp{
-	pixel_y = 5
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/obj/item/toy/figure/clown,
-/obj/item/clipboard,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -13026,7 +12549,7 @@
 "aPC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -13313,25 +12836,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"aQl" = (
-/obj/structure/table/wood,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/item/camera,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar/atrium)
 "aQm" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/grimy,
@@ -13497,14 +13001,13 @@
 /obj/item/storage/box/lights/mixed,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -13683,7 +13186,7 @@
 /area/security/prison)
 "aRc" = (
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -14102,31 +13605,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"aSy" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 32
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "aSA" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -14341,6 +13819,20 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den/secondary)
+"aTr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = -22
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = -36
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
 "aTu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -14367,30 +13859,6 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/theatre)
-"aTy" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Theatre Backstage";
-	dir = 8;
-	name = "service camera"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aTz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14551,25 +14019,6 @@
 "aTO" = (
 /turf/closed/wall,
 /area/quartermaster/office)
-"aTP" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "aTQ" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
@@ -14602,26 +14051,6 @@
 /obj/machinery/photocopier,
 /obj/machinery/status_display/ai{
 	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aTU" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/machinery/requests_console{
-	department = "Cargo Office";
-	name = "Cargo Office RC";
-	pixel_y = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo - Office";
-	name = "cargo camera"
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -15240,27 +14669,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den/secondary)
-"aVh" = (
-/obj/structure/table/wood,
-/obj/machinery/requests_console{
-	department = "Theatre Backstage";
-	name = "Theatre RC";
-	pixel_x = -32
-	},
-/obj/item/lipstick/random{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/lipstick/random{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/lipstick/random,
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/theatre)
 "aVi" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/baguette,
@@ -15492,6 +14900,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"aVJ" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "aVN" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 8
@@ -15505,6 +14934,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"aVQ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "aWa" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
@@ -15658,8 +15102,7 @@
 "aWl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light_switch{
-	pixel_x = -7;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/item/flashlight/lamp,
 /obj/item/radio/intercom{
@@ -15674,24 +15117,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
-"aWn" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "aWo" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 5
@@ -15835,26 +15263,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"aWV" = (
-/obj/structure/table/wood,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = -32
-	},
-/obj/item/staff/broom,
-/obj/item/clothing/head/witchwig,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar/atrium)
 "aWW" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/fakemoustache,
@@ -15897,7 +15305,7 @@
 	name = "Theatre Stage"
 	},
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/atrium)
@@ -16275,28 +15683,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"aXD" = (
-/obj/machinery/requests_console{
-	department = "Quartermaster's Desk";
-	name = "Quartermaster RC";
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 23
-	},
-/obj/machinery/computer/bounty{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "aXE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -16337,6 +15723,36 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/security/prison)
+"aXT" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/white,
+/obj/item/storage/pill_bottle/mutadone,
+/obj/item/storage/pill_bottle/mannitol,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay - Genetics Lab";
+	dir = 4;
+	name = "medbay camera";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "aXU" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/security/prison)
@@ -16355,26 +15771,6 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/engine/atmos)
-"aYh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/disposal/bin,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
 /area/engine/atmos)
 "aYi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16417,26 +15813,6 @@
 	c_tag = "Bar - Aft";
 	dir = 4;
 	name = "service camera"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar/atrium)
-"aYF" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -16585,32 +15961,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"aYR" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
-	},
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "aYS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -16664,7 +16014,7 @@
 /obj/machinery/disposal/bin,
 /obj/machinery/light,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -16690,22 +16040,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/qm)
-"aZb" = (
-/obj/machinery/photocopier,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "aZc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -16720,7 +16054,7 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -16749,20 +16083,6 @@
 /area/quartermaster/qm)
 "aZf" = (
 /obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"aZh" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -16810,14 +16130,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"aZl" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aZm" = (
 /obj/machinery/camera{
 	c_tag = "Security - Prison Port"
@@ -17106,23 +16418,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"baD" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar/atrium)
 "baE" = (
 /obj/structure/chair/stool/bar,
 /obj/structure/disposalpipe/segment{
@@ -17157,19 +16452,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
-"baG" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "baH" = (
 /obj/machinery/autolathe,
 /obj/machinery/airalarm{
@@ -17178,13 +16460,13 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -33
+	pixel_x = -26
 	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -17264,7 +16546,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/item/radio/intercom{
 	dir = 8;
@@ -17535,7 +16817,7 @@
 "bbU" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
@@ -17569,34 +16851,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"bbZ" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/chem_master/condimaster{
-	name = "BrewMaster 3000"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"bcd" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
 "bce" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -17615,7 +16869,7 @@
 "bch" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
@@ -17696,24 +16950,6 @@
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
-"bcy" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clipboard,
-/obj/item/toy/figure/miner,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/light_switch{
-	pixel_x = -38
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
@@ -17820,7 +17056,7 @@
 	},
 /obj/item/storage/box/prisoner,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -18548,14 +17784,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"bfd" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
 "bfe" = (
 /obj/machinery/deepfryer,
 /obj/effect/turf_decal/tile/red{
@@ -19218,24 +18446,6 @@
 	dir = 1
 	},
 /area/engine/atmos)
-"bhn" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics - Aft";
-	name = "atmospherics camera"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/engine/atmos)
 "bho" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19324,16 +18534,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"bhB" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "bhC" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom{
@@ -19356,23 +18556,6 @@
 	pixel_y = 5
 	},
 /obj/structure/table/glass,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"bhE" = (
-/obj/structure/table/glass,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/item/clipboard,
-/obj/item/toy/figure/botanist,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"bhF" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -19410,43 +18593,8 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
-"bhL" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 32
-	},
-/obj/machinery/light_switch{
-	pixel_x = -7;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
 "bhM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
-"bhN" = (
-/obj/machinery/requests_console{
-	department = "Kitchen";
-	name = "Kitchen RC";
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -19673,6 +18821,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"bir" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
 "biy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -19765,19 +18925,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"biG" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "biI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20371,30 +19518,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"bkD" = (
-/obj/machinery/photocopier,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	name = "Head of Security RC";
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "bkE" = (
 /obj/structure/window/reinforced,
 /turf/open/space,
@@ -20603,7 +19726,7 @@
 "blt" = (
 /obj/machinery/icecream_vat,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20827,7 +19950,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -20858,7 +19981,7 @@
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/item/shovel,
 /obj/item/shovel,
@@ -20900,7 +20023,7 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -21077,7 +20200,7 @@
 	req_access_txt = "58"
 	},
 /obj/machinery/light_switch{
-	pixel_x = 38
+	pixel_y = -23
 	},
 /obj/machinery/keycard_auth{
 	pixel_x = 26;
@@ -21097,13 +20220,6 @@
 /area/crew_quarters/heads/hos)
 "bmz" = (
 /turf/closed/wall,
-/area/crew_quarters/heads/hos)
-"bmA" = (
-/obj/structure/dresser,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "bmB" = (
 /obj/structure/bed,
@@ -21243,7 +20359,7 @@
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -21355,8 +20471,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 8
+	pixel_y = -23
 	},
 /obj/machinery/plantgenes{
 	pixel_y = 6
@@ -21893,18 +21008,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"boS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "boT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -22375,14 +21478,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"bqy" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "bqz" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
@@ -22641,16 +21736,6 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
-"brG" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "brH" = (
 /obj/machinery/button/door{
@@ -22913,17 +21998,6 @@
 	},
 /turf/closed/wall,
 /area/storage/tech)
-"bsw" = (
-/obj/machinery/hydroponics/constructable,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "bsx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -22963,21 +22037,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bsC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
@@ -23029,23 +22088,6 @@
 	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bsI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -23161,21 +22203,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bsS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -23311,30 +22338,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
-/area/crew_quarters/heads/hos)
-"btB" = (
-/obj/structure/table/wood,
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Head of Security"
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "btC" = (
 /obj/structure/closet/secure_closet/hos,
@@ -23595,17 +22598,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"buM" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "buN" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -23799,7 +22791,7 @@
 	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
@@ -23815,7 +22807,7 @@
 	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Pumps";
@@ -23837,22 +22829,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/engine/atmos)
-"bvh" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/engine/atmos)
 "bvi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -23868,8 +22844,7 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/light/small,
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23953,7 +22928,6 @@
 	department = "Hydroponics";
 	departmentType = 2;
 	name = "Hydroponics RC";
-	pixel_x = 32;
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -24080,24 +23054,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
-"bwc" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/execution/transfer)
 "bwd" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -24112,17 +23068,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"bwe" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "bwf" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
@@ -24187,6 +23132,28 @@
 /obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
+"bwq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "bwr" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
 	dir = 1
@@ -24279,27 +23246,6 @@
 /obj/structure/sign/warning/securearea,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
-"bwB" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -38;
-	pixel_y = -8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bwC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -24470,21 +23416,6 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"bxp" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Security - Brig Fore";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -24695,65 +23626,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"bxM" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bxN" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/firealarm{
-	pixel_x = -32;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bxP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"bxQ" = (
-/obj/structure/table/reinforced,
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/obj/item/analyzer{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/engine/atmos)
 "bxR" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
@@ -24804,16 +23682,6 @@
 "bxY" = (
 /turf/closed/wall/r_wall,
 /area/storage/tech)
-"byd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bye" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -24949,35 +23817,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
-"byI" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/execution/transfer)
-"byJ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "byK" = (
 /obj/machinery/light{
 	dir = 4
@@ -25187,43 +24026,8 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
-"bzn" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/donkpockets,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bzo" = (
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bzp" = (
-/obj/machinery/vending/cola/random,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bzq" = (
@@ -25287,7 +24091,9 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/primary/port)
 "bzD" = (
-/obj/structure/extinguisher_cabinet,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "bzL" = (
@@ -26301,7 +25107,7 @@
 	pixel_y = -26
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red,
@@ -26624,16 +25430,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"bCQ" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bCR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -26698,20 +25494,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"bCW" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmospherics_engine)
 "bCX" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -26753,7 +25535,7 @@
 	},
 /obj/machinery/light,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -26783,11 +25565,10 @@
 /obj/machinery/requests_console{
 	department = "Atmospherics Office";
 	name = "Atmospherics RC";
-	pixel_x = 30
+	pixel_y = -32
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -26912,17 +25693,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"bDo" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/requests_console{
-	department = "Primary Tool Storage";
-	name = "Primary Tool Storage RC";
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "bDr" = (
 /obj/item/clothing/suit/hazardvest{
 	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
@@ -27006,17 +25776,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"bDs" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/belt/utility,
-/obj/item/weldingtool,
-/obj/item/clothing/head/welding,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "bDt" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/igniter,
@@ -27091,29 +25850,6 @@
 "bDV" = (
 /turf/closed/wall,
 /area/security/execution/transfer)
-"bDW" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/button/door{
-	desc = "A remote control switch.";
-	id = "gulagdoor";
-	name = "Transfer Door Control";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/execution/transfer)
 "bEc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -27168,43 +25904,12 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"bEi" = (
-/obj/machinery/turretid{
-	icon_state = "control_stun";
-	name = "AI Chamber turret control";
-	pixel_x = 3;
-	pixel_y = -23
-	},
-/obj/machinery/door/window{
-	base_state = "leftsecure";
-	dir = 8;
-	icon_state = "leftsecure";
-	name = "Primary AI Core Access";
-	req_access_txt = "16"
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 4;
-	pixel_y = 33
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
 "bEj" = (
 /obj/machinery/requests_console{
 	department = "AI";
 	departmentType = 5;
 	name = "AI RC";
-	pixel_x = 30;
-	pixel_y = 30
+	pixel_y = -32
 	},
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -27300,6 +26005,22 @@
 "bEo" = (
 /turf/open/floor/circuit/green,
 /area/engine/gravity_generator)
+"bEx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bEN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
@@ -27523,6 +26244,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"bFn" = (
+/obj/machinery/computer/crew,
+/obj/machinery/requests_console{
+	department = "Security";
+	name = "Security RC";
+	pixel_x = -31;
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/warden)
 "bFo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27963,7 +26706,7 @@
 /area/engine/storage_shared)
 "bGh" = (
 /obj/machinery/light_switch{
-	pixel_x = -22
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -28109,30 +26852,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bGt" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -28354,8 +27073,7 @@
 /area/bridge)
 "bGT" = (
 /obj/machinery/light_switch{
-	pixel_x = -7;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -28372,7 +27090,7 @@
 /area/bridge)
 "bGV" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -28530,28 +27248,6 @@
 /area/bridge)
 "bHm" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"bHn" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"bHo" = (
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -28730,20 +27426,6 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"bHS" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/plasteel/twenty,
-/obj/item/wrench,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "bHV" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/chief)
@@ -28884,19 +27566,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
-"bIx" = (
-/obj/machinery/vending/assist,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/camera{
-	c_tag = "Primary Tool Storage";
-	dir = 4;
-	name = "engineering camera"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "bIz" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/packageWrap,
@@ -28951,15 +27620,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bIG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bIH" = (
@@ -29035,7 +27695,6 @@
 	department = "Bridge";
 	departmentType = 5;
 	name = "Bridge RC";
-	pixel_x = -32;
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -29127,25 +27786,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"bJg" = (
-/obj/structure/table/wood,
-/obj/item/clipboard,
-/obj/item/toy/figure/detective,
-/obj/structure/sign/poster/official/report_crimes{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/detectives_office)
 "bJm" = (
 /obj/machinery/photocopier,
 /obj/machinery/status_display/ai{
@@ -29235,15 +27875,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"bJy" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bJz" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -29419,26 +28050,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"bJR" = (
-/obj/machinery/disposal/bin,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "bJS" = (
 /obj/machinery/cell_charger,
 /obj/structure/table/reinforced,
@@ -29462,29 +28073,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"bJT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Engineer"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "bJU" = (
 /obj/structure/rack,
 /obj/item/crowbar,
@@ -29494,36 +28082,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
-"bJV" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/button/door{
-	id = "ceblast";
-	name = "Lockdown Control";
-	pixel_x = 26;
-	pixel_y = 26;
-	req_access_txt = "56"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29774,17 +28332,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bKy" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/wood,
-/area/bridge/meeting_room/council)
 "bKz" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/wood,
@@ -29798,7 +28345,7 @@
 /area/bridge/meeting_room/council)
 "bKB" = (
 /obj/machinery/firealarm{
-	pixel_y = 26
+	pixel_y = -26
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room/council)
@@ -29837,12 +28384,6 @@
 "bKO" = (
 /obj/machinery/light{
 	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
-"bKP" = (
-/obj/machinery/firealarm{
-	pixel_y = 26
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -29896,17 +28437,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"bKU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bKV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -30195,31 +28725,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/engine/transit_tube)
-"bLK" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/button/door{
-	id = "transitlock";
-	name = "Transit Tube Lockdown Control";
-	pixel_y = 26;
-	req_access_txt = "19"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
 "bLL" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -30270,16 +28775,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"bLZ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bMa" = (
 /turf/closed/wall,
 /area/security/checkpoint/engineering)
@@ -30622,29 +29117,6 @@
 "bMW" = (
 /turf/closed/wall,
 /area/security/detectives_office)
-"bMX" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
-/obj/machinery/camera{
-	c_tag = "Detective's Office";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/detectives_office)
 "bMY" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
@@ -30687,20 +29159,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
-"bNd" = (
-/obj/machinery/computer/med_data{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Detective's Office";
-	name = "Detective RC";
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bNe" = (
@@ -30963,26 +29421,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"bNw" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
 "bNx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -31175,7 +29613,7 @@
 "bNZ" = (
 /obj/machinery/light,
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -31243,6 +29681,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"bOh" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/start/head_of_personnel,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/head_of_personnel)
 "bOj" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
@@ -31256,7 +29711,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -31532,7 +29987,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -31542,7 +29997,7 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/multitool,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/machinery/light{
 	dir = 8
@@ -31841,34 +30296,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
-"bPQ" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 5;
-	name = "Chief Engineer's RC";
-	pixel_x = -32
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Chief Engineer's Office";
-	dir = 4;
-	name = "engineering camera"
-	},
-/obj/machinery/computer/apc_control{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "bPR" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -31928,17 +30355,6 @@
 "bQg" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/engineering)
-"bQh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "bQj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -31974,20 +30390,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/tech)
-"bQm" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/storage/tech)
 "bQn" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -31998,7 +30404,7 @@
 /obj/item/crowbar,
 /obj/item/paicard,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -32061,10 +30467,10 @@
 /obj/item/radio,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/machinery/light_switch{
-	pixel_x = 26
+	pixel_y = -23
 	},
 /obj/machinery/light{
 	dir = 4
@@ -32120,14 +30526,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/bridge/meeting_room/council)
-"bQE" = (
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/bridge/meeting_room/council)
 "bQF" = (
 /turf/open/floor/wood,
 /area/bridge/meeting_room/council)
@@ -32145,26 +30543,6 @@
 /obj/structure/closet/secure_closet/lieutenant,
 /turf/open/floor/plasteel/dark,
 /area/bridge/meeting_room/council)
-"bQH" = (
-/obj/machinery/computer/message_monitor{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/item/paper/monitorkey,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "bQI" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -32186,25 +30564,6 @@
 /obj/structure/chair/office,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"bQO" = (
-/obj/machinery/computer/telecomms/server{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "bQP" = (
 /obj/structure/bed/dogbed/renault,
 /obj/effect/turf_decal/tile/neutral{
@@ -32219,19 +30578,6 @@
 	},
 /mob/living/simple_animal/pet/fox/Renault,
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
-"bQQ" = (
-/obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bQR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -32287,7 +30633,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/light_switch{
-	pixel_x = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -32362,7 +30708,7 @@
 "bRf" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -26
+	pixel_y = 26
 	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -32407,8 +30753,7 @@
 	req_access_txt = "4"
 	},
 /obj/machinery/light_switch{
-	pixel_x = 38;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/flashlight/lamp,
@@ -32784,23 +31129,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
-"bSd" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "bSe" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -32833,8 +31161,7 @@
 	req_access_txt = "56"
 	},
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Chief Engineer's Quarters";
@@ -32845,20 +31172,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
-"bSi" = (
-/obj/structure/closet/radiation,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bSk" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/light/small{
@@ -33003,7 +31316,7 @@
 /obj/structure/table/wood,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -26
+	pixel_y = 26
 	},
 /obj/item/phone{
 	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
@@ -33108,18 +31421,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/storage/tools)
-"bTa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bTb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/bed,
@@ -33178,42 +31479,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
-"bTi" = (
-/obj/structure/rack,
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "bTj" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser{
@@ -33303,7 +31568,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -33829,24 +32094,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/tcommsat/server)
-"bUL" = (
-/obj/machinery/computer/card{
-	dir = 4
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Captain's Desk";
-	departmentType = 5;
-	name = "Captain RC";
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "bUN" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
@@ -33915,21 +32162,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"bUW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34080,20 +32312,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"bVl" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/warden)
 "bVp" = (
 /obj/vehicle/ridden/secway,
 /obj/effect/turf_decal/tile/neutral{
@@ -34409,8 +32627,7 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = -24;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -34669,59 +32886,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"bWQ" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Personnel's Desk";
-	departmentType = 5;
-	name = "Head of Personnel RC";
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/obj/machinery/light_switch{
-	pixel_x = -38;
-	pixel_y = 7
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/obj/machinery/button/door{
-	id = "foline";
-	name = "Queue Shutters Control";
-	pixel_x = -26;
-	pixel_y = -7;
-	req_access_txt = "57"
-	},
-/obj/machinery/button/door{
-	id = "foblast";
-	name = "Lockdown Blast doors";
-	pixel_x = -26;
-	pixel_y = 7;
-	req_access_txt = "57"
-	},
-/obj/machinery/button/flasher{
-	id = "foflash";
-	pixel_x = -38;
-	pixel_y = -7;
-	req_access_txt = "28"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/button/ticket_machine{
-	pixel_y = 40
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/head_of_personnel)
 "bWR" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon,
@@ -34801,9 +32965,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"bXe" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "bXf" = (
@@ -35067,27 +33228,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"bXY" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "bXZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -35153,51 +33293,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"bYh" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"bYi" = (
-/obj/structure/window/reinforced,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bYj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -35298,7 +33393,7 @@
 /area/engine/transit_tube)
 "bYq" = (
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -35359,7 +33454,7 @@
 /obj/structure/rack,
 /obj/item/storage/secure/briefcase,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -35409,8 +33504,7 @@
 "bYw" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -35472,35 +33566,13 @@
 /area/engine/engineering)
 "bYF" = (
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/light,
 /obj/machinery/computer/security{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
-"bYH" = (
-/obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = -32
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/recharger,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -35552,7 +33624,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -35564,20 +33636,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
-"bYS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -35605,23 +33663,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bYZ" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/landmark/start/head_of_personnel,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/head_of_personnel)
 "bZa" = (
 /turf/open/floor/wood,
 /area/crew_quarters/heads/head_of_personnel)
@@ -35792,7 +33833,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
@@ -35980,7 +34021,7 @@
 "caj" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral{
@@ -35998,7 +34039,7 @@
 "cak" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch{
-	pixel_x = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -36081,7 +34122,7 @@
 "cao" = (
 /obj/item/kirbyplants/random,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/structure/sign/poster/official/ian{
 	pixel_y = -32
@@ -36287,10 +34328,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"cbd" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain/private)
 "cbe" = (
 /obj/machinery/light{
 	dir = 1
@@ -36417,24 +34454,6 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/warden)
-"cbD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light_switch{
-	pixel_x = -38;
-	pixel_y = -26
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/warden)
 "cbF" = (
 /obj/structure/closet/secure_closet/warden,
@@ -36576,27 +34595,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cca" = (
-/obj/item/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Fore";
-	name = "engineering camera"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ccb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
@@ -36633,14 +34631,6 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"ccn" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole,
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel/dark,
-/area/library)
 "cco" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -36667,25 +34657,6 @@
 "ccr" = (
 /turf/open/floor/plasteel/dark,
 /area/library)
-"ccs" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/library)
 "cct" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -36705,7 +34676,7 @@
 /obj/item/folder,
 /obj/item/pen,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -36843,35 +34814,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain/private)
-"ccT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ccU" = (
-/obj/machinery/vending/snack/random,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
 "ccV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -36949,19 +34891,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"cdb" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/courtroom)
 "cdc" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -37012,24 +34941,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"cdg" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/taperecorder{
-	pixel_x = 3
-	},
-/obj/item/clothing/glasses/sunglasses,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/button/door{
-	id = "lawyerprivacy";
-	name = "Lawyer's Privacy Control";
-	pixel_y = 24
-	},
-/turf/open/floor/wood,
-/area/lawoffice)
 "cdh" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -37038,39 +34949,14 @@
 /area/lawoffice)
 "cdj" = (
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/lawoffice)
-"cdk" = (
-/obj/machinery/vending/wardrobe/law_wardrobe,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /turf/open/floor/wood,
 /area/lawoffice)
 "cdl" = (
 /turf/closed/wall/r_wall,
 /area/lawoffice)
-"cdn" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cdp" = (
 /obj/item/radio/intercom{
 	pixel_x = 26;
@@ -37173,22 +35059,18 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cdA" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/porta_turret/ai,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload)
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cdB" = (
 /obj/structure/grille,
 /obj/effect/turf_decal/stripes/line{
@@ -37363,7 +35245,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/machinery/camera{
 	c_tag = "Library - Fore";
@@ -37493,39 +35375,6 @@
 "ceK" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
-"ceL" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/captain,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/effect/landmark/start/captain,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain/private)
-"ceM" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
 "ceO" = (
 /obj/structure/chair{
 	dir = 4
@@ -37570,6 +35419,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"ceW" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "cfa" = (
 /obj/structure/filingcabinet/employment,
 /obj/machinery/airalarm{
@@ -37982,22 +35846,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
-"cgv" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/camera{
-	c_tag = "Bridge - Captain's Quarters";
-	dir = 1;
-	name = "command camera"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain/private)
 "cgw" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -38147,29 +35995,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"cgI" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "Judge"
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/courtroom)
 "cgJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -38244,6 +36069,24 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"cha" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/sign/nanotrasen{
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "chh" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -38389,16 +36232,6 @@
 /obj/machinery/bookbinder,
 /turf/open/floor/wood,
 /area/library)
-"chR" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/structure/bookcase/random,
-/turf/open/floor/wood,
-/area/library)
 "chS" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/assistant,
@@ -38406,27 +36239,6 @@
 /area/library)
 "chT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/library)
-"chU" = (
-/obj/machinery/photocopier,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/library)
-"chV" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/structure/bookcase/manuals/research_and_development,
-/obj/machinery/camera{
-	c_tag = "Library";
-	name = "library camera"
-	},
 /turf/open/floor/wood,
 /area/library)
 "chW" = (
@@ -38440,15 +36252,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
 /area/library)
-"cib" = (
-/obj/structure/table/wood,
-/obj/machinery/recharger,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/head_of_personnel)
 "cid" = (
 /obj/machinery/telecomms/bus/preset_four,
 /obj/effect/turf_decal/tile/brown{
@@ -38497,16 +36300,6 @@
 	},
 /turf/open/floor/plasteel/telecomms,
 /area/tcommsat/server)
-"cik" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "cim" = (
 /obj/structure/chair{
 	dir = 4
@@ -38619,24 +36412,6 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/lawoffice)
-"civ" = (
-/obj/structure/table/wood,
-/obj/machinery/requests_console{
-	department = "Law Office";
-	name = "'Law Office RC";
-	pixel_y = -64
-	},
-/obj/item/folder/blue{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/folder/red,
-/obj/item/stamp/law,
-/obj/machinery/photocopier/faxmachine/longrange{
-	department = "Internal Affairs"
-	},
-/turf/open/floor/plasteel/grimy,
 /area/lawoffice)
 "ciw" = (
 /obj/structure/chair/office{
@@ -38932,14 +36707,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
-"cjr" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/library)
 "cjs" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -39016,8 +36783,7 @@
 "cjA" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/item/folder/blue,
 /obj/item/pen,
@@ -39241,11 +37007,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"ckf" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/turf/open/floor/wood,
-/area/lawoffice)
 "ckg" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -39369,6 +37130,27 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ckx" = (
+/obj/structure/chair{
+	dir = 8;
+	name = "Judge"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "ckD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -39710,36 +37492,6 @@
 "clA" = (
 /turf/closed/wall,
 /area/security/range)
-"clB" = (
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/target,
-/obj/item/target/syndicate,
-/obj/item/target/alien,
-/obj/item/target/clown,
-/obj/structure/closet/crate/secure{
-	desc = "A secure crate containing various materials for building a customised test-site.";
-	name = "Test Site Materials Crate";
-	req_access_txt = "63"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/light_switch{
-	pixel_x = -36
-	},
-/turf/open/floor/plasteel,
-/area/security/range)
 "clD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -39928,7 +37680,7 @@
 "cmc" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/small,
@@ -40000,14 +37752,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/library)
-"cmw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "cmx" = (
 /obj/structure/dresser,
 /turf/open/floor/plasteel/grimy,
@@ -40024,7 +37768,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/wood,
@@ -40052,16 +37796,6 @@
 /area/teleporter)
 "cmH" = (
 /obj/effect/turf_decal/loading_area,
-/turf/open/floor/plasteel,
-/area/teleporter)
-"cmI" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "cmJ" = (
@@ -40231,26 +37965,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"cmY" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "Judge"
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/courtroom)
 "cnk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown,
@@ -40376,14 +38090,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"cnF" = (
-/obj/machinery/requests_console{
-	department = "Chapel Office";
-	name = "Chapel RC";
-	pixel_y = -32
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "cnG" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -40467,38 +38173,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/grimy,
 /area/library)
-"cnV" = (
-/obj/structure/table/wood,
-/obj/item/camera_film{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/camera_film,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/grimy,
-/area/library)
-"cnW" = (
-/obj/structure/bed,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/item/bedsheet/head_of_personnel,
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/heads/head_of_personnel)
-"cnX" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/effect/landmark/start/head_of_personnel,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/heads/head_of_personnel)
 "cnZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -40724,16 +38398,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"coA" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/courtroom)
 "coC" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -40925,13 +38589,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cpe" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/toy/figure/engineer,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cpg" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
@@ -41045,14 +38702,6 @@
 "cpy" = (
 /turf/open/floor/carpet,
 /area/library)
-"cpz" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/grimy,
-/area/library)
 "cpA" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -41072,14 +38721,6 @@
 /turf/closed/wall,
 /area/crew_quarters/heads/head_of_personnel)
 "cpD" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/head_of_personnel)
-"cpF" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/head_of_personnel)
@@ -41114,38 +38755,13 @@
 "cpL" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -26
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/server)
-"cpM" = (
-/obj/structure/table,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/item/book/manual/wiki/tcomms,
-/obj/item/wrench,
-/obj/item/screwdriver{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/tcommsat/server)
-"cpN" = (
-/obj/structure/rack,
-/obj/item/tank/internals/oxygen,
-/obj/item/radio,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/teleporter)
 "cpO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -41155,8 +38771,7 @@
 /area/teleporter)
 "cpP" = (
 /obj/machinery/light_switch{
-	pixel_x = -7;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -41929,12 +39544,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"csh" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/library)
 "csi" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -42130,24 +39739,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"csK" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
 "csL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -42372,6 +39963,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"cte" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/explab)
 "cth" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -42582,7 +40195,7 @@
 /obj/machinery/light,
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/grimy,
@@ -42862,7 +40475,7 @@
 "cuV" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/bot,
 /obj/item/tank/internals/plasma,
@@ -42890,6 +40503,25 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cuZ" = (
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "cva" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/decal/cleanable/dirt,
@@ -42940,7 +40572,7 @@
 "cvf" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/item/clipboard,
 /obj/item/folder/blue,
@@ -43480,7 +41112,7 @@
 /obj/item/canvas/twentythreeXtwentythree,
 /obj/item/canvas/twentythreeXtwentythree,
 /obj/machinery/light_switch{
-	pixel_y = 26
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -43515,7 +41147,7 @@
 /area/library)
 "cww" = (
 /obj/machinery/light_switch{
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -43618,29 +41250,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"cwI" = (
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/camera{
-	c_tag = "Bridge - E.V.A. Fore";
-	name = "command camera"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "cwJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -43681,7 +41290,7 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/flashlight,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -43997,8 +41606,7 @@
 /area/engine/engineering)
 "cxG" = (
 /obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/turf_decal/bot,
@@ -44118,28 +41726,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"cyb" = (
-/obj/structure/table/wood,
-/obj/item/storage/briefcase{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/secure/briefcase,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/library)
 "cyc" = (
 /obj/structure/destructible/cult/tome,
 /obj/item/book/codex_gigas,
@@ -44185,25 +41771,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"cyg" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/library)
 "cyh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
@@ -44216,31 +41783,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"cyi" = (
-/obj/item/stack/sheet/plasteel/twenty,
-/obj/item/stack/sheet/rglass{
-	amount = 30;
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/crowbar,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "cyj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -44644,8 +42186,7 @@
 /obj/item/clothing/glasses/meson/engine,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
-	pixel_x = -22;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -44681,7 +42222,7 @@
 /obj/item/electronics/airlock,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/bot,
 /obj/item/rcl/pre_loaded,
@@ -44849,17 +42390,6 @@
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/dark,
 /area/library)
-"czP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "czQ" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -45300,7 +42830,7 @@
 "cBa" = (
 /obj/item/kirbyplants/random,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -45342,23 +42872,6 @@
 /area/library)
 "cBg" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/library)
-"cBh" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cBi" = (
@@ -45408,23 +42921,6 @@
 "cBl" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
-"cBm" = (
-/obj/machinery/camera/motion{
-	c_tag = "E.V.A. Storage";
-	dir = 8;
-	name = "motion-sensitive command camera"
-	},
-/obj/machinery/requests_console{
-	department = "E.V.A. Storage";
-	name = "E.V.A. RC";
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cBn" = (
@@ -45607,25 +43103,6 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/crew_quarters/toilet/restrooms)
-"cBL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "cBM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -46411,15 +43888,6 @@
 	icon_state = "wood-broken3"
 	},
 /area/crew_quarters/dorms)
-"cDE" = (
-/obj/structure/table/wood,
-/obj/item/folder,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/item/razor,
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
 "cDF" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -46579,15 +44047,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cEj" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/maintenance/port)
 "cEk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -46779,7 +44238,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/wrench,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/structure/table/reinforced,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
@@ -46898,20 +44357,6 @@
 	},
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
-"cES" = (
-/obj/structure/table,
-/obj/item/storage/belt,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/gateway)
 "cET" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -47080,14 +44525,6 @@
 /obj/item/bedsheet/dorms,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"cFA" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
 "cFB" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -47131,20 +44568,6 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
-"cFV" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility,
-/obj/item/weldingtool,
-/obj/item/clothing/head/welding,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/storage)
 "cFW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow,
@@ -47161,20 +44584,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/storage)
-"cFY" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/rglass{
-	amount = 50;
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cGa" = (
@@ -47323,7 +44732,7 @@
 "cGq" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -26
+	pixel_y = 26
 	},
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
@@ -47339,21 +44748,6 @@
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
-/area/bridge/showroom/corporate)
-"cGu" = (
-/obj/machinery/button/door{
-	id = "corporatelounge";
-	name = "Corporate Lounge Shutters";
-	pixel_x = -7;
-	pixel_y = -26
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = -26
-	},
-/obj/item/kirbyplants/random,
-/obj/machinery/light,
 /turf/open/floor/plasteel/grimy,
 /area/bridge/showroom/corporate)
 "cGv" = (
@@ -47383,8 +44777,7 @@
 /area/gateway)
 "cGz" = (
 /obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -47778,24 +45171,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"cHE" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/vacant_room/commissary)
 "cHF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -47809,7 +45184,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
@@ -47865,7 +45240,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -47876,7 +45251,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/machinery/light/small,
 /obj/effect/turf_decal/bot,
@@ -47888,7 +45263,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/machinery/light/small,
 /obj/effect/landmark/start/assistant,
@@ -47903,17 +45278,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/crew_quarters/dorms)
-"cIk" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "cIl" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -48063,18 +45427,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"cII" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "cIJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -48137,18 +45489,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/plaque{
 	icon_state = "L13"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"cIQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -48337,7 +45677,7 @@
 "cJB" = (
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -48941,6 +46281,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"cLz" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "cLA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -49334,7 +46684,7 @@
 "cMv" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -26
+	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -49460,8 +46810,7 @@
 /area/crew_quarters/dorms)
 "cMF" = (
 /obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -49873,17 +47222,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/medical/storage)
-"cNM" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/medical/storage)
 "cNN" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/radio/intercom{
@@ -49900,21 +47238,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/medical/storage)
-"cNP" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/bot,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/requests_console{
-	department = "Medbay Storage";
-	name = "Medbay Storage RC";
-	pixel_y = 28
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
@@ -49991,7 +47314,7 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50094,7 +47417,7 @@
 "cOr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/light_switch{
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -50107,7 +47430,7 @@
 "cOt" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
 /obj/effect/turf_decal/delivery,
@@ -50142,7 +47465,7 @@
 /area/maintenance/department/electrical)
 "cOy" = (
 /obj/machinery/light_switch{
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
@@ -50164,20 +47487,6 @@
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
-/area/maintenance/department/electrical)
-"cOA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "cOB" = (
@@ -50903,30 +48212,6 @@
 "cQD" = (
 /turf/closed/wall,
 /area/security/checkpoint/science/research)
-"cQE" = (
-/obj/structure/closet/secure_closet/security/science,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science/research)
 "cQF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -51353,28 +48638,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cRt" = (
-/obj/structure/table/wood,
-/obj/item/storage/briefcase{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/briefcase,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/item/cane,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"cRu" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/dorms)
 "cRv" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/nanotrasen{
@@ -51383,15 +48646,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/dorms)
-"cRw" = (
-/obj/machinery/vending/snack/random,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "cRx" = (
 /obj/structure/chair{
 	dir = 4
@@ -51608,8 +48862,7 @@
 /area/security/checkpoint/science/research)
 "cSm" = (
 /obj/machinery/light_switch{
-	pixel_x = -38;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/red{
@@ -51905,46 +49158,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"cSO" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 38
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 32
-	},
-/obj/structure/closet/secure_closet/security/med,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/medical)
-"cSP" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/masks,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "cSQ" = (
 /obj/structure/table,
 /obj/item/storage/box/gloves{
@@ -52066,15 +49279,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/medical/medbay/central)
-"cTa" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
 "cTb" = (
 /obj/structure/chair/office,
 /turf/open/floor/wood,
@@ -52358,21 +49562,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"cTM" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "cTN" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -52381,34 +49570,9 @@
 	},
 /turf/closed/wall,
 /area/science/xenobiology)
-"cTO" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 32
-	},
-/obj/machinery/button/door{
-	id = "xeno6";
-	name = "Containment Control";
-	req_access_txt = "55"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "cTP" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
-/area/science/xenobiology)
-"cTQ" = (
-/obj/machinery/monkey_recycler,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cTR" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
@@ -52426,24 +49590,6 @@
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"cTV" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/beakers{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/syringes,
-/obj/item/radio/intercom{
-	pixel_y = 32
-	},
-/obj/item/extinguisher/mini,
-/obj/effect/turf_decal/delivery,
-/obj/item/storage/box/monkeycubes,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "cTW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -52453,6 +49599,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"cUb" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "cUe" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -52881,7 +50036,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -53254,13 +50409,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
-"cVA" = (
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/maintenance/department/electrical)
 "cVB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -53373,30 +50521,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"cVT" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/white,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
-	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/dropper,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Xenobiology Lab";
-	name = "Xenobiology RC";
-	pixel_x = 32;
-	receive_ore_updates = 1
-	},
-/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cVU" = (
@@ -53624,7 +50748,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cWt" = (
-/obj/machinery/newscaster,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
 /turf/closed/wall,
 /area/medical/storage)
 "cWu" = (
@@ -53658,8 +50784,7 @@
 /area/medical/storage)
 "cWx" = (
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -38
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -53680,7 +50805,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -54479,7 +51604,7 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -54500,7 +51625,7 @@
 /area/maintenance/department/electrical)
 "cYB" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
@@ -54534,7 +51659,7 @@
 /area/maintenance/department/electrical)
 "cYF" = (
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/bot,
@@ -54793,7 +51918,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 27
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
@@ -54894,18 +52019,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"cZL" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "cZM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -55176,8 +52289,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/button/door{
 	id = "xeno1";
@@ -55193,8 +52305,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/bot,
@@ -55360,20 +52471,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"daW" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/wrench,
-/obj/item/clothing/glasses/welding,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "daX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -55417,7 +52514,7 @@
 	},
 /obj/item/reagent_containers/dropper,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -55930,7 +53027,7 @@
 /obj/item/clothing/mask/gas,
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
@@ -55939,7 +53036,7 @@
 "dcp" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /obj/machinery/light_switch{
-	pixel_x = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -56270,17 +53367,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
-"ddg" = (
-/obj/machinery/shower{
-	dir = 8;
-	name = "emergency shower"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "ddh" = (
 /obj/structure/table/wood,
 /obj/item/folder/white,
@@ -56327,7 +53413,7 @@
 "ddk" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
@@ -56603,19 +53689,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"ddS" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/item/storage/bag/bio,
-/obj/item/storage/bag/bio,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "ddT" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/bot,
@@ -56637,16 +53710,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"ddW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "ddY" = (
 /obj/item/radio/intercom{
 	pixel_y = -32
@@ -57203,22 +54266,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
 /area/science/research)
-"dfu" = (
-/obj/machinery/requests_console{
-	department = "Research Lab";
-	name = "Research RC";
-	pixel_x = 32;
-	receive_ore_updates = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Science - Research and Development";
-	dir = 8;
-	name = "science camera";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "dfv" = (
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall,
@@ -57266,32 +54313,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"dfz" = (
-/obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/reagent_containers/dropper,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay - Chemistry";
-	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "dfA" = (
@@ -57866,17 +54887,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"dhf" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -58460,7 +55470,7 @@
 /obj/machinery/requests_console{
 	department = "Chemistry Lab";
 	name = "Chemistry RC";
-	pixel_y = -64;
+	pixel_y = -32;
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -58600,7 +55610,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_x = 26
+	pixel_y = -23
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue,
@@ -58641,7 +55651,7 @@
 "dja" = (
 /obj/machinery/vending/assist,
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -58814,73 +55824,6 @@
 /area/maintenance/department/science)
 "djA" = (
 /turf/closed/wall/r_wall,
-/area/science/explab)
-"djB" = (
-/obj/item/storage/toolbox/mechanical,
-/obj/item/flashlight,
-/obj/effect/turf_decal/bot,
-/obj/structure/sign/poster/official/science{
-	pixel_x = -32
-	},
-/obj/structure/rack,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
-"djC" = (
-/obj/machinery/camera{
-	c_tag = "Science - Experimentation Lab";
-	name = "science camera";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
-"djD" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/bombcloset/white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "djE" = (
 /obj/item/crowbar,
@@ -59077,26 +56020,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"djY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light,
-/obj/machinery/cell_charger,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/science/lab)
 "djZ" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/packageWrap,
@@ -59136,7 +56059,7 @@
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/dropper,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -59202,7 +56125,7 @@
 "dkg" = (
 /obj/machinery/chem_master,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -32;
@@ -59434,7 +56357,7 @@
 "dkL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/item/hemostat,
 /obj/effect/decal/cleanable/dirt,
@@ -59594,27 +56517,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port)
-"dlo" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/bot,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
 "dlp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/neutral{
@@ -59657,7 +56559,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -59714,14 +56616,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"dlL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "dlM" = (
@@ -59841,51 +56735,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
-"dmB" = (
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/bot,
-/obj/item/stack/medical/gauze,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/mesh,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
 "dmC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
-"dmE" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -59971,23 +56822,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/research)
-"dmO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Science - Lab Access";
-	dir = 8;
-	name = "science camera";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "dmR" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/blobstart,
@@ -60012,7 +56846,7 @@
 	pixel_x = -24
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -60366,23 +57200,6 @@
 "dnJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
-"dnK" = (
-/obj/structure/chair,
-/obj/machinery/newscaster{
-	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -60971,14 +57788,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
-"dpA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "dpB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -61251,44 +58060,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/nanite)
-"dqo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/nanite_scanner{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/nanite_scanner{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/nanite_remote{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/nanite_remote{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "dqp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -61393,14 +58164,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"dqL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
 "dqN" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -61610,22 +58373,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/surgery)
-"drp" = (
-/obj/structure/rack,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/item/stack/sheet/metal{
-	amount = 30
-	},
-/obj/item/stack/packageWrap,
-/obj/item/stack/sheet/glass{
-	amount = 30
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/construction)
 "drq" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
@@ -61726,17 +58473,6 @@
 	pixel_y = -32
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab/range)
-"drF" = (
-/obj/machinery/light_switch{
-	pixel_x = 36
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/vending/assist,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "drG" = (
@@ -61892,7 +58628,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /obj/machinery/camera{
 	c_tag = "Science - Research Director's Office";
@@ -62046,6 +58782,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"dsx" = (
+/obj/machinery/light,
+/obj/machinery/computer/station_alert{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "dsy" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue,
@@ -62055,13 +58814,11 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 7;
-	pixel_y = -26
+	pixel_x = 26
 	},
 /obj/machinery/light,
 /obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = -38
+	pixel_y = -23
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Cloning Lab";
@@ -62158,41 +58915,11 @@
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall,
 /area/medical/surgery)
-"dsJ" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
 "dsK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"dsL" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/iv_drip,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -62352,17 +59079,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"dti" = (
-/obj/structure/closet/bombcloset,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "dtj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/purple{
@@ -62385,17 +59101,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/science/mixing)
-"dtm" = (
-/obj/structure/closet/bombcloset,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
 /area/science/mixing)
 "dtq" = (
 /obj/machinery/disposal/bin,
@@ -62866,24 +59571,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"duK" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/toy/figure/rd,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Research Director's Desk";
-	departmentType = 5;
-	name = "Research Director's RC";
-	pixel_x = -32;
-	receive_ore_updates = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hor)
 "duL" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -62945,20 +59632,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"duZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24;
-	pixel_y = -26
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -38
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
 "dva" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -62975,24 +59648,6 @@
 /area/hallway/primary/aft)
 "dvc" = (
 /turf/closed/wall,
-/area/medical/genetics)
-"dvd" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/medical/genetics)
-"dve" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dvf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -63022,19 +59677,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
-"dvg" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "dvh" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -63083,20 +59725,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
-"dvm" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "dvo" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/stripes/end{
@@ -63131,17 +59759,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/genetics)
-"dvs" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/cmo)
 "dvt" = (
 /obj/structure/table/glass,
 /obj/item/folder/blue,
@@ -63210,6 +59827,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"dvz" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "dvL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -63285,7 +59918,7 @@
 "dvT" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -63380,7 +60013,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -26
+	pixel_y = 26
 	},
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -63430,7 +60063,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/item/radio/intercom{
 	pixel_x = -26;
@@ -63455,25 +60088,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
-"dws" = (
-/obj/machinery/computer/robotics{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = -5;
-	pixel_y = -26
-	},
-/obj/machinery/light_switch{
-	pixel_x = 5;
-	pixel_y = -26
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
 "dwu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -63552,35 +60166,6 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/medical/genetics)
-"dwN" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/white,
-/obj/item/storage/pill_bottle/mutadone,
-/obj/item/storage/pill_bottle/mannitol,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay - Genetics Lab";
-	dir = 4;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "dwO" = (
 /obj/structure/chair/office/light{
@@ -63722,19 +60307,6 @@
 	},
 /obj/machinery/light{
 	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"dxl" = (
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
@@ -63951,7 +60523,7 @@
 "dxO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
-	pixel_x = 26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -64233,7 +60805,7 @@
 "dyW" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -64319,6 +60891,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
+"dzj" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/toy/figure/secofficer,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "dzs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -64357,8 +60948,7 @@
 /area/crew_quarters/heads/hor)
 "dzD" = (
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/purple{
@@ -64376,24 +60966,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
-"dzF" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table/reinforced,
-/obj/machinery/requests_console{
-	department = "Robotics Lab";
-	name = "Robotics RC";
-	pixel_y = 32;
-	receive_ore_updates = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "dzG" = (
 /obj/item/paper_bin,
 /obj/item/assembly/prox_sensor{
@@ -64441,8 +61013,7 @@
 	req_access_txt = "29"
 	},
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 38
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -64672,23 +61243,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
-"dAJ" = (
-/obj/item/stack/sheet/plasteel{
-	amount = 15
-	},
-/obj/item/wrench,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/clothing/glasses/welding,
-/obj/structure/table/reinforced,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "dAO" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -64755,7 +61309,7 @@
 "dAY" = (
 /obj/machinery/dna_scannernew,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -64775,7 +61329,7 @@
 /area/medical/genetics)
 "dBb" = (
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -65062,7 +61616,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/item/radio/intercom{
 	pixel_x = 26
@@ -65084,31 +61638,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/science/robotics/lab)
-"dCp" = (
-/obj/item/stack/cable_coil,
-/obj/item/bodypart/r_arm/robot{
-	pixel_x = 3
-	},
-/obj/item/bodypart/l_arm/robot{
-	pixel_x = -3
-	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/structure/table/reinforced,
-/obj/machinery/light_switch{
-	pixel_x = -38;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dCv" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -65572,15 +62101,6 @@
 /obj/machinery/aug_manipulator,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"dDH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "dDI" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
@@ -65742,7 +62262,7 @@
 "dDW" = (
 /obj/structure/table/glass,
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32;
@@ -65789,42 +62309,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/cmo)
-"dEa" = (
-/obj/machinery/computer/crew{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "cmoshutter";
-	name = "CMO Office Shutters";
-	pixel_x = 7;
-	pixel_y = -26;
-	req_access_txt = "40"
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = 7;
-	pixel_y = -38
-	},
-/obj/machinery/light_switch{
-	pixel_x = -7;
-	pixel_y = -26
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer's RC";
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
 /area/crew_quarters/heads/cmo)
 "dEb" = (
 /obj/machinery/door/poddoor/preopen{
@@ -65920,31 +62404,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
-"dEq" = (
-/obj/item/transfer_valve{
-	pixel_x = -5
-	},
-/obj/item/transfer_valve{
-	pixel_x = -5
-	},
-/obj/item/transfer_valve,
-/obj/item/transfer_valve,
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/requests_console{
-	department = "Toxins Lab";
-	name = "Toxins RC";
-	pixel_x = -32;
-	receive_ore_updates = 1
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "dEr" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -66000,21 +62459,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"dEz" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/clothing/mask/gas,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/storage)
 "dEA" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
@@ -66025,7 +62469,7 @@
 	},
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/item/clipboard,
 /obj/item/wrench,
@@ -66209,9 +62653,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/morgue)
-"dEY" = (
-/turf/open/floor/plating,
-/area/medical/morgue)
 "dEZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -66279,12 +62720,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/theatre/abandoned)
-"dFn" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/theatre/abandoned)
 "dFo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -66357,13 +62792,6 @@
 	pixel_y = 3
 	},
 /obj/item/newspaper,
-/turf/open/floor/plating,
-/area/security/detectives_office/private_investigators_office)
-"dFv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
 /turf/open/floor/plating,
 /area/security/detectives_office/private_investigators_office)
 "dFw" = (
@@ -66454,20 +62882,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"dFE" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/newscaster{
-	pixel_y = 32
+"dFG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/machinery/airalarm{
+/obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/science/misc_lab)
+/area/hallway/primary/port)
 "dFH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -66526,18 +62951,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"dFM" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/science/storage)
 "dFN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -66558,16 +62971,6 @@
 "dFP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/storage)
-"dFQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
@@ -66676,20 +63079,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"dGy" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/cmo)
 "dGz" = (
 /obj/structure/dresser,
 /obj/structure/mirror{
@@ -66771,17 +63160,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre/abandoned)
-"dGL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plating,
-/area/security/detectives_office/private_investigators_office)
 "dGN" = (
 /turf/open/floor/wood,
 /area/security/detectives_office/private_investigators_office)
@@ -66966,36 +63344,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"dHp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel,
-/area/science/storage)
-"dHu" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/toolbox/electrical,
-/obj/item/screwdriver{
-	pixel_y = 5
-	},
-/obj/item/multitool,
-/obj/item/clothing/head/welding,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "dHw" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -67052,24 +63400,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"dHC" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "dHD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -67340,12 +63670,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
-"dHX" = (
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre/abandoned)
 "dHY" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
@@ -67493,7 +63817,7 @@
 "dII" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/machinery/camera{
 	c_tag = "Science - Aft";
@@ -67574,7 +63898,7 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -67726,7 +64050,7 @@
 	pixel_y = 4
 	},
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -67791,7 +64115,7 @@
 "dJo" = (
 /obj/effect/turf_decal/tile/green,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -67917,19 +64241,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"dJJ" = (
-/obj/machinery/doppler_array/research/science{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
 "dJK" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -67972,18 +64283,6 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dJN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
-"dJO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -68041,7 +64340,7 @@
 "dJU" = (
 /obj/structure/rack,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/item/clothing/suit/fire/firefighter,
 /obj/item/clothing/head/hardhat/red,
@@ -68184,16 +64483,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"dKl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "dKm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -68849,27 +65138,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"dMc" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "dMd" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets,
@@ -69258,6 +65526,28 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dNx" = (
+/obj/machinery/light_switch{
+	pixel_x = -8;
+	pixel_y = 25
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 6;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "dNB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -69627,21 +65917,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
-"dOC" = (
-/obj/structure/filingcabinet/medical,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs/auxiliary)
 "dOD" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -69684,22 +65959,6 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
-/area/hallway/primary/aft)
-"dOH" = (
-/obj/structure/table,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dOI" = (
 /obj/machinery/light/small,
@@ -69799,7 +66058,7 @@
 "dOZ" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/item/clipboard,
 /obj/item/folder,
@@ -70048,7 +66307,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -70131,6 +66390,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"dPV" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "dPZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -70194,7 +66483,7 @@
 "dQm" = (
 /obj/structure/table/glass,
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/item/paper_bin,
 /obj/item/radio/intercom{
@@ -70214,23 +66503,6 @@
 /obj/machinery/computer/med_data/laptop,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"dQp" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -70390,23 +66662,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
-"dQN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs/auxiliary)
 "dQP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -70446,27 +66701,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"dQY" = (
-/obj/structure/table/glass,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/item/paper_bin,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Virology - Cells";
-	dir = 8;
-	name = "virology camera";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "dRe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -70536,27 +66770,6 @@
 	},
 /obj/structure/sign/poster/official/cleanliness,
 /turf/closed/wall,
-/area/medical/virology)
-"dRl" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/structure/table/glass,
-/obj/item/flashlight/lamp,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "dRn" = (
 /obj/structure/table/glass,
@@ -70804,7 +67017,7 @@
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -70816,21 +67029,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/medical/virology)
-"dSd" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dSo" = (
 /obj/machinery/light{
@@ -71180,15 +67378,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"dTE" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "dTF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -71215,49 +67404,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"dTR" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "dTT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/virology)
-"dTU" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/sign/poster/official/work_for_a_future{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "dTV" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -71369,50 +67521,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"dUi" = (
-/obj/structure/table,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/bodybags,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
-"dUk" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "dUl" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box{
@@ -71530,14 +67638,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
-"dUt" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/machinery/light_switch{
-	pixel_y = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -71742,22 +67842,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"dVu" = (
-/obj/structure/table/glass,
-/obj/machinery/requests_console{
-	department = "Virology Lab";
-	name = "Virology RC";
-	pixel_y = 32;
-	receive_ore_updates = 1
-	},
-/obj/item/folder/white,
-/obj/item/pen/red,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/medical/virology)
 "dVw" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/bot,
@@ -71913,6 +67997,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"dVO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "dVP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -72514,21 +68609,6 @@
 	icon_state = "chapel"
 	},
 /area/chapel/main)
-"dXI" = (
-/obj/structure/chair/wood,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel - Starboard";
-	dir = 8;
-	name = "chapel camera"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "dXJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -72625,19 +68705,6 @@
 "dYd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"dYe" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dYf" = (
@@ -72769,7 +68836,7 @@
 "dYy" = (
 /obj/structure/chair/wood,
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel{
 	dir = 1;
@@ -72855,22 +68922,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/medical/virology)
-"dYV" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/closet/secure_closet/medical1,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/medical/virology)
 "dYW" = (
 /obj/machinery/light{
 	dir = 8
@@ -72926,18 +68977,6 @@
 	icon_state = "chapel"
 	},
 /area/chapel/main)
-"dZm" = (
-/obj/structure/chair/wood,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel{
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "dZn" = (
 /obj/machinery/light{
 	dir = 8
@@ -72976,6 +69015,25 @@
 /obj/structure/sign/warning/vacuum,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"dZx" = (
+/obj/machinery/computer/card{
+	dir = 4
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = -26;
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
+	dir = 8;
+	name = "Captain RC";
+	pixel_x = -32
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain)
 "dZA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -72986,7 +69044,7 @@
 "dZE" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -26
+	pixel_y = 26
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73419,8 +69477,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "ebq" = (
 /obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -73535,15 +69592,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ebQ" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/yellow,
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "ebR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -73573,18 +69621,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"ebU" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel{
-	dir = 8;
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "ebV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -73758,32 +69794,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
-"ecu" = (
-/obj/structure/table/reinforced,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
 "ecv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral,
@@ -73796,7 +69806,7 @@
 /obj/structure/bodycontainer/morgue,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -73885,8 +69895,7 @@
 "ecE" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -74267,7 +70276,7 @@
 	},
 /obj/machinery/light/small,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/item/radio/intercom{
 	broadcasting = 1;
@@ -74293,7 +70302,7 @@
 	},
 /obj/machinery/light/small,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/item/radio/intercom{
 	broadcasting = 1;
@@ -74357,26 +70366,6 @@
 "edu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
-"edv" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "edy" = (
@@ -74449,7 +70438,7 @@
 "edR" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/flashlight,
@@ -74590,32 +70579,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"eez" = (
-/obj/structure/table/wood,
-/obj/item/camera_film{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/camera_film,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "eeA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -74684,30 +70647,6 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/office)
-"eeH" = (
-/obj/structure/filingcabinet/security,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/machinery/camera{
-	c_tag = "Security - Departures Port"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/escape)
 "eeJ" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -74830,28 +70769,7 @@
 /area/chapel/office)
 "efl" = (
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
-"efn" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -74910,7 +70828,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /turf/open/floor/carpet,
 /area/chapel/office)
@@ -74952,7 +70870,7 @@
 "efW" = (
 /obj/structure/dresser,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
@@ -75010,7 +70928,7 @@
 /obj/structure/table/wood,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /obj/item/clipboard,
 /obj/item/toy/figure/chaplain,
@@ -75075,7 +70993,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -75425,23 +71343,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
-"ejV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "ejX" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -75742,6 +71643,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"epy" = (
+/obj/structure/table/wood,
+/obj/item/camera_film{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/camera_film,
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "epW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -75916,6 +71843,15 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"eru" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/grimy,
+/area/vacant_room/office)
 "erN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -75935,6 +71871,22 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/fitness/recreation)
+"erS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/detectives_office)
 "esr" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Long-Term Cell 3";
@@ -76027,8 +71979,7 @@
 /area/security/checkpoint/escape)
 "etx" = (
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -76143,6 +72094,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"eve" = (
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/item/stack/sheet/rglass{
+	amount = 30;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/crowbar,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "evw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -76260,6 +72236,37 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
+"exU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/science/storage)
+"eyf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "eys" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -76355,6 +72362,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"ezx" = (
+/obj/structure/table/wood,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/vacant_room/office)
 "ezJ" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/airalarm{
@@ -76380,6 +72397,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"ezR" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/camera{
+	c_tag = "Bridge - Captain's Quarters";
+	dir = 1;
+	name = "command camera"
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain/private)
 "eAf" = (
 /obj/machinery/power/rad_collector/anchored/delta,
 /obj/effect/decal/cleanable/dirt,
@@ -76563,6 +72595,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"eDG" = (
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/screwdriver,
+/obj/machinery/button/door{
+	id = "commissarydoor";
+	name = "Commissary Door Lock";
+	normaldoorcontrol = 1;
+	pixel_x = -5;
+	pixel_y = -26;
+	specialfunctions = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/item/stack/cable_coil/random/five,
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "eDN" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/structure/cable{
@@ -76661,6 +72720,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
+"eFm" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/machinery/requests_console{
+	department = "Law Office";
+	name = "'Law Office RC";
+	pixel_y = -32
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "eFD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -76793,6 +72862,26 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/security/warden)
+"eIt" = (
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "eIW" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/end{
@@ -77047,6 +73136,25 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"eMF" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/donkpockets,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "eMJ" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 8
@@ -77115,6 +73223,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"eNp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "eNA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -77162,6 +73286,16 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"eOM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "eOQ" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -77294,6 +73428,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
+"eQC" = (
+/obj/machinery/computer/telecomms/server{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "eQL" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -77378,25 +73532,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/supermatter)
-"eSb" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "eSq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -77807,6 +73942,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"eYm" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "eYG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -77983,6 +74139,32 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/library/abandoned)
+"fbb" = (
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve,
+/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/requests_console{
+	department = "Toxins Lab";
+	dir = 8;
+	name = "Toxins RC";
+	pixel_x = -32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "fbc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -78229,18 +74411,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"fex" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/bot,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "feZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -78251,6 +74421,50 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"ffm" = (
+/obj/structure/filingcabinet/security,
+/obj/machinery/light_switch{
+	pixel_x = -23;
+	pixel_y = -7
+	},
+/obj/machinery/camera{
+	c_tag = "Security - Departures Port"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/escape)
+"ffy" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower"
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/medical/virology)
 "ffD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -78516,6 +74730,17 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"fig" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "fir" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -78743,6 +74968,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"flW" = (
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "fml" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -78818,6 +75057,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
+"fnq" = (
+/obj/structure/table,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "fnM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -79000,6 +75256,31 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"fuh" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "fuz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79375,6 +75656,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"fAB" = (
+/obj/structure/closet/bombcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "fAC" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
@@ -79459,26 +75751,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"fBQ" = (
-/obj/machinery/light,
-/obj/machinery/computer/station_alert{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "fBY" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/engine/transit_tube";
@@ -79683,6 +75955,23 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fFV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "fGq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -79737,6 +76026,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"fHj" = (
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain)
 "fHm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -79903,6 +76198,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
+"fJd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "fJj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79949,20 +76264,43 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/construction)
-"fKc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
+"fJS" = (
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
+"fKi" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Construction";
+	dir = 1;
+	name = "Construction RC";
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/construction/mining/aux_base)
 "fKq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/status_display/ai{
@@ -80192,6 +76530,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
+"fNF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/newscaster/security_unit{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fNM" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 9
@@ -80254,6 +76601,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"fPl" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fPn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -80349,6 +76712,21 @@
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space)
+"fRf" = (
+/obj/structure/chair/wood,
+/obj/machinery/camera{
+	c_tag = "Chapel - Starboard";
+	dir = 8;
+	name = "chapel camera"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel{
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "fRp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -80362,6 +76740,14 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"fRt" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain/private)
 "fRy" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/delivery,
@@ -80444,6 +76830,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
+"fSF" = (
+/obj/structure/table/wood,
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Head of Security"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "fSK" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Storage";
@@ -80783,6 +77193,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
+"fXU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "fXX" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Fore Primary Hallway"
@@ -80880,6 +77304,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
+"gaT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Science - Lab Access";
+	dir = 8;
+	name = "science camera";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "gbq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/highsecurity{
@@ -80913,6 +77354,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gcn" = (
+/obj/structure/table/wood,
+/obj/item/folder/blue{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/folder/red,
+/obj/item/stamp/law,
+/obj/machinery/photocopier/faxmachine/longrange{
+	department = "Internal Affairs"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/lawoffice)
 "gcz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -80967,19 +77421,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
-"gdH" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "gdI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -81322,6 +77763,14 @@
 	},
 /turf/open/space,
 /area/solar/starboard/fore)
+"giI" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "gjk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -81356,19 +77805,6 @@
 	icon_state = "wood-broken7"
 	},
 /area/crew_quarters/dorms)
-"gjA" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "gjD" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
@@ -81484,6 +77920,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"glx" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "glK" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -81523,6 +77973,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"gmf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "gmn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -81627,6 +78087,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"gnZ" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab/range)
 "gof" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -81693,6 +78160,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"gpU" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "gpX" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 10
@@ -81808,6 +78293,28 @@
 	heat_capacity = 1e+006
 	},
 /area/engine/storage_shared)
+"grm" = (
+/obj/structure/table/glass,
+/obj/item/flashlight/lamp,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "grn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -81817,6 +78324,36 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
+"grS" = (
+/obj/machinery/turretid{
+	icon_state = "control_stun";
+	name = "AI Chamber turret control";
+	pixel_x = 3;
+	pixel_y = -23
+	},
+/obj/machinery/door/window{
+	base_state = "leftsecure";
+	dir = 8;
+	icon_state = "leftsecure";
+	name = "Primary AI Core Access";
+	req_access_txt = "16"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "grV" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -81849,6 +78386,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"gss" = (
+/obj/machinery/doppler_array/research/science{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = -31
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "gsx" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -81981,6 +78531,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"gug" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/obj/machinery/cell_charger,
+/obj/machinery/light_switch{
+	pixel_x = -8;
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	pixel_x = 5;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/science/lab)
 "gum" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -82071,6 +78641,17 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
+"gwk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gwu" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/machinery/status_display/evac{
@@ -82124,6 +78705,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"gxu" = (
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/head_of_personnel)
 "gxY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -82226,6 +78817,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"gAX" = (
+/obj/structure/chair/wood,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel{
+	icon_state = "chapel"
+	},
+/area/chapel/main)
+"gBl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/newscaster/security_unit{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gBq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -82314,6 +78928,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/aft)
+"gCH" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "gCK" = (
 /turf/closed/wall,
 /area/maintenance/department/science)
@@ -82372,6 +79010,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"gDA" = (
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower"
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "gDF" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "evashutters2";
@@ -82614,22 +79264,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"gIc" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmospherics_engine)
 "gIC" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -82671,6 +79305,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gJr" = (
+/obj/structure/closet/radiation,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gJx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -82711,6 +79360,39 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"gJW" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/department/electrical)
+"gKa" = (
+/obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	dir = 1;
+	name = "Head of Security RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "gKb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -82882,6 +79564,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science)
+"gNz" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "gNB" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemisttop";
@@ -83294,6 +79998,25 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/maintenance/disposal/incinerator)
+"gTm" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "gTr" = (
 /obj/machinery/door/airlock{
 	name = "Courtroom"
@@ -83333,23 +80056,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/bridge/showroom/corporate)
-"gTH" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "gTK" = (
 /obj/machinery/door/airlock/security{
 	name = "Armoury";
@@ -83626,6 +80332,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"gXt" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/suit_storage_unit/atmos,
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "gXw" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -83666,6 +80381,29 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
+"gXT" = (
+/obj/machinery/camera{
+	c_tag = "Science - Experimentation Lab";
+	name = "science camera";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/explab)
 "gXZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -83832,6 +80570,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"haw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
 "haM" = (
 /obj/item/radio/intercom{
 	pixel_y = 26
@@ -84032,6 +80785,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hhq" = (
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/cmo)
 "hhr" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -84054,6 +80821,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"hhA" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "hib" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -84133,6 +80907,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/surgery)
+"hjx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "hjL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -84266,6 +81057,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"hlx" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/iv_drip,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "hlP" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre/abandoned";
@@ -84278,6 +81085,20 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
+"hlX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "hmb" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -84662,6 +81483,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"hpr" = (
+/obj/structure/closet/l3closet/janitor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Custodial Closet";
+	name = "service camera"
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Custodial Closet";
+	dir = 1;
+	name = "Custodial RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "hpO" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/engine/atmos";
@@ -84679,6 +81526,16 @@
 	dir = 1
 	},
 /area/engine/atmos)
+"hpZ" = (
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/pen,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/hallway/secondary/service)
 "hqe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -84815,6 +81672,28 @@
 	dir = 1
 	},
 /area/engine/atmos)
+"hsg" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Virology - Cells";
+	dir = 8;
+	name = "virology camera";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "hsn" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -85040,6 +81919,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"hvH" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar/atrium)
 "hvJ" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/hallway/secondary/exit/departure_lounge";
@@ -85578,6 +82475,24 @@
 	heat_capacity = 1e+006
 	},
 /area/maintenance/port/aft)
+"hFj" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
 "hFu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -85664,6 +82579,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
+"hHF" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "hHQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -86155,23 +83082,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/science/misc_lab)
-"hPc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hPA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/junction/flip{
@@ -86261,6 +83171,15 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
+"hSe" = (
+/obj/structure/rack,
+/obj/item/storage/belt/utility,
+/obj/item/weldingtool,
+/obj/item/clothing/head/welding,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "hSQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -86289,6 +83208,25 @@
 	},
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
+"hTR" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/explab)
 "hTV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -86387,6 +83325,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"hVQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar/atrium)
 "hVR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -86561,6 +83519,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
+"hYD" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "hYZ" = (
 /obj/machinery/door/airlock{
 	name = "Hydroponics Backroom";
@@ -86903,6 +83872,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"iem" = (
+/obj/structure/table/glass,
+/obj/item/clipboard,
+/obj/item/toy/figure/botanist,
+/obj/effect/turf_decal/bot,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "ieQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -87073,35 +84053,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"igG" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "iho" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -87133,27 +84084,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"ihs" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "ihB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -87314,8 +84244,7 @@
 /area/science/lab)
 "ikB" = (
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
@@ -87340,6 +84269,25 @@
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"ikR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Aft";
+	name = "atmospherics camera"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "ilu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -87595,6 +84543,23 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"iqb" = (
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "iqk" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -87721,24 +84686,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
-"isU" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/execution/transfer)
 "itc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -88134,6 +85081,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
+"izy" = (
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/obj/machinery/light_switch{
+	pixel_x = 25;
+	pixel_y = -8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 27;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "izN" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen Coldroom";
@@ -88244,7 +85213,7 @@
 /area/storage/tech)
 "iAU" = (
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/green{
@@ -88558,6 +85527,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/virology)
+"iFy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "iFB" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Fore Primary Hallway"
@@ -88579,6 +85559,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"iFV" = (
+/obj/machinery/computer/message_monitor{
+	dir = 4
+	},
+/obj/item/paper/monitorkey,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
+"iGb" = (
+/obj/structure/bed,
+/obj/item/bedsheet/head_of_personnel,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/heads/head_of_personnel)
 "iGM" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -88842,27 +85852,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"iKs" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "iLh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -89049,22 +86038,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
-"iOn" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "iOr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -89465,6 +86438,22 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
+"iUy" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/masks,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "iUB" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -32
@@ -89486,8 +86475,7 @@
 "iUZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -89674,6 +86662,25 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"iXL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/toilet/restrooms)
 "iYj" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Warden's Office";
@@ -89858,6 +86865,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"jas" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/genetics)
 "jbb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/yellow{
@@ -89865,6 +86879,28 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/maintenance/disposal/incinerator)
+"jbd" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave{
+	desc = "Cooks and boils stuff, somehow.";
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "jbm" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
@@ -89881,6 +86917,15 @@
 /obj/structure/cable/white,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"jbX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "jce" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -89965,6 +87010,18 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"jcS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plating,
+/area/security/detectives_office/private_investigators_office)
 "jcV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -90010,23 +87067,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
-"jdv" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/courtroom)
 "jdx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -90187,6 +87227,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"jfd" = (
+/obj/item/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Fore";
+	name = "engineering camera"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jfj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -90330,6 +87392,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"jgk" = (
+/obj/structure/closet/secure_closet/medical1,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = -6
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/medical/virology)
 "jgm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -90377,6 +87457,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"jhr" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "jhA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -90424,6 +87519,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
+"jie" = (
+/obj/structure/table/wood,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/obj/item/flashlight/lamp/bananalamp{
+	pixel_y = 5
+	},
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/obj/item/toy/figure/clown,
+/obj/item/clipboard,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "jin" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/shutters,
@@ -90837,6 +87960,15 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
+"jpo" = (
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "jpx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -91091,6 +88223,31 @@
 	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"jtc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/medical/medbay/central)
+"jtn" = (
+/obj/machinery/light_switch{
+	pixel_x = 32;
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "jtG" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/warning/nosmoking{
@@ -91187,7 +88344,7 @@
 	pixel_y = 32
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
@@ -91550,6 +88707,47 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
+"jBB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
+"jCb" = (
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "jDd" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab";
@@ -91704,6 +88902,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"jFB" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Incinerator";
+	name = "atmospherics camera"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/tank/toxins,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "jFK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -91826,6 +89050,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jHS" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25;
+	pixel_y = -1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "jIc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -91980,6 +89219,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
+"jLs" = (
+/obj/structure/table/wood,
+/obj/item/lipstick/random{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/lipstick/random{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/lipstick/random,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = -32
+	},
+/obj/machinery/requests_console{
+	department = "Theatre Backstage";
+	dir = 8;
+	name = "Theatre RC";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/theatre)
 "jLN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92547,12 +89808,22 @@
 	heat_capacity = 1e+006
 	},
 /area/maintenance/port)
-"jWk" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
+"jVU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain/private)
+"jWP" = (
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/structure/table/reinforced,
+/obj/machinery/camera{
+	c_tag = "Bridge - E.V.A. Fore";
+	name = "command camera"
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -92563,11 +89834,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/office)
+/area/ai_monitored/storage/eva)
 "jXg" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -92651,6 +89923,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"jYL" = (
+/obj/machinery/light_switch{
+	pixel_x = -21;
+	pixel_y = -31
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "jZi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -92911,14 +90196,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"kdy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/space/basic,
-/area/space)
 "kdB" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
@@ -93131,6 +90408,30 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"khQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/stack/packageWrap,
+/obj/item/crowbar,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "khX" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
@@ -93236,6 +90537,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
+"kjM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kjQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -93472,6 +90787,43 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"koG" = (
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "cmoshutter";
+	name = "CMO Office Shutters";
+	pixel_x = 7;
+	pixel_y = -26;
+	req_access_txt = "40"
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = 7;
+	pixel_y = -38
+	},
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = -25
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	dir = 4;
+	name = "Chief Medical Officer's RC";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
+/area/crew_quarters/heads/cmo)
 "koH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -93529,6 +90881,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"kpQ" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clipboard,
+/obj/item/toy/figure/miner,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "kqw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
@@ -93648,6 +91018,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"kss" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/grimy,
+/area/vacant_room/office)
 "ksQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -93774,8 +91151,7 @@
 "kvh" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch{
-	pixel_x = 22;
-	pixel_y = -10
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -93852,6 +91228,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"kwn" = (
+/obj/machinery/light_switch{
+	pixel_x = 25;
+	pixel_y = 31
+	},
+/obj/effect/landmark/start/head_of_personnel,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/heads/head_of_personnel)
 "kwC" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -93859,6 +91246,20 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
+"kwT" = (
+/obj/machinery/vending/assist,
+/obj/machinery/camera{
+	c_tag = "Primary Tool Storage";
+	dir = 4;
+	name = "engineering camera"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "kwW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -94172,6 +91573,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"kDu" = (
+/obj/item/stack/cable_coil,
+/obj/item/bodypart/r_arm/robot{
+	pixel_x = 3
+	},
+/obj/item/bodypart/l_arm/robot{
+	pixel_x = -3
+	},
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "kDw" = (
 /obj/machinery/door/airlock/command{
 	name = "E.V.A. Storage";
@@ -94316,6 +91738,17 @@
 /obj/item/weldingtool/largetank,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"kGt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kGF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -94459,6 +91892,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"kJy" = (
+/obj/structure/table/wood,
+/obj/item/storage/briefcase{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/secure/briefcase,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/library)
 "kJO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -94542,21 +91998,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"kLu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "kLE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -94648,13 +92089,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"kNm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/medical/genetics)
 "kNp" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/shutters,
@@ -95001,6 +92435,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"kTg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/science/storage)
 "kTh" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Service Hallway Maintenance Hatch";
@@ -95133,6 +92580,31 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"kUP" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/button/door{
+	id = "transitlock";
+	name = "Transit Tube Lockdown Control";
+	pixel_y = 26;
+	req_access_txt = "19"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "kUQ" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -95151,6 +92623,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"kUV" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/rglass{
+	amount = 50;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "kUY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/westright{
@@ -95215,6 +92705,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"kVt" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/security/main)
 "kVA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -95323,6 +92819,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"kWD" = (
+/obj/structure/filingcabinet/medical,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs/auxiliary)
 "kWR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -95438,29 +92949,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"kYP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 32
-	},
-/obj/machinery/power/terminal{
+"kYT" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/machinery/newscaster{
+	pixel_x = 29;
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/security/checkpoint/customs/auxiliary)
 "kZm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -95745,6 +93250,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ldr" = (
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/item/toy/figure/detective,
+/obj/structure/sign/poster/official/report_crimes{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/detectives_office)
 "lec" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -95825,7 +93353,7 @@
 /area/quartermaster/storage)
 "lfH" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -26
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -96156,8 +93684,7 @@
 /area/hallway/primary/central)
 "lmD" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -32;
-	pixel_y = -64
+	pixel_y = -30
 	},
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -96180,6 +93707,23 @@
 /obj/machinery/particle_accelerator/control_box,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"lnl" = (
+/obj/structure/table/glass,
+/obj/item/folder/white,
+/obj/item/pen/red,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/requests_console{
+	department = "Virology Lab";
+	dir = 1;
+	name = "Virology RC";
+	pixel_y = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel,
+/area/medical/virology)
 "loc" = (
 /turf/open/floor/plasteel,
 /area/medical/surgery/room_b)
@@ -96370,6 +93914,53 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"lsW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/disposal/bin,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
+"lte" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "lti" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped,
 /obj/effect/turf_decal/tile/neutral{
@@ -96463,6 +94054,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"luJ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/bombcloset/white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/explab)
 "luM" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "engdoor";
@@ -96700,12 +94312,44 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"lyw" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "lyU" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"lzi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "lzn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/cyborg,
@@ -97010,6 +94654,27 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"lCu" = (
+/obj/structure/dresser,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "lCC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -97834,6 +95499,19 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"lUw" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "lUN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
@@ -97881,6 +95559,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"lUZ" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 29
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "lVe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -97945,6 +95634,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"lVW" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 5
+	},
+/turf/open/floor/plating,
+/area/medical/morgue)
+"lWf" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "lWr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/atmos{
@@ -98129,6 +95836,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"lZO" = (
+/obj/machinery/keycard_auth{
+	pixel_x = 26;
+	pixel_y = 26
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs)
 "mag" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue,
@@ -98497,6 +96223,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"mhi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "mhp" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -98578,6 +96322,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
+"miH" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/clothing/mask/gas,
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/science/storage)
 "miP" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -99086,6 +96846,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"mox" = (
+/obj/machinery/camera{
+	c_tag = "Engineering - Chief Engineer's Office";
+	dir = 4;
+	name = "engineering camera"
+	},
+/obj/machinery/computer/apc_control{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 5;
+	dir = 8;
+	name = "Chief Engineer's RC";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "moL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -99257,6 +97046,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/morgue)
+"mrx" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "msg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -99784,6 +97585,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mBy" = (
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "mBM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -99826,6 +97646,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"mDf" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
+/area/crew_quarters/locker)
 "mDu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -100072,24 +97910,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"mGU" = (
-/obj/structure/table/reinforced,
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
-/obj/item/clipboard,
-/obj/item/toy/figure/secofficer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "mGV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -100114,6 +97934,26 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/lawoffice)
+"mHp" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "mHt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -100149,13 +97989,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"mHL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "mHM" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -100241,7 +98074,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery/room_b)
@@ -100305,6 +98138,31 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"mJI" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Theatre Backstage";
+	dir = 8;
+	name = "service camera"
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 27;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "mJJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -100348,6 +98206,23 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/plasteel/dark/corner,
 /area/maintenance/disposal/incinerator)
+"mJZ" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25;
+	pixel_y = -1
+	},
+/obj/machinery/button/door{
+	id = "xeno6";
+	name = "Containment Control";
+	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "mKc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -100538,23 +98413,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"mMI" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "mMY" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/snack/random,
@@ -100616,6 +98474,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
+"mNq" = (
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/teleporter)
 "mOw" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Access"
@@ -100679,6 +98548,44 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"mQs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/nanite_scanner{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/nanite_scanner{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/nanite_remote{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/nanite_remote{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "mQD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -100792,6 +98699,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"mTh" = (
+/obj/item/stack/sheet/plasteel{
+	amount = 15
+	},
+/obj/item/wrench,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/clothing/glasses/welding,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -22;
+	pixel_y = -9
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "mTk" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -100820,6 +98750,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"mTO" = (
+/obj/item/kirbyplants/random,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_x = -5;
+	pixel_y = -41
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "mTR" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -100893,6 +98841,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"mUO" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -13;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "mUU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -100939,6 +98902,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
+"mVG" = (
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room/council)
 "mVR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -101300,6 +99275,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mZX" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
+"naf" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "nan" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -101534,6 +99543,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"ndh" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 31;
+	pixel_y = -30
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nds" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable/white{
@@ -101610,6 +99637,16 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"nel" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "nem" = (
 /obj/machinery/door/poddoor{
 	id = "engstorage";
@@ -101846,7 +99883,7 @@
 /obj/item/book/manual/wiki/experimentor,
 /obj/item/healthanalyzer,
 /obj/machinery/light_switch{
-	pixel_x = -26
+	pixel_y = -23
 	},
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
@@ -101869,6 +99906,23 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"nhQ" = (
+/obj/structure/table/reinforced,
+/obj/item/tank/internals/plasma,
+/obj/machinery/light/small,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmospherics_engine)
 "nig" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -102046,23 +100100,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"nmf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/engine/atmos)
 "nmC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -102181,6 +100218,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"npj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"npr" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/bookmanagement,
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/library)
 "npL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -102263,28 +100318,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"nqw" = (
-/obj/machinery/computer/crew,
-/obj/machinery/requests_console{
-	department = "Security";
-	name = "Security RC";
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/warden)
 "nqR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -102501,6 +100534,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/janitor)
+"ntX" = (
+/obj/machinery/light_switch{
+	pixel_x = 32;
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/head_of_personnel)
 "nul" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -102862,6 +100906,20 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"nzy" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "nzF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "permacell2";
@@ -102979,6 +101037,30 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
+"nAy" = (
+/obj/machinery/disposal/bin,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "nAE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -103129,6 +101211,64 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"nCQ" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/mesh,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/explab)
+"nCS" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"nDb" = (
+/obj/machinery/newscaster{
+	pixel_x = -32;
+	pixel_y = -29
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "nDc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -103349,6 +101489,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre/abandoned)
+"nIp" = (
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/wood,
+/area/library)
 "nIE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -103468,6 +101615,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"nKI" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal{
+	amount = 30
+	},
+/obj/item/stack/packageWrap,
+/obj/item/stack/sheet/glass{
+	amount = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/construction)
 "nKO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -103869,26 +102033,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"nSF" = (
-/obj/item/kirbyplants/random,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/execution/transfer)
 "nSU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -104027,6 +102171,19 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
+"nUA" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/storage/bag/bio,
+/obj/item/storage/bag/bio,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "nUK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -104042,6 +102199,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"nUO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain)
 "nVq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -104189,7 +102354,7 @@
 /area/medical/medbay/central)
 "nXK" = (
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/bz,
@@ -104218,6 +102383,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"nYa" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/medical/genetics)
 "nYn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -104307,16 +102481,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"oaf" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 32
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/main)
 "oap" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/science/robotics/mechbay";
@@ -104476,6 +102640,26 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"oeQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "oeX" = (
 /obj/structure/sink{
 	dir = 4;
@@ -104788,6 +102972,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"oiy" = (
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/reagent_containers/glass/rag,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Bar Counter";
+	dir = 1;
+	name = "Bar RC";
+	pixel_y = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "oiJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -104906,8 +103117,7 @@
 /area/security/detectives_office)
 "olx" = (
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -105190,6 +103400,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"oqS" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/requests_console{
+	department = "Medbay Storage";
+	dir = 1;
+	name = "Medbay Storage RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "oqW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -105629,6 +103855,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"oxQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "oyx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
@@ -105664,6 +103900,26 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
+"oyW" = (
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "ozb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -105800,6 +104056,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"oBD" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
 "oBJ" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Auxiliary Port";
@@ -105990,6 +104255,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"oFr" = (
+/obj/structure/chair{
+	dir = 8;
+	name = "Judge"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "oFw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -106231,6 +104520,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"oJW" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/taperecorder{
+	pixel_x = 3
+	},
+/obj/item/clothing/glasses/sunglasses,
+/obj/machinery/button/door{
+	id = "lawyerprivacy";
+	name = "Lawyer's Privacy Control";
+	pixel_y = 24
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "oKa" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Customs Desk";
@@ -106500,6 +104808,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/virology)
+"oOU" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/yellow,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "oPf" = (
 /obj/effect/landmark/start/lieutenant,
 /turf/open/floor/wood,
@@ -106630,7 +104959,7 @@
 /area/hydroponics)
 "oRB" = (
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -107163,27 +105492,6 @@
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"oYK" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 20
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	name = "MiniSat APC";
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/white,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "oYU" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -107196,6 +105504,14 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/bridge/showroom/corporate)
+"oZm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plating,
+/area/security/detectives_office/private_investigators_office)
 "oZp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -107240,21 +105556,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"paR" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/lawoffice)
 "paV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -107288,6 +105589,51 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"pbx" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/machinery/camera{
+	c_tag = "Cargo - Office";
+	name = "cargo camera"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Cargo Office";
+	dir = 1;
+	name = "Cargo Office RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"pcg" = (
+/obj/structure/table/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Engineer"
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "pct" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -107402,18 +105748,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
-"pfk" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain/private)
 "pfl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/corner{
@@ -107477,6 +105811,16 @@
 	},
 /turf/open/floor/plating,
 /area/bridge/showroom/corporate)
+"pfR" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/vacant_room/office)
 "pfV" = (
 /obj/machinery/gulag_item_reclaimer{
 	pixel_y = 28
@@ -107568,6 +105912,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"pha" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
+/obj/effect/landmark/start/captain,
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "phC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -107700,27 +106057,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
-"pkx" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "pkF" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -107902,6 +106238,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"pnD" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmospherics_engine)
 "pnT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -107933,24 +106278,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"poi" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
-/area/crew_quarters/locker)
 "pop" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -107967,6 +106294,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
+"pot" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "poO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -108006,6 +106347,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"ppp" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/item/book/manual/wiki/tcomms,
+/obj/item/wrench,
+/obj/item/screwdriver{
+	pixel_y = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/tcommsat/server)
 "ppu" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engpa";
@@ -108043,6 +106399,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
+"ppQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ppU" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmoslock";
@@ -108080,6 +106449,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"pqC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pqL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -108182,6 +106561,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard)
+"prM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "prV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -109274,6 +107662,15 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"pLy" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/dark,
+/area/library)
 "pLE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -109311,6 +107708,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"pMs" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/storage/tech)
 "pMz" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 8
@@ -110161,16 +108567,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
-"qcx" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+"qcP" = (
+/obj/machinery/button/door{
+	id = "corporatelounge";
+	name = "Corporate Lounge Shutters";
+	pixel_x = -7;
+	pixel_y = -26
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/light_switch{
+	pixel_x = 6;
+	pixel_y = -25
 	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
+/obj/item/kirbyplants/random,
+/obj/machinery/light,
+/turf/open/floor/plasteel/grimy,
+/area/bridge/showroom/corporate)
 "qcU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -110396,6 +108807,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"qfL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = -29
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "qgd" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -110468,6 +108896,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"qhu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
 "qhA" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Command Hallway"
@@ -110497,6 +108934,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden/abandoned)
+"qhZ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "qiw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -110597,6 +109051,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"qkq" = (
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "qlk" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -110604,6 +109075,25 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"qll" = (
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar/atrium)
 "qln" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -110674,6 +109164,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"qlZ" = (
+/obj/structure/closet/bombcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "qmb" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "cargocell";
@@ -110920,6 +109421,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"qqi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "qqw" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -111052,17 +109569,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
-"qtr" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/head_of_personnel)
 "qtV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -111076,8 +109582,7 @@
 "quc" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
+	pixel_x = 26
 	},
 /obj/machinery/status_display/evac{
 	pixel_y = -32
@@ -111332,6 +109837,31 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"qwN" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/white,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker,
+/obj/item/reagent_containers/dropper,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/reagent_containers/dropper,
+/obj/machinery/requests_console{
+	department = "Xenobiology Lab";
+	dir = 4;
+	name = "Xenobiology RC";
+	pixel_x = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "qxd" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -111560,6 +110090,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
+"qBH" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/library)
 "qBM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -111684,6 +110232,23 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
+"qDQ" = (
+/obj/structure/filingcabinet/security,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint)
 "qDZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden,
@@ -111804,6 +110369,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"qFx" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/toy/figure/rd,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Research Director's Desk";
+	departmentType = 5;
+	dir = 8;
+	name = "Research Director's RC";
+	pixel_x = -32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hor)
 "qFC" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -111833,6 +110417,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qFZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Security - Brig Fore";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qGf" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -112052,6 +110652,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/virology)
+"qJz" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "qJB" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -112141,6 +110766,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"qLl" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/beanbag,
+/obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_x = -7;
+	pixel_y = 30
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 7;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "qLE" = (
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /obj/machinery/air_sensor/atmos/carbon_tank,
@@ -112275,8 +110916,7 @@
 /area/maintenance/port/aft)
 "qMw" = (
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
@@ -112410,6 +111050,28 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qPJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "qPP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -112434,10 +111096,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"qQj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "qQI" = (
 /obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -112456,6 +111127,18 @@
 	},
 /turf/open/floor/plating,
 /area/teleporter)
+"qQN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qRq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/stripes/line{
@@ -112513,6 +111196,19 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"qRK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "qRU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -112926,6 +111622,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"qYO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmospherics_engine)
 "qYX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -113199,6 +111908,30 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"rdn" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Detective's Office";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/detectives_office)
 "rdT" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -113238,6 +111971,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"reA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plating,
+/area/quartermaster/warehouse)
 "reG" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
@@ -113283,6 +112024,29 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/port)
+"rfr" = (
+/obj/structure/table,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/bodybags,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "rfw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -113649,6 +112413,16 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
+"rkP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/science/storage)
 "rlc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -113690,26 +112464,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"rlG" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/detectives_office)
 "rma" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -113721,31 +112475,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
-"rml" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics - Incinerator";
-	name = "atmospherics camera"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/tank/toxins,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
 "rmn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -113861,6 +112590,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
+"rrb" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/kitchen)
 "rrw" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Transferring Control";
@@ -114207,6 +112943,42 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
+"ryC" = (
+/obj/structure/rack,
+/obj/item/storage/box/rubbershot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/rubbershot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/storage/box/rubbershot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ryK" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/structure/cable{
@@ -114277,25 +113049,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rzX" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
-	},
-/obj/machinery/shower{
-	dir = 8;
-	name = "emergency shower"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/medical/virology)
 "rzY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -114471,6 +113224,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"rDd" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/dorms)
 "rDi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -114573,6 +113336,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"rEy" = (
+/obj/machinery/light_switch{
+	pixel_x = -22;
+	pixel_y = -31
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/heads/hos)
 "rEY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -114581,6 +113354,21 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"rFc" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bookcase/manuals/research_and_development,
+/obj/machinery/camera{
+	c_tag = "Library";
+	name = "library camera"
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/wood,
+/area/library)
 "rFt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -114719,6 +113507,27 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"rIJ" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "rIK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -114766,19 +113575,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"rJs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "rJv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -115032,7 +113828,7 @@
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light_switch{
-	pixel_x = 22
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
@@ -115243,6 +114039,20 @@
 	},
 /turf/open/floor/circuit/green,
 /area/engine/supermatter)
+"rSR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rSU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/neutral{
@@ -115296,6 +114106,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"rTV" = (
+/obj/structure/closet/emcloset,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch.";
+	id = "gulagdoor";
+	name = "Transfer Door Control";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = -8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "rUa" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -115328,6 +114161,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"rUF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rUJ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -115422,18 +114268,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"rVz" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "rVO" = (
 /obj/structure/chair{
 	dir = 4
@@ -115645,6 +114479,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"rZW" = (
+/obj/structure/closet/secure_closet/security/science,
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science/research)
 "saj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -115687,6 +114541,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"saP" = (
+/obj/machinery/photocopier,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/wood,
+/area/library)
 "saQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -115756,6 +114618,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"sbN" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/starboard/fore)
 "scA" = (
 /obj/structure/sign/warning/vacuum,
 /obj/structure/cable{
@@ -115858,6 +114739,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"seR" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/engine/atmos)
 "sfj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -116081,6 +114977,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"sgX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Quartermaster's Desk";
+	dir = 4;
+	name = "Quartermaster RC";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "sgY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -116235,6 +115151,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"sjJ" = (
+/obj/machinery/porta_turret/ai,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "sjS" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -116538,19 +115472,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"son" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "soC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -116655,6 +115576,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
+"sps" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "spt" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -116686,26 +115621,13 @@
 "spE" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
+	pixel_x = 26
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
-"spG" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "spN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -116883,6 +115805,25 @@
 	heat_capacity = 1e+006
 	},
 /area/crew_quarters/locker)
+"srO" = (
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table/reinforced,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/requests_console{
+	department = "Robotics Lab";
+	dir = 8;
+	name = "Robotics RC";
+	pixel_x = -32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "srY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -116949,6 +115890,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"stB" = (
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre/abandoned)
+"stE" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/toolbox/electrical,
+/obj/item/screwdriver{
+	pixel_y = 5
+	},
+/obj/item/multitool,
+/obj/item/clothing/head/welding,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "stV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -117135,6 +116105,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"syQ" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "syX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -117300,6 +116288,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"sDb" = (
+/obj/machinery/light_switch{
+	pixel_x = 32;
+	pixel_y = 25
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "sDk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -117595,6 +116604,25 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
+"sIZ" = (
+/obj/structure/table/reinforced,
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/item/analyzer{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "sJg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -117615,20 +116643,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/science/research)
-"sKb" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
 "sKl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgedoors";
@@ -117886,6 +116900,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"sNR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmospherics_engine)
 "sOe" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green{
@@ -118319,6 +117349,16 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"sXS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sYa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -118373,6 +117413,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"sYT" = (
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/target,
+/obj/item/target/syndicate,
+/obj/item/target/alien,
+/obj/item/target/clown,
+/obj/structure/closet/crate/secure{
+	desc = "A secure crate containing various materials for building a customised test-site.";
+	name = "Test Site Materials Crate";
+	req_access_txt = "63"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -40;
+	pixel_y = 2
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/light_switch{
+	pixel_x = -23;
+	pixel_y = -8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "sYX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -118520,7 +117592,7 @@
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -118662,27 +117734,6 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/space,
 /area/engine/atmos)
-"teZ" = (
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
 "tfj" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hall5";
@@ -118905,6 +117956,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/range)
+"tjW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bookcase/random,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/wood,
+/area/library)
 "tkp" = (
 /obj/machinery/telecomms/hub/preset,
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -118955,6 +118017,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"tkA" = (
+/obj/machinery/light_switch{
+	pixel_x = 32;
+	pixel_y = -23
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room/council)
 "tkO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -119134,6 +118207,37 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"tmQ" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/button/door{
+	id = "ceblast";
+	name = "Lockdown Control";
+	pixel_x = 26;
+	pixel_y = 26;
+	req_access_txt = "56"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "tmU" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -119284,6 +118388,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
+"tpp" = (
+/obj/structure/table/wood,
+/obj/item/storage/briefcase{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/briefcase,
+/obj/item/cane,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
 "tpv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -119699,6 +118817,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"tvi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "tvm" = (
 /obj/machinery/button/door{
 	id = "brigprison";
@@ -119759,6 +118891,26 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"tvJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar/atrium)
 "tvL" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -119997,6 +119149,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"tyh" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/dorms)
 "tyz" = (
 /obj/machinery/door/airlock{
 	name = "Locker Room"
@@ -120054,6 +119216,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/medical/virology)
+"tzj" = (
+/obj/machinery/monkey_recycler,
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "tzL" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/yellow{
@@ -120114,6 +119285,13 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
+/area/crew_quarters/heads/head_of_personnel)
+"tAF" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/heads/head_of_personnel)
 "tAV" = (
 /obj/machinery/door/poddoor/shutters{
@@ -120184,6 +119362,26 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
+"tBB" = (
+/obj/item/storage/toolbox/mechanical,
+/obj/item/flashlight,
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/poster/official/science{
+	pixel_x = -32
+	},
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/explab)
 "tBK" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -120252,6 +119450,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"tCY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/security/warden)
 "tDa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -120405,6 +119618,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
+"tFq" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/wood,
+/area/library)
 "tFM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -121004,6 +120226,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"tPP" = (
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = -30
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/bridge/meeting_room/council)
 "tQd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -121258,6 +120488,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"tVn" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Kitchen";
+	dir = 1;
+	name = "Kitchen RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
 "tVA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -121268,6 +120517,17 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"tVF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/toilet/auxiliary)
 "tVM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -121322,31 +120582,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"tXA" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "tXV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -121502,6 +120737,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"uad" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "uaf" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/status_display/ai{
@@ -121636,6 +120885,26 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/security/checkpoint/escape)
+"ucz" = (
+/obj/structure/table/wood,
+/obj/item/staff/broom,
+/obj/item/clothing/head/witchwig,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar/atrium)
 "udc" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -121800,6 +121069,25 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"ugO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "uhg" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -122206,6 +121494,18 @@
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"umE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "umH" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Mixing Lab";
@@ -122508,14 +121808,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"utg" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/atmos,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "uti" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Port Quarter Solar Access";
@@ -122657,8 +121949,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/light_switch{
-	pixel_x = -28;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -122859,6 +122150,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"uzO" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "uAk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -123125,7 +122431,7 @@
 /area/maintenance/port/aft)
 "uDj" = (
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -123157,6 +122463,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"uEg" = (
+/obj/machinery/computer/med_data{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Detective's Office";
+	dir = 4;
+	name = "Detective RC";
+	pixel_x = 32
+	},
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "uEt" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -123454,6 +122775,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
+"uJs" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
 "uJt" = (
 /obj/machinery/computer/med_data,
 /obj/effect/turf_decal/tile/blue{
@@ -123597,7 +122927,7 @@
 "uKF" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
@@ -123625,32 +122955,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
-"uKT" = (
-/obj/structure/rack,
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
-/obj/item/wrench,
-/obj/item/screwdriver,
-/obj/machinery/button/door{
-	id = "commissarydoor";
-	name = "Commissary Door Lock";
-	normaldoorcontrol = 1;
-	pixel_x = -5;
-	pixel_y = -26;
-	specialfunctions = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/stack/cable_coil/random/five,
-/turf/open/floor/plasteel,
-/area/vacant_room/commissary)
 "uLo" = (
 /obj/structure/table/reinforced,
 /obj/item/tank/jetpack/carbondioxide{
@@ -123734,6 +123038,20 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"uMx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light_switch{
+	pixel_x = -30;
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "uMy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -123773,25 +123091,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"uMN" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/vacant_room/commissary)
 "uMO" = (
 /obj/machinery/door/airlock{
 	name = "Bar Backroom";
@@ -123847,6 +123146,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"uNk" = (
+/obj/structure/closet/radiation,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmospherics_engine)
 "uNt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -123933,7 +123242,7 @@
 /area/crew_quarters/dorms)
 "uON" = (
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -124095,6 +123404,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"uRU" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "uSK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -124138,6 +123457,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/range)
+"uUf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/library)
 "uUu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -124244,6 +123583,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"uXn" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "uXr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -124338,6 +123686,22 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"uZm" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "uZz" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -124573,8 +123937,7 @@
 /area/construction/mining/aux_base)
 "vef" = (
 /obj/machinery/light_switch{
-	pixel_x = 10;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -124653,6 +124016,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"vgv" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "vgC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -124670,6 +124048,18 @@
 	},
 /turf/open/floor/plating,
 /area/bridge/meeting_room/council)
+"vgE" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/bot,
+/obj/machinery/requests_console{
+	department = "Primary Tool Storage";
+	dir = 1;
+	name = "Primary Tool Storage RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "vgG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/terminal{
@@ -124680,6 +124070,20 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"vgK" = (
+/obj/structure/table,
+/obj/item/storage/belt,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "vhK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -124698,6 +124102,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vhP" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar/atrium)
 "vhZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -124836,6 +124258,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/space,
 /area/space/nearstation)
+"vjH" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/toy/figure/engineer,
+/obj/effect/turf_decal/bot,
+/obj/machinery/requests_console{
+	department = "Engineering";
+	dir = 8;
+	name = "Engineering RC";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vjS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
@@ -124965,6 +124400,21 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"vmz" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "vmC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -125625,6 +125075,28 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"vxc" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/cmo)
+"vyc" = (
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/razor,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/dorms)
 "vyn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -125665,6 +125137,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"vyV" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmospherics_engine)
 "vzc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -125688,6 +125172,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
+"vze" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil,
+/obj/item/multitool,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/department/electrical)
 "vzk" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -125896,6 +125395,33 @@
 	},
 /turf/open/floor/plating,
 /area/teleporter)
+"vBW" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/yellow,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"vBZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/computer/bounty{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "vCa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -126092,6 +125618,27 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/fitness/recreation)
+"vHv" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = -23;
+	pixel_y = -15
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vHN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -126332,6 +125879,17 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"vKh" = (
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/machinery/vending/assist,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab/range)
 "vKi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -126455,6 +126013,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"vLt" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/aft)
 "vLE" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -126813,8 +126398,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "vSo" = (
 /obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -127158,6 +126742,20 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
+"vZe" = (
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/item/wrench,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "vZi" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
@@ -127301,6 +126899,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/medical/morgue)
+"wbC" = (
+/obj/structure/table/wood,
+/obj/item/camera_film{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/camera_film,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/grimy,
+/area/library)
 "wbM" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_x = 32;
@@ -127452,6 +127063,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"wfc" = (
+/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "wfG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -127823,6 +127452,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"wlE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "wlJ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -127862,24 +127502,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
-"wms" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "wmx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -128100,6 +127722,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"wph" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "wpo" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -128372,6 +128013,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"wsH" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "wsM" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "construction";
@@ -128871,6 +128521,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wDm" = (
+/obj/machinery/vending/snack/random,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "wDG" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -128878,6 +128549,24 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/gateway)
+"wDV" = (
+/obj/structure/table/reinforced,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = -32
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/obj/machinery/recharger,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "wDW" = (
 /obj/machinery/door/window/brigdoor{
 	id = "medcell";
@@ -128980,6 +128669,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wEU" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 20
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	name = "MiniSat APC";
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/white,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "wFF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -129274,6 +128985,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"wJb" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/machinery/chem_master/condimaster{
+	name = "BrewMaster 3000"
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "wJq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -129331,6 +129056,24 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"wJM" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -129562,6 +129305,29 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"wNN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4"
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"wNY" = (
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre/abandoned)
 "wOy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -129677,6 +129443,30 @@
 	},
 /turf/open/space,
 /area/solar/port/aft)
+"wQh" = (
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/obj/structure/closet/secure_closet/security/med,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 5
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/medical)
 "wQo" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -129732,6 +129522,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
+"wRl" = (
+/obj/machinery/camera{
+	c_tag = "Science - Research and Development";
+	dir = 8;
+	name = "science camera";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/requests_console{
+	department = "Research Lab";
+	dir = 4;
+	name = "Research RC";
+	pixel_x = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "wRt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -129847,6 +129654,25 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"wTE" = (
+/obj/machinery/computer/robotics{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = -5;
+	pixel_y = -26
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hor)
 "wUv" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -130086,6 +129912,28 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"wYJ" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "wYL" = (
 /obj/item/beacon,
 /obj/structure/disposalpipe/segment,
@@ -130137,6 +129985,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"wZJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wZX" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Science Maintenance";
@@ -130522,6 +130383,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"xgU" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/wrench,
+/obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "xha" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -130562,6 +130438,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"xhy" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "xhL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -130920,6 +130810,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"xom" = (
+/obj/machinery/camera/motion{
+	c_tag = "E.V.A. Storage";
+	dir = 8;
+	name = "motion-sensitive command camera"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "E.V.A. Storage";
+	dir = 4;
+	name = "E.V.A. RC";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "xoF" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -130959,6 +130867,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"xpl" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/beakers{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/syringes,
+/obj/item/radio/intercom{
+	pixel_y = 32
+	},
+/obj/item/extinguisher/mini,
+/obj/effect/turf_decal/delivery,
+/obj/item/storage/box/monkeycubes,
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "xpr" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
@@ -131115,6 +131042,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"xti" = (
+/obj/machinery/vending/wardrobe/law_wardrobe,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "xtr" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 25
@@ -131144,6 +131079,14 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
+"xuJ" = (
+/obj/structure/dresser,
+/obj/machinery/newscaster/security_unit{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "xuT" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -131262,6 +131205,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
+"xwM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xxx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -131720,6 +131674,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"xGl" = (
+/obj/machinery/vending/snack/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "xHl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -131796,6 +131760,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"xIf" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light_switch{
+	pixel_x = -22;
+	pixel_y = -36
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = -26;
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/warden)
 "xIQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -131939,12 +131921,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"xKH" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab/range)
 "xLk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -132112,13 +132088,11 @@
 /area/engine/gravity_generator)
 "xOM" = (
 /obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -38;
-	pixel_y = -24
+	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -132379,6 +132353,59 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"xUB" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Personnel's Desk";
+	departmentType = 5;
+	name = "Head of Personnel RC";
+	pixel_x = 32;
+	pixel_y = 27
+	},
+/obj/machinery/light_switch{
+	pixel_x = -37;
+	pixel_y = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/obj/machinery/button/door{
+	id = "foline";
+	name = "Queue Shutters Control";
+	pixel_x = -26;
+	pixel_y = -7;
+	req_access_txt = "57"
+	},
+/obj/machinery/button/door{
+	id = "foblast";
+	name = "Lockdown Blast doors";
+	pixel_x = -26;
+	pixel_y = 7;
+	req_access_txt = "57"
+	},
+/obj/machinery/button/flasher{
+	id = "foflash";
+	pixel_x = -38;
+	pixel_y = -7;
+	req_access_txt = "28"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/button/ticket_machine{
+	pixel_y = 40
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/head_of_personnel)
 "xUO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -132658,6 +132685,18 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
+"xYF" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/utility,
+/obj/item/weldingtool,
+/obj/item/clothing/head/welding,
+/obj/effect/turf_decal/bot,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "xYJ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -132840,6 +132879,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"yct" = (
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/item/reagent_containers/dropper,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay - Chemistry";
+	dir = 8;
+	name = "medbay camera";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "ydw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -133387,6 +133452,35 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"ykv" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/library)
+"ykH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "ykP" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Checkpoint";
@@ -133410,6 +133504,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
+"ykR" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/warden)
 "ylc" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -139547,7 +139648,7 @@ bRy
 bTo
 jpA
 vER
-oYK
+wEU
 bPC
 bkE
 bLu
@@ -140574,7 +140675,7 @@ bPC
 bRC
 bTs
 ivE
-bXY
+rIJ
 cad
 bPC
 cdt
@@ -141340,7 +141441,7 @@ bFS
 bCq
 bCq
 neu
-bNw
+ugO
 bPC
 bRF
 bTu
@@ -141592,7 +141693,7 @@ tZx
 wao
 bAB
 btH
-bEi
+grS
 btH
 btH
 bJH
@@ -142633,7 +142734,7 @@ qww
 bYg
 caj
 bPC
-cdA
+sjJ
 cft
 wSo
 ciX
@@ -143144,7 +143245,7 @@ bPC
 bRF
 bTB
 qok
-bYh
+eYm
 cak
 bPC
 cdt
@@ -143674,7 +143775,7 @@ crH
 brN
 aad
 aaa
-kdy
+aaa
 aaa
 aaa
 aaa
@@ -144686,7 +144787,7 @@ bmD
 bRN
 bTF
 ndt
-bYi
+gCH
 brS
 bmD
 boe
@@ -153159,7 +153260,7 @@ jvq
 wVJ
 uPy
 bGb
-bHS
+vZe
 bxC
 aad
 aad
@@ -154184,7 +154285,7 @@ abj
 bxC
 kKz
 xXL
-gdH
+glx
 hKe
 bGa
 bHR
@@ -154697,10 +154798,10 @@ aRF
 qYo
 nBr
 qWg
-mHL
+aJQ
 dor
 lLg
-qcx
+oxQ
 gWT
 bLF
 fBY
@@ -155217,7 +155318,7 @@ tmN
 bGe
 fgG
 bJP
-bLK
+kUP
 bNN
 kvh
 bRX
@@ -155733,7 +155834,7 @@ bHV
 bJQ
 bLL
 bNO
-bPQ
+mox
 bRY
 bTP
 bWf
@@ -155953,7 +156054,7 @@ awa
 aDl
 azN
 aFr
-rml
+jFB
 pXF
 gAm
 jbb
@@ -155987,7 +156088,7 @@ bxG
 lmy
 nBr
 bHV
-bJR
+aVJ
 bLM
 bNP
 bPR
@@ -156501,7 +156602,7 @@ bCM
 wgX
 bGi
 bHV
-bJT
+pcg
 bLN
 bNR
 ccL
@@ -157015,7 +157116,7 @@ enB
 iXf
 bGk
 bHV
-bJV
+tmQ
 sAM
 sfj
 pTD
@@ -157237,9 +157338,9 @@ aAQ
 awb
 awb
 auT
-aFt
+nhQ
 aFr
-aIy
+mUO
 hFD
 aLm
 aMF
@@ -157533,7 +157634,7 @@ sKP
 oif
 rIo
 bHV
-bSd
+syQ
 btr
 bWm
 bPW
@@ -157563,7 +157664,7 @@ car
 vKt
 cLC
 cMO
-cOA
+vze
 jgV
 cRM
 cRM
@@ -157782,7 +157883,7 @@ aMG
 bxE
 bzg
 bzg
-bCQ
+iFy
 ehO
 bAR
 bHX
@@ -157824,7 +157925,7 @@ cOB
 jgQ
 cRN
 cTw
-cVA
+gJW
 cWT
 cYJ
 cMO
@@ -158037,7 +158138,7 @@ kid
 bve
 aMG
 bxK
-bzn
+eMF
 bAV
 bCR
 fUY
@@ -158269,7 +158370,7 @@ aFx
 dHE
 aBf
 aJV
-aLp
+vyV
 aMG
 aOn
 hVl
@@ -158277,11 +158378,11 @@ aRv
 aSW
 aUS
 aMB
-aYh
+lsW
 baa
 bbF
 bdg
-nmf
+hjx
 bfZ
 bhk
 mVR
@@ -158316,7 +158417,7 @@ chx
 cjj
 cjn
 clZ
-cnF
+car
 car
 mZT
 car
@@ -158550,8 +158651,8 @@ bor
 vrX
 bvg
 bwy
-bxM
-bzp
+mHp
+wfc
 bAW
 bCT
 dIK
@@ -158574,7 +158675,7 @@ cjk
 ckE
 pqq
 cnG
-cpe
+vjH
 dDA
 crQ
 pQd
@@ -158780,10 +158881,10 @@ aCl
 awg
 oFR
 aFz
-bCW
+qYO
 alT
 aJW
-aLq
+uNk
 aMG
 aOn
 aPN
@@ -158791,7 +158892,7 @@ aRv
 aSW
 aUS
 aMB
-utg
+gXt
 bac
 bbH
 bdi
@@ -158805,7 +158906,7 @@ iqq
 sSD
 gGT
 icd
-bvh
+seR
 aMG
 bxE
 bxE
@@ -158823,7 +158924,7 @@ gdV
 bHV
 bHV
 bSl
-cca
+jfd
 uNJ
 cfH
 chz
@@ -159054,7 +159155,7 @@ aMB
 aMB
 beE
 aWH
-bhn
+ikR
 nsu
 bkR
 bmU
@@ -159064,7 +159165,7 @@ bsf
 btW
 bvi
 bwz
-bxN
+dvz
 bzq
 iml
 kEI
@@ -159075,7 +159176,7 @@ bKc
 kJO
 bOa
 bPY
-bSi
+gJr
 bUa
 bWq
 bYz
@@ -159851,7 +159952,7 @@ cJl
 bOA
 bWt
 bSl
-spG
+wZJ
 cdS
 wCW
 chx
@@ -159870,7 +159971,7 @@ czv
 cAQ
 oAD
 bNJ
-cFV
+hSe
 cHq
 cwo
 wdL
@@ -160061,7 +160162,7 @@ xPD
 wjP
 wjP
 awg
-aCo
+pnD
 aDr
 jZl
 aFD
@@ -160091,16 +160192,16 @@ bqg
 bsj
 usi
 dxS
-bwB
-bxQ
+vHv
+sIZ
 pBF
 bBa
 bCY
 aMG
-bGt
+fuh
 grV
 bKg
-bLZ
+hYD
 bOe
 bQb
 sOf
@@ -160324,7 +160425,7 @@ iqv
 rJv
 fWJ
 vth
-gIc
+sNR
 kXJ
 aMG
 aOn
@@ -160406,7 +160507,7 @@ caE
 djv
 ceb
 saw
-xKH
+gnZ
 nCP
 drE
 saw
@@ -160665,7 +160766,7 @@ djr
 saw
 doo
 oig
-drF
+vKh
 saw
 dus
 dwa
@@ -160882,7 +160983,7 @@ bOf
 qEP
 jwl
 oqh
-fBQ
+dsx
 car
 ckK
 cmf
@@ -160898,7 +160999,7 @@ czy
 cAU
 cCB
 uLo
-cFY
+kUV
 cHu
 cwo
 qVe
@@ -161134,10 +161235,10 @@ nyg
 rjw
 bUi
 bWy
-bYH
+wDV
 bQg
 irW
-kYP
+oeQ
 hvo
 iaW
 car
@@ -161644,7 +161745,7 @@ qtf
 bKm
 bMf
 bKm
-bQh
+dFG
 bKm
 bKm
 bWz
@@ -161925,7 +162026,7 @@ qQa
 caE
 cAW
 cCD
-cEj
+cLz
 cGa
 cHv
 caE
@@ -161963,7 +162064,7 @@ hOU
 dFz
 dGY
 dIj
-dJJ
+gss
 hOU
 dLJ
 gSi
@@ -162202,9 +162303,9 @@ cNd
 cNd
 cNd
 cMY
-djB
-dlo
-dmB
+tBB
+cte
+nCQ
 jEO
 nhz
 drI
@@ -162459,7 +162560,7 @@ cNc
 cNc
 cNc
 cMY
-djC
+gXT
 dlp
 dmC
 pUQ
@@ -162716,7 +162817,7 @@ ddR
 cNd
 cNd
 cMY
-djD
+luJ
 nOy
 nOy
 gBN
@@ -162975,7 +163076,7 @@ dgs
 cMY
 djE
 dlr
-dmE
+hTR
 fJj
 dqm
 drL
@@ -163186,7 +163287,7 @@ jmh
 bKp
 bMh
 bOm
-bQm
+pMs
 bSr
 xrQ
 bWE
@@ -163220,7 +163321,7 @@ cNd
 cNd
 cQv
 pFh
-cTM
+jHS
 cVK
 jrA
 cYU
@@ -163245,10 +163346,10 @@ cLu
 caE
 aad
 gSi
-dFE
+aVQ
 fUx
-sKb
-dJO
+qQj
+qfL
 dKC
 dLO
 gSi
@@ -163477,7 +163578,7 @@ cNc
 cNc
 cNc
 cNc
-cTN
+cNc
 cVM
 oXI
 cYU
@@ -163491,7 +163592,7 @@ djG
 nta
 dmG
 qLR
-dqo
+mQs
 drM
 gFZ
 duz
@@ -163706,20 +163807,20 @@ gRB
 bWD
 bYM
 caG
-ccn
+pLy
 cee
 cfV
 chM
-cjr
+tFq
 cjs
 yeX
 cnM
 hnQ
 cqM
-csh
+nIp
 ctJ
 caG
-ccs
+ykv
 cxU
 czC
 cBa
@@ -163734,7 +163835,7 @@ cNd
 cNd
 cNd
 nEW
-cTO
+mJZ
 cVN
 gGO
 cYU
@@ -164762,13 +164863,13 @@ cNh
 cNh
 cNh
 cNc
-cTQ
+tzj
 cVI
 kTV
 cYQ
 daB
 dcp
-ddS
+nUA
 dfc
 dgu
 dhV
@@ -164778,7 +164879,7 @@ dcz
 doD
 dqt
 drQ
-dti
+qlZ
 duF
 dwg
 dxP
@@ -164786,7 +164887,7 @@ dzt
 oSg
 dCa
 dDn
-dEq
+fbb
 dFI
 dHh
 iUZ
@@ -164991,7 +165092,7 @@ hNv
 bWE
 bYO
 caG
-ccs
+ykv
 cei
 cfZ
 chQ
@@ -165227,8 +165328,8 @@ bjp
 bld
 bng
 boy
-bqy
-bsw
+cUb
+mrx
 bwN
 bvz
 bwM
@@ -165238,7 +165339,7 @@ bBr
 bDm
 jMx
 bGG
-bIx
+kwT
 bKs
 bMk
 bOp
@@ -165251,7 +165352,7 @@ caG
 caG
 caG
 caG
-chR
+tjW
 cjt
 ckR
 cmt
@@ -165325,8 +165426,8 @@ dON
 dZJ
 urZ
 ebc
-ebQ
-ecu
+vBW
+vLt
 ecP
 edk
 edR
@@ -165519,9 +165620,9 @@ cmt
 cqP
 caG
 cwu
-cyb
+kJy
 czJ
-cBh
+qBH
 ccr
 cEv
 tyU
@@ -165749,7 +165850,7 @@ bwN
 bar
 fDw
 bBr
-bDo
+vgE
 tiG
 bGI
 bGI
@@ -165802,12 +165903,12 @@ dgx
 dhX
 gPv
 dlz
-dmO
+gaT
 iaF
 xOo
 drT
-dtm
-kLu
+fAB
+qqi
 lXF
 sTi
 vAb
@@ -165993,7 +166094,7 @@ bbU
 jce
 beP
 hYZ
-bhB
+acw
 bjs
 blg
 bni
@@ -166022,7 +166123,7 @@ caG
 ccv
 cel
 caG
-chU
+saP
 cjt
 ckR
 cmt
@@ -166036,10 +166137,10 @@ cwv
 cyc
 czK
 caG
-uMN
+cuZ
 cEx
 elS
-cHE
+gTm
 cCP
 tAv
 cLK
@@ -166047,8 +166148,8 @@ cnI
 cMY
 cMY
 cMY
-cTV
-cVT
+xpl
+qwN
 cXm
 cZb
 cXm
@@ -166231,18 +166332,18 @@ aAe
 wZG
 aCB
 aDD
-aEH
+hpZ
 aFT
 aDI
 aIN
-aKm
+jpo
 aLC
 aMX
-aOv
+lCu
 aQe
 fzw
 aTv
-aVh
+jLs
 aMX
 rBP
 bav
@@ -166274,12 +166375,12 @@ bKv
 skx
 gRB
 bWD
-bYS
+qRK
 caG
 caG
 caG
 caG
-chV
+rFc
 cjt
 ckT
 cmu
@@ -166329,7 +166430,7 @@ lti
 xDZ
 drQ
 dEv
-dFM
+kTg
 dHl
 fYZ
 dJZ
@@ -166343,7 +166444,7 @@ dQC
 gtW
 dSz
 dTx
-dUi
+rfr
 dTx
 dVN
 dTx
@@ -166764,7 +166865,7 @@ bbX
 kBI
 beS
 bar
-bhE
+iem
 bju
 blj
 bnl
@@ -166777,7 +166878,7 @@ bwN
 bar
 fBg
 bBr
-bDs
+xYF
 bFc
 bGL
 bIC
@@ -166810,7 +166911,7 @@ caG
 npR
 cEz
 tub
-uKT
+eDG
 cCP
 gcQ
 tOj
@@ -166857,14 +166958,14 @@ wwY
 pdL
 dSB
 dTz
-dUk
+wYJ
 dVa
 dVP
 dWL
 dXD
-pkx
+jBB
 uoR
-jWk
+eyf
 irX
 mtY
 rCA
@@ -166986,7 +167087,7 @@ ajX
 aky
 alj
 alZ
-amZ
+kss
 anZ
 aoZ
 alj
@@ -167021,7 +167122,7 @@ bbY
 fxA
 beT
 bar
-bhF
+giI
 bjv
 blk
 bnm
@@ -167054,14 +167155,14 @@ chX
 cjt
 ckR
 chP
-cnV
-cpz
+wbC
+npr
 cqU
 csl
 ctO
 caG
 cwz
-cyg
+uUf
 czO
 caG
 cCP
@@ -167081,7 +167182,7 @@ cXn
 cSk
 cSk
 cSk
-ddW
+lzi
 uIQ
 dgC
 dia
@@ -167238,10 +167339,10 @@ aaa
 aad
 rdj
 abf
-ajy
+fJS
 ajV
 aky
-alk
+pfR
 ama
 ana
 anf
@@ -167266,15 +167367,15 @@ aDI
 tvE
 aFY
 aMX
-aOz
+jie
 aQh
 trm
-aTy
+mJI
 aVl
 aMX
 uDv
 bav
-bbZ
+wJb
 pQu
 beU
 bar
@@ -167349,16 +167450,16 @@ doM
 hQF
 drX
 dtq
-duK
+qFx
 dwo
 dxW
 dzA
 dAE
 dCi
 dlE
-dEz
-dFQ
-dHp
+miH
+exU
+rkP
 qgK
 dKd
 dKH
@@ -167381,7 +167482,7 @@ dZj
 xbq
 eaw
 ebf
-ebU
+lUw
 ecy
 iZf
 edo
@@ -167545,7 +167646,7 @@ bqE
 hbH
 bvF
 bvF
-byd
+gwk
 qRs
 bBu
 bqE
@@ -167587,7 +167688,7 @@ ewa
 cLQ
 bvI
 cOV
-cQE
+rZW
 cSm
 oMe
 cVX
@@ -167643,8 +167744,8 @@ ecz
 dTA
 dUu
 dTw
-eez
-efl
+epy
+oyW
 ega
 dTw
 aad
@@ -167755,12 +167856,12 @@ pdr
 fbe
 ajV
 aky
-alm
+ezx
 amc
 amg
 amg
 ama
-aqd
+alk
 aky
 mAD
 asT
@@ -168065,7 +168166,7 @@ bBv
 wkI
 bFg
 bGO
-bIG
+npj
 bKx
 bKx
 bKx
@@ -168080,8 +168181,8 @@ cem
 bYV
 bYV
 cjx
-bIG
-cmw
+npj
+prM
 bKx
 bKx
 iJV
@@ -168090,7 +168191,7 @@ rij
 brb
 cwA
 brb
-czP
+kGt
 brb
 brb
 fQi
@@ -168158,7 +168259,7 @@ dTA
 nff
 dTw
 eeA
-efn
+efl
 egb
 dTw
 aad
@@ -168269,7 +168370,7 @@ snV
 hKu
 htT
 akA
-alo
+wsH
 amd
 anc
 aob
@@ -168312,7 +168413,7 @@ pUk
 bcl
 boH
 sBV
-bsC
+rSR
 bsW
 bvI
 bvK
@@ -168378,7 +168479,7 @@ tkO
 dsb
 dtu
 eCx
-dws
+wTE
 dxW
 dzE
 dAI
@@ -168390,7 +168491,7 @@ xdN
 dIH
 dKg
 cOR
-dMc
+jbd
 dNE
 dOs
 dOV
@@ -168526,7 +168627,7 @@ agj
 ajz
 ajU
 uFC
-alp
+ame
 ame
 and
 kAs
@@ -168536,7 +168637,7 @@ aky
 pJT
 asW
 auh
-avC
+hpr
 awE
 axX
 azd
@@ -168552,18 +168653,18 @@ aKu
 aDL
 aNa
 aOD
-aQl
+qll
 ebq
 aTD
 aVn
-aWV
+ucz
 aYD
 bay
-bcd
+haw
 uXr
 beY
 bgp
-bhL
+bir
 bjB
 blq
 aYC
@@ -168580,7 +168681,7 @@ xci
 bFi
 bGQ
 bIH
-bKy
+mVG
 bMn
 tel
 bQy
@@ -168596,14 +168697,14 @@ caL
 cjy
 bUB
 cmx
-cnW
+iGb
 cpA
 bUB
 csp
 lXQ
 cvo
 cwB
-cyi
+eve
 czQ
 cBj
 cCQ
@@ -168783,7 +168884,7 @@ abf
 ajA
 ajV
 aky
-alq
+eru
 amf
 ane
 sQb
@@ -168820,7 +168921,7 @@ bce
 uhO
 beZ
 aYC
-bdJ
+rrb
 bjC
 blr
 aYC
@@ -168853,7 +168954,7 @@ uCH
 bUB
 bUB
 cmy
-cnX
+kwn
 cpB
 bUB
 csp
@@ -169050,10 +169151,10 @@ aky
 ivM
 asT
 auh
-avE
+khQ
 awG
 axZ
-azf
+nAy
 auh
 aBC
 epW
@@ -169100,8 +169201,8 @@ pOO
 bQz
 bSz
 bUB
-bWQ
-bYZ
+xUB
+bOh
 rrD
 ccA
 pAq
@@ -169399,7 +169500,7 @@ inT
 dgI
 dig
 djV
-dlL
+jbX
 dmY
 doU
 dqK
@@ -169427,20 +169528,20 @@ dfm
 fHm
 dSJ
 dTA
-dUt
+uXn
 dVg
 dVc
 dWR
-dXI
+fRf
 dYz
-dZm
+gAX
 dZU
 dZk
 dWN
 ebZ
 ecE
 dTA
-edv
+dNx
 edW
 eeF
 efs
@@ -169572,7 +169673,7 @@ aAl
 aBE
 cMn
 aDL
-aES
+qLl
 aGg
 aHx
 aIX
@@ -169591,7 +169692,7 @@ bch
 bdG
 bfc
 aYC
-bhN
+tVn
 bjF
 aah
 aYC
@@ -169869,7 +169970,7 @@ obV
 red
 oRN
 iST
-ado
+tkA
 iVr
 vnQ
 hQG
@@ -169882,7 +169983,7 @@ rce
 tAC
 wkg
 lNt
-cpF
+tAF
 bUB
 csp
 pCg
@@ -169916,19 +170017,19 @@ ePk
 dlN
 dmZ
 doW
-dqL
+qhu
 dqQ
 dtw
 duU
 aaG
 dyc
-dzF
-dAJ
-dCp
+srO
+mTh
+kDu
 dDz
 dEH
 wqD
-dHu
+stE
 dIL
 dyg
 dKJ
@@ -170078,7 +170179,7 @@ akE
 ivM
 atb
 auj
-avG
+tVF
 awI
 awI
 tui
@@ -170090,8 +170191,8 @@ aEU
 aGg
 aHz
 aIZ
-aKy
-aLK
+hvH
+tvJ
 aLL
 aLL
 aLL
@@ -170100,10 +170201,10 @@ aLL
 aLL
 aXb
 aYE
-baD
+vhP
 aYD
 bdH
-bfd
+oBD
 bgr
 bhP
 bjH
@@ -170118,7 +170219,7 @@ aad
 aaa
 bwU
 bBC
-igG
+dPV
 gOe
 tLs
 rwH
@@ -170139,7 +170240,7 @@ caR
 caR
 caR
 lPi
-qtr
+ntX
 azX
 nGM
 iIL
@@ -170169,7 +170270,7 @@ ded
 khX
 dgK
 dij
-djY
+gug
 dlN
 mfA
 lzn
@@ -170382,7 +170483,7 @@ bIK
 bKF
 bMu
 bOD
-bQE
+tPP
 bKF
 bUE
 bWV
@@ -170391,7 +170492,7 @@ caS
 ccC
 ces
 cgh
-cib
+gxu
 cjD
 ckY
 cmC
@@ -170404,7 +170505,7 @@ cvo
 cwH
 fak
 czW
-cBm
+xom
 cCT
 cEI
 cGm
@@ -170454,7 +170555,7 @@ dNL
 dNL
 dNL
 dNL
-dTE
+gmf
 dUx
 dUx
 ike
@@ -170470,7 +170571,7 @@ dXO
 ecX
 edy
 edZ
-eeH
+ffm
 ujC
 egh
 egE
@@ -170658,7 +170759,7 @@ bUB
 csp
 hqr
 cvo
-cwI
+jWP
 lvz
 czX
 cBn
@@ -170666,7 +170767,7 @@ czX
 cEJ
 cGn
 cvo
-cII
+rUF
 gsD
 bsO
 cNp
@@ -170711,7 +170812,7 @@ aND
 dQK
 dRP
 dNL
-dTE
+gmf
 dUx
 dUx
 wmA
@@ -170839,7 +170940,7 @@ abf
 ajw
 ajV
 akE
-alw
+lZO
 aml
 ank
 ovw
@@ -170857,7 +170958,7 @@ auj
 aBF
 fBg
 aDL
-aEX
+oiy
 aGj
 aHC
 aJb
@@ -170923,7 +171024,7 @@ cvo
 cvo
 cvo
 cvo
-boS
+cdA
 gsD
 cLR
 rLJ
@@ -171410,7 +171511,7 @@ bIM
 bKH
 bMx
 bOG
-bQH
+iFV
 bSD
 bUH
 bWX
@@ -171451,7 +171552,7 @@ odj
 daV
 dcJ
 dei
-dfu
+wRl
 dgP
 dil
 dkd
@@ -171476,10 +171577,10 @@ dyg
 dKP
 noJ
 dNL
-dOC
+kWD
 dPf
 tia
-dQN
+kYT
 dRS
 dSO
 dTF
@@ -171629,7 +171730,7 @@ aBF
 wOz
 aDL
 aFa
-aGl
+fJd
 aHE
 aJa
 aKB
@@ -171641,7 +171742,7 @@ aLL
 aTL
 aLL
 aLL
-aYF
+hVQ
 baF
 aYD
 bdM
@@ -171705,7 +171806,7 @@ cUm
 cWf
 cXC
 cZm
-daW
+xgU
 dcK
 dej
 cZm
@@ -171718,7 +171819,7 @@ dpd
 dqQ
 dsk
 dqQ
-duZ
+aTr
 dwC
 dyg
 fEA
@@ -171910,7 +172011,7 @@ aYC
 bnr
 boH
 ogv
-bsI
+wNN
 bsW
 aad
 bwU
@@ -172156,7 +172257,7 @@ aBG
 azi
 azi
 aYG
-baG
+tvi
 qDh
 azi
 azi
@@ -172655,7 +172756,7 @@ azk
 aAr
 aAr
 aCN
-aDN
+wlE
 aFd
 aGm
 aHF
@@ -172740,7 +172841,7 @@ dek
 dgS
 dek
 dek
-ejV
+fFV
 cXE
 luP
 cXE
@@ -172752,12 +172853,12 @@ tiJ
 dzM
 dvb
 oqW
-dDH
+eOM
 dEQ
 dGf
 cXE
 cXE
-dKl
+nel
 reN
 dMs
 uMp
@@ -172966,7 +173067,7 @@ cgk
 cgk
 cmE
 coj
-cpM
+ppp
 cqY
 csz
 gSh
@@ -172977,7 +173078,7 @@ xlv
 cbR
 vqn
 cEQ
-cGu
+qcP
 czZ
 cIO
 rtD
@@ -173018,7 +173119,7 @@ dCy
 kve
 dMt
 dNO
-dOH
+fnq
 dPk
 dQd
 dPk
@@ -173180,7 +173281,7 @@ aNl
 qlw
 aQB
 aFe
-aTP
+nCS
 aVy
 aXg
 aYK
@@ -173260,7 +173361,7 @@ nOQ
 dqU
 dso
 inw
-dvd
+nYa
 dwH
 dvc
 uKg
@@ -173269,7 +173370,7 @@ dCy
 dDI
 dER
 dGh
-dHC
+gpU
 dIU
 dCy
 yaP
@@ -173466,7 +173567,7 @@ bIU
 bKH
 bMF
 bOO
-bQO
+eQC
 bSK
 bUG
 bWX
@@ -173517,7 +173618,7 @@ idk
 dqV
 dsp
 inw
-dve
+uRU
 dwI
 dyi
 dzO
@@ -173680,7 +173781,7 @@ avQ
 awT
 awU
 azm
-aAt
+reA
 aBJ
 pjs
 aDP
@@ -173780,7 +173881,7 @@ msB
 fDc
 vUe
 sfX
-ihs
+sDb
 mJc
 hnS
 uln
@@ -173923,7 +174024,7 @@ abf
 ajG
 ajY
 akP
-alz
+qDQ
 amv
 anv
 ohv
@@ -174007,7 +174108,7 @@ cvz
 cvz
 cvz
 cvz
-cIQ
+ppQ
 gsD
 cMa
 xdL
@@ -174031,7 +174132,7 @@ aNC
 dqX
 vjd
 dtB
-dvg
+hlX
 upB
 phC
 dzQ
@@ -174199,7 +174300,7 @@ tLP
 qdy
 aDR
 aFh
-aGs
+qhZ
 aHJ
 aJj
 aKI
@@ -174237,7 +174338,7 @@ bIW
 bKL
 bMH
 bOQ
-bQQ
+nDb
 bIV
 bIV
 bIV
@@ -174261,7 +174362,7 @@ gSs
 cAc
 cBx
 cDf
-cES
+vgK
 cGx
 cvz
 boH
@@ -174465,7 +174566,7 @@ aNp
 aHK
 aQF
 aSg
-aTU
+pbx
 mXW
 aXl
 aYO
@@ -174496,7 +174597,7 @@ bMI
 bMK
 bQR
 bSL
-bUL
+dZx
 bXc
 bZl
 cbb
@@ -174508,7 +174609,7 @@ cjK
 cjK
 cmG
 cok
-cpN
+ahI
 cjJ
 csz
 vzW
@@ -174744,7 +174845,7 @@ aad
 aaa
 bwU
 bBC
-igG
+dPV
 pNz
 mmf
 vRS
@@ -174754,9 +174855,9 @@ mmZ
 lCl
 rZh
 dou
-rVz
+nUO
 fMw
-pfk
+jVU
 oPA
 omS
 cgs
@@ -174770,7 +174871,7 @@ tYu
 csE
 gfE
 ovp
-fex
+jtn
 kYl
 tSw
 iTH
@@ -174792,7 +174893,7 @@ sqL
 dbh
 dcT
 deq
-dfz
+yct
 dha
 qBd
 vef
@@ -174803,7 +174904,7 @@ dqZ
 dst
 dtC
 dvj
-dwN
+aXT
 yeu
 noE
 dAW
@@ -175011,16 +175112,16 @@ qVN
 bQT
 bSN
 bUN
-bXe
+fHj
 bUQ
-cbd
+fRt
 ccO
 wuB
 cgt
 bUQ
 cjL
 cjL
-cmI
+mNq
 com
 cpP
 cjJ
@@ -175260,9 +175361,9 @@ bwU
 bBQ
 kby
 bFi
-bHn
+lWf
 bIV
-bKP
+hhA
 bMK
 gsc
 bQU
@@ -175448,7 +175549,7 @@ add
 adx
 adO
 abi
-aeC
+fKi
 afd
 afE
 afW
@@ -175456,7 +175557,7 @@ xSu
 agM
 aha
 agM
-ahD
+bwq
 abi
 aih
 aiC
@@ -175484,7 +175585,7 @@ awU
 oTs
 aDW
 aFi
-aGw
+izy
 aHO
 riP
 aKM
@@ -175493,7 +175594,7 @@ kts
 nBX
 cCY
 nMU
-mMI
+wJM
 vao
 aXp
 aYQ
@@ -175517,7 +175618,7 @@ bwU
 bBz
 kby
 bFi
-bHo
+bGT
 bIV
 bKQ
 bML
@@ -175530,7 +175631,7 @@ bZn
 cbf
 ccP
 grn
-cgv
+ezR
 bZl
 nge
 clc
@@ -175572,8 +175673,8 @@ dno
 dpo
 drc
 dsw
-kNm
-dvm
+jas
+vgv
 dwQ
 jqg
 eVL
@@ -175763,7 +175864,7 @@ aTB
 baU
 baQ
 baQ
-boS
+cdA
 gsD
 bsO
 wnu
@@ -175837,8 +175938,8 @@ sJg
 dBa
 dCB
 dDQ
-dEY
-tXA
+lVW
+jCb
 dHK
 dJb
 dCy
@@ -176007,10 +176108,10 @@ aNt
 aOV
 aQK
 uBz
-iKs
+qPJ
 lXL
 aXr
-aYR
+qJz
 baQ
 bct
 bdW
@@ -176300,7 +176401,7 @@ bXi
 bZp
 cbi
 ccS
-ceL
+pha
 cgy
 bUQ
 cjQ
@@ -176536,7 +176637,7 @@ blQ
 dPU
 boU
 tkS
-bsS
+sps
 bsW
 bvK
 bvK
@@ -176804,7 +176905,7 @@ uFa
 bFD
 bBR
 bvL
-bKU
+xwM
 bvL
 bvL
 bvL
@@ -176849,7 +176950,7 @@ cWm
 dcZ
 dew
 cWm
-dhf
+lUZ
 wzS
 dkr
 yhS
@@ -177327,10 +177428,10 @@ bUR
 vKQ
 bZq
 bvH
-ccT
+sXS
 bvH
 bvH
-cik
+pqC
 cjR
 clf
 cmQ
@@ -177343,10 +177444,10 @@ cvG
 cwY
 cyH
 bvH
-ccT
+sXS
 bvH
 bvH
-cik
+pqC
 bvH
 cIU
 hmg
@@ -177554,7 +177655,7 @@ sQa
 aXt
 aYX
 baQ
-bcy
+kpQ
 beb
 bfx
 bgM
@@ -177771,7 +177872,7 @@ aeF
 aeF
 aeF
 abi
-aiq
+sbN
 aiI
 ajc
 ajp
@@ -177841,8 +177942,8 @@ bUT
 esZ
 bZs
 cbk
-ccU
-ceM
+wDm
+gNz
 cgz
 ccX
 cjT
@@ -177851,7 +177952,7 @@ ccW
 cot
 cpV
 crh
-csK
+qkq
 cbk
 cvI
 cxa
@@ -177886,7 +177987,7 @@ dpv
 dpv
 dsC
 dtK
-dvs
+vxc
 nRD
 dyy
 dAb
@@ -178382,7 +178483,7 @@ ueb
 cNH
 cPB
 cRd
-cSO
+wQh
 cUJ
 ojS
 cXU
@@ -178580,7 +178681,7 @@ aSs
 aUi
 iOV
 aXx
-aZb
+flW
 baX
 bcB
 mLP
@@ -178665,7 +178766,7 @@ ieS
 dCJ
 dDZ
 tAj
-dGy
+hhq
 dHU
 dJk
 dtK
@@ -178885,7 +178986,7 @@ cvM
 cxa
 bsE
 cAm
-cBL
+iXL
 cDr
 cFf
 cGH
@@ -178896,7 +178997,7 @@ gLE
 cNI
 cHW
 cPy
-cSP
+iUy
 cUL
 cWm
 cXW
@@ -178920,7 +179021,7 @@ dyC
 qqc
 ctT
 dCK
-dEa
+koG
 dFe
 dGz
 dHV
@@ -179122,7 +179223,7 @@ bMQ
 bMQ
 bMQ
 bMQ
-bUW
+bEx
 sDR
 bZv
 cbk
@@ -179445,7 +179546,7 @@ bpt
 dNU
 dOI
 dPn
-rzX
+ffy
 ukB
 dRZ
 dPq
@@ -179640,7 +179741,7 @@ bUY
 esZ
 bZx
 cbk
-cdb
+uad
 ceQ
 cgE
 cip
@@ -179708,7 +179809,7 @@ dSa
 dPq
 aaa
 dPq
-dVu
+lnl
 dWn
 mGb
 dXV
@@ -179887,9 +179988,9 @@ aad
 aaa
 aaa
 bHr
-bJg
-rlG
-bMX
+ldr
+erS
+rdn
 bPe
 bRf
 bHr
@@ -179938,7 +180039,7 @@ jlh
 dkA
 yhS
 dnB
-dpA
+ykH
 dnB
 dsH
 dnB
@@ -180118,11 +180219,11 @@ aaa
 aaa
 aad
 rdT
-aSy
+oOU
 aUo
 lHH
-aXD
-aZh
+vBZ
+sgX
 rdT
 aad
 qwL
@@ -180178,7 +180279,7 @@ cIb
 cAm
 oKT
 cMm
-cNM
+hHF
 rDV
 uRE
 aLZ
@@ -180411,7 +180512,7 @@ bVa
 lbO
 hGZ
 cZn
-jdv
+iqb
 oPU
 cgH
 cis
@@ -180454,7 +180555,7 @@ dma
 dnC
 dpB
 dmd
-dsJ
+vmz
 dtN
 sey
 dxi
@@ -180670,12 +180771,12 @@ vZY
 cbk
 cdf
 ent
-cgI
+oFr
 cit
 ckd
 clr
-cmY
-coA
+ckx
+fig
 tMD
 crp
 csR
@@ -180949,7 +181050,7 @@ cAm
 cAm
 qBU
 cMm
-cNP
+oqS
 kIK
 cRj
 cSW
@@ -180958,7 +181059,7 @@ cWy
 cRe
 aaj
 dbu
-ddg
+gDA
 aal
 cNz
 dhj
@@ -180968,7 +181069,7 @@ dma
 dnE
 dnD
 dmd
-dsL
+hlx
 dtP
 wPr
 dxk
@@ -180997,7 +181098,7 @@ dVz
 dWs
 ozM
 dYa
-dYV
+jgk
 dPq
 aad
 aad
@@ -181182,9 +181283,9 @@ bVd
 esZ
 bZs
 cbp
-cdg
+oJW
 biE
-paR
+eNp
 ciu
 cke
 cbp
@@ -181192,12 +181293,12 @@ byl
 mTL
 gFY
 unZ
-son
-rJs
+nzy
+pot
 unL
 tIM
 srI
-poi
+mDf
 lVe
 hLG
 vkr
@@ -181431,7 +181532,7 @@ aaa
 bHr
 bJm
 bLf
-bNd
+uEg
 bPk
 bRl
 bHr
@@ -181442,8 +181543,8 @@ mHo
 cdh
 fQy
 cgL
-civ
-ckf
+gcn
+eFm
 cbp
 sUp
 coC
@@ -181470,7 +181571,7 @@ cPy
 cUP
 cPy
 cYa
-cZL
+jtc
 dbv
 ddh
 deG
@@ -181485,8 +181586,8 @@ slY
 dsN
 tEK
 fWS
-dxl
-teZ
+aNR
+eIt
 dma
 dBs
 dCP
@@ -181502,10 +181603,10 @@ cHU
 aad
 dPq
 dQi
-eSb
-dSd
+mBy
+uzO
 dSY
-dTR
+umE
 dUO
 dVA
 dWu
@@ -182210,7 +182311,7 @@ bUZ
 esZ
 bZF
 cbp
-cdk
+xti
 cfa
 cgO
 ciy
@@ -182507,7 +182608,7 @@ iAW
 iEb
 dkv
 dma
-dnK
+hFj
 dpD
 slY
 dsR
@@ -182533,12 +182634,12 @@ dQm
 dRg
 gNP
 dTc
-dTU
+lte
 dQl
 dVD
 dWx
 dQl
-dYe
+xhy
 teb
 oeX
 dXo
@@ -182711,7 +182812,7 @@ bnG
 pfV
 buC
 fRA
-bDW
+rTV
 xLk
 bHt
 bJp
@@ -182719,14 +182820,14 @@ bLj
 bNh
 bLj
 bLj
-bTa
+qQN
 bVh
 nYn
 bZH
 cbt
 jUH
 jen
-mGU
+dzj
 gJf
 bgZ
 clu
@@ -182745,7 +182846,7 @@ xTa
 xAZ
 nAr
 tyz
-fKc
+uMx
 cKU
 cMr
 cAw
@@ -182778,7 +182879,7 @@ dCS
 dEi
 dFk
 dGD
-dHX
+wNY
 nIk
 dGE
 dLr
@@ -183300,7 +183401,7 @@ dNb
 sjs
 aad
 dPq
-dQp
+cha
 dRj
 kkC
 dTf
@@ -183547,7 +183648,7 @@ dmh
 qlC
 dCV
 dEi
-dFn
+stB
 dGG
 dGG
 dJv
@@ -183568,7 +183669,7 @@ dWB
 dQl
 dYi
 xgL
-dQY
+hsg
 dXo
 eaQ
 ebz
@@ -183779,7 +183880,7 @@ cMv
 cIg
 cPQ
 cFy
-cTa
+tyh
 cCe
 cAw
 cYh
@@ -183794,7 +183895,7 @@ dkI
 dmh
 dnN
 dpF
-drp
+nKI
 dsT
 dtY
 dvM
@@ -183815,8 +183916,8 @@ dEi
 aad
 aad
 dPq
-dRl
-gjA
+grm
+jYL
 dTh
 dTZ
 dPq
@@ -183977,7 +184078,7 @@ aad
 aaa
 aaa
 aFm
-aZl
+fNF
 kvB
 bcK
 aFm
@@ -183987,16 +184088,16 @@ biB
 oGZ
 bmf
 bnG
-isU
+wph
 iGM
 fSq
 wnF
-bwc
+mTO
 bnG
-byI
+ceW
 bAj
 oNm
-nSF
+lyw
 bnG
 bHy
 iwu
@@ -184235,7 +184336,7 @@ aFm
 aFm
 aFm
 aZm
-gTH
+uZm
 aFm
 aFm
 aFm
@@ -184507,7 +184608,7 @@ iSW
 buJ
 bmh
 bxo
-byJ
+kjM
 bAl
 bCe
 bEc
@@ -184523,12 +184624,12 @@ bVk
 qwq
 bmh
 cbA
-cdn
+fPl
 cfg
 vFN
 ciF
 smv
-clB
+sYT
 uTP
 kQT
 cqg
@@ -184797,7 +184898,7 @@ oYG
 cza
 cAw
 cCe
-cDE
+vyc
 cFy
 cGV
 cIg
@@ -184806,7 +184907,7 @@ cLc
 cMz
 cIg
 cPS
-cRt
+tpp
 cDH
 cCh
 cAw
@@ -185020,14 +185121,14 @@ brn
 mep
 bkq
 bkq
-bxp
+qFZ
 byK
 bAn
 bCg
 bEe
 bFK
 xSp
-bJy
+gBl
 bLp
 bNl
 bNl
@@ -185347,7 +185448,7 @@ qlC
 dCV
 dEk
 dFt
-dGL
+jcS
 rsD
 dJB
 dKs
@@ -185525,15 +185626,15 @@ aFm
 bes
 ooZ
 bhd
-biG
-oaf
+naf
+kVt
 bml
 imU
 bpl
 brp
 hau
-buM
-bwe
+bku
+jhr
 bhd
 bmr
 bnT
@@ -185543,15 +185644,15 @@ bFM
 ubX
 bJz
 eFD
-nqw
+bFn
 nrp
 gZf
 bTf
-bVl
+tCY
 bXJ
 fwz
-cbD
-eFD
+xIf
+ykR
 lhG
 frG
 ciI
@@ -185826,7 +185927,7 @@ lFy
 cAw
 cCh
 cDH
-cFA
+uJs
 cGX
 cIg
 nsh
@@ -185834,7 +185935,7 @@ cLg
 cMD
 cIg
 cPU
-cRu
+rDd
 cPV
 cUZ
 cAw
@@ -185860,7 +185961,7 @@ diW
 eQd
 dCV
 dEk
-dFv
+oZm
 dGN
 dIf
 dJD
@@ -186553,7 +186654,7 @@ mzr
 kdZ
 aad
 bhd
-iOn
+mZX
 bku
 bmp
 bnP
@@ -186574,7 +186675,7 @@ bLs
 bNp
 bNp
 bNp
-bTi
+ryC
 bVp
 bXN
 fUV
@@ -186856,13 +186957,13 @@ cCk
 cDJ
 cFC
 cGZ
-cIk
+dVO
 tZX
 cLj
 cMF
 cNW
 cPX
-cRw
+xGl
 cTd
 cVc
 doz
@@ -187609,7 +187710,7 @@ bZY
 cbL
 bLs
 cfr
-wms
+ndh
 cfr
 bgZ
 aaa
@@ -188603,7 +188704,7 @@ aSI
 aUD
 aWl
 aFm
-hPc
+mhi
 nKh
 kdZ
 aad
@@ -189115,7 +189216,7 @@ aPu
 jTZ
 ylU
 mkz
-aWn
+fXU
 aXS
 oxw
 bbn
@@ -189124,7 +189225,7 @@ aad
 aad
 aad
 biP
-bkD
+gKa
 bmx
 bnV
 aeA
@@ -189386,7 +189487,7 @@ bmy
 bnZ
 kda
 brE
-btB
+fSF
 biP
 biP
 aad
@@ -189896,10 +189997,10 @@ aaa
 aad
 aaa
 biP
-bmA
+xuJ
 bnV
 jOl
-brG
+rEy
 btC
 biP
 aad

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -452,7 +452,7 @@
 /area/mine/eva)
 "bu" = (
 /obj/machinery/light_switch{
-	pixel_x = 27
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -557,17 +557,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"bK" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/mine/eva)
 "bL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -637,17 +626,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
-"cj" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	glass = 1;
-	name = "Mining Shuttle Airlock";
-	opacity = 0
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "ck" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -799,16 +777,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"cP" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "cQ" = (
 /turf/closed/wall/r_wall,
 /area/mine/maintenance)
@@ -853,15 +821,6 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/mine/production)
-"dd" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/obj/structure/table,
-/obj/item/paper/fluff/stations/lavaland/orm_notice,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "de" = (
@@ -975,7 +934,7 @@
 /area/mine/production)
 "dz" = (
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -1062,25 +1021,6 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"dK" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Shuttle Docking Foyer";
-	dir = 8;
-	network = list("mine")
-	},
-/obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -1212,13 +1152,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"eh" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "ej" = (
@@ -1441,27 +1374,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/production)
-"fa" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"fb" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "fc" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -1551,17 +1463,6 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "fk" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"fm" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -2399,6 +2300,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"jC" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "jF" = (
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/surrounding_tile{
@@ -2482,6 +2394,18 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
+"ka" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	glass = 1;
+	name = "Mining Shuttle Airlock";
+	opacity = 0;
+	safety_mode = 1
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -3268,6 +3192,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"nk" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Lavaland Shuttle Airlock";
+	safety_mode = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "nm" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -3410,17 +3347,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/laborcamp)
-"pz" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/advanced_airlock_controller{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plating,
-/area/mine/laborcamp)
 "pO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -3495,6 +3421,20 @@
 "qt" = (
 /obj/structure/table,
 /obj/item/cigbutt,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"qD" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chair,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "qG" = (
@@ -3646,6 +3586,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"sJ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	glass = 1;
+	name = "Mining Shuttle Airlock";
+	opacity = 0;
+	safety_mode = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 "sK" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -3726,6 +3681,26 @@
 /area/mine/living_quarters)
 "tP" = (
 /obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/mine/laborcamp)
+"tT" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "labor";
+	name = "Labor Camp Lockdown";
+	pixel_y = 28;
+	req_access_txt = "2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/advanced_airlock_controller/lavaland{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "tZ" = (
@@ -3854,6 +3829,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
+"vU" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/advanced_airlock_controller/lavaland{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "wj" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/purple{
@@ -3948,20 +3935,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"xA" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	glass = 1;
-	name = "Mining Shuttle Airlock";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "xB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -4127,11 +4100,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"AT" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/advanced_airlock_controller{
+"AQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Shuttle Docking Foyer";
+	dir = 8;
+	network = list("mine")
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/newscaster{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -4200,12 +4184,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/laborcamp)
-"BF" = (
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
+"BI" = (
+/obj/machinery/shower{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -4394,26 +4382,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
-"FS" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "labor";
-	name = "Labor Camp Lockdown";
-	pixel_y = 28;
-	req_access_txt = "2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/advanced_airlock_controller{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/laborcamp)
 "Gb" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -4436,6 +4404,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Gx" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/advanced_airlock_controller/lavaland{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 "Gz" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "gulag3";
@@ -4640,6 +4616,15 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/living_quarters)
+"KT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/advanced_airlock_controller/lavaland{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "KY" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "labor";
@@ -4661,19 +4646,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
-"Lf" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/laborcamp)
 "Lg" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/brown{
@@ -4709,15 +4681,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"LR" = (
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "LS" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -4890,6 +4853,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"Ox" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Lavaland Shuttle Airlock";
+	safety_mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Oz" = (
 /obj/structure/table,
 /obj/item/paper,
@@ -4905,6 +4878,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"OG" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "OI" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -5072,6 +5052,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Qz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/advanced_airlock_controller/lavaland{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
+"QG" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "QN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5127,18 +5128,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
-"RE" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "RI" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -5181,6 +5170,17 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/mine/laborcamp)
+"Sa" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/advanced_airlock_controller/lavaland{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
 /area/mine/laborcamp)
 "Sd" = (
 /obj/machinery/hydroponics/constructable,
@@ -5355,19 +5355,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"US" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Lavaland Shuttle Airlock"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "UV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -5435,6 +5426,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/mine/laborcamp)
+"VF" = (
+/obj/structure/table,
+/obj/item/paper/fluff/stations/lavaland/orm_notice,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 "VN" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -5477,18 +5477,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Wr" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/mine/eva)
 "WD" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -5514,6 +5502,17 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
+"WW" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 "Xb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -5525,6 +5524,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"Xk" = (
+/obj/structure/chair,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Xr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5597,18 +5604,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
-"Yy" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Lavaland Shuttle Airlock"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "YG" = (
 /obj/structure/fence{
 	dir = 4
@@ -5625,6 +5620,19 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
+/area/mine/laborcamp)
+"YP" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/advanced_airlock_controller/lavaland{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "YV" = (
 /obj/structure/rack,
@@ -10552,11 +10560,11 @@ Pr
 Pr
 vj
 aq
-FS
+tT
 aq
 ao
 aq
-Lf
+YP
 yr
 aD
 bZ
@@ -12117,7 +12125,7 @@ ab
 ab
 ab
 cR
-US
+Ox
 cR
 ab
 ab
@@ -12374,7 +12382,7 @@ ab
 ab
 ab
 cR
-LR
+KT
 cR
 ab
 ab
@@ -12631,7 +12639,7 @@ cM
 xi
 cM
 cR
-Yy
+nk
 cR
 aj
 aj
@@ -13140,7 +13148,7 @@ dZ
 Pc
 dZ
 cM
-fa
+Xk
 dZ
 dZ
 dZ
@@ -13397,7 +13405,7 @@ ea
 Pc
 ek
 cM
-fb
+qD
 lL
 fy
 fy
@@ -14137,7 +14145,7 @@ aD
 aD
 aD
 sq
-pz
+Sa
 tr
 Za
 nt
@@ -15963,7 +15971,7 @@ Kn
 Xz
 dF
 cM
-eh
+OG
 Ly
 fp
 cM
@@ -17252,7 +17260,7 @@ dZ
 Qs
 dZ
 cM
-fm
+QG
 fk
 fF
 fk
@@ -19810,7 +19818,7 @@ aj
 ab
 ab
 bN
-cj
+ka
 br
 ab
 ab
@@ -20067,7 +20075,7 @@ aj
 aj
 ab
 br
-BF
+Qz
 br
 ab
 aj
@@ -20324,7 +20332,7 @@ aj
 aj
 br
 br
-xA
+sJ
 br
 br
 ab
@@ -21355,7 +21363,7 @@ ql
 cn
 cF
 cI
-cP
+WW
 cn
 hq
 bP
@@ -21615,7 +21623,7 @@ cJ
 bq
 cZ
 pk
-dK
+AQ
 yl
 bP
 eE
@@ -21623,7 +21631,7 @@ bP
 dU
 br
 wj
-AT
+Gx
 br
 ab
 ab
@@ -22137,7 +22145,7 @@ bP
 cH
 br
 jV
-RE
+BI
 br
 ab
 ab
@@ -22898,7 +22906,7 @@ bg
 bf
 ai
 bq
-dd
+VF
 bP
 dN
 dX
@@ -23149,7 +23157,7 @@ ab
 ab
 ab
 bf
-Wr
+vU
 NF
 cs
 bf
@@ -23406,7 +23414,7 @@ aj
 ab
 ab
 bf
-bK
+jC
 bW
 ct
 bf

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -4268,6 +4268,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"DH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp)
 "Ef" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/ore_box,
@@ -5354,19 +5368,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/mine/laborcamp)
-"UV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "UX" = (
 /obj/effect/turf_decal/tile/blue{
@@ -13127,7 +13128,7 @@ aq
 aq
 pr
 aq
-UV
+DH
 rH
 aq
 nj

--- a/_maps/map_files/PackedStation/PackedStation.dmm
+++ b/_maps/map_files/PackedStation/PackedStation.dmm
@@ -357,7 +357,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = -24
+	pixel_y = -26
 	},
 /obj/machinery/camera{
 	c_tag = "Bar South";
@@ -434,7 +434,7 @@
 /area/medical/medbay/central)
 "adx" = (
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_y = -23
 	},
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -449,33 +449,13 @@
 "adD" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -26
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"adF" = (
-/obj/structure/table,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/item/stack/sheet/glass{
-	amount = 20;
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/stack/sheet/metal/twenty,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "adI" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -525,16 +505,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"adU" = (
-/obj/machinery/computer/robotics{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
 "adV" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -553,8 +523,7 @@
 "aee" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = -31
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
@@ -598,29 +567,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/lawoffice)
-"aep" = (
-/obj/structure/table,
-/obj/machinery/requests_console{
-	department = "Virology";
-	name = "Virology Requests Console";
-	pixel_x = -32
-	},
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/virology)
 "aeq" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
@@ -680,18 +626,6 @@
 "aeW" = (
 /turf/closed/wall,
 /area/chapel/main)
-"aeX" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "afb" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -724,28 +658,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"afe" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/book/manual/wiki/grenades,
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/construction/plumbing,
-/obj/item/stack/ducts/fifty,
-/obj/item/plunger,
-/turf/open/floor/plasteel/white,
-/area/medical/pharmacy)
 "afp" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/secure_closet/security/sec,
@@ -879,7 +791,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -986,7 +898,7 @@
 /area/science/nanite)
 "agX" = (
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -1130,19 +1042,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aib" = (
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/computer/med_data,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "aic" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1308,7 +1207,7 @@
 /obj/structure/table,
 /obj/item/storage/box/disks_nanite,
 /obj/machinery/firealarm{
-	pixel_y = -24
+	pixel_y = -26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -1446,7 +1345,7 @@
 "ajG" = (
 /obj/machinery/photocopier,
 /obj/machinery/newscaster/security_unit{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -1456,7 +1355,7 @@
 /area/crew_quarters/kitchen)
 "ajJ" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -1645,25 +1544,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"akS" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/chem_master,
-/turf/open/floor/plasteel/white,
-/area/medical/pharmacy)
 "akW" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -1815,8 +1695,7 @@
 /area/bridge)
 "amj" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -1888,14 +1767,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"amK" = (
-/obj/machinery/requests_console{
-	department = "AI";
-	departmentType = 5;
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
 "amP" = (
 /obj/structure/closet/radiation,
 /obj/machinery/airalarm{
@@ -2022,7 +1893,7 @@
 "anC" = (
 /obj/structure/table,
 /obj/machinery/light_switch{
-	pixel_y = 25
+	pixel_y = -23
 	},
 /obj/item/assembly/igniter{
 	pixel_x = -8;
@@ -2109,22 +1980,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
-"aoh" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "aok" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_y = 25
+	pixel_y = -23
 	},
 /obj/structure/table,
 /obj/item/stock_parts/subspace/transmitter,
@@ -2319,17 +2180,6 @@
 "apB" = (
 /turf/closed/wall,
 /area/science/robotics/lab)
-"apD" = (
-/obj/structure/bed,
-/obj/item/bedsheet/dorms,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/structure/curtain/cloth/grey,
-/obj/item/toy/plush/beeplushie,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "apF" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
@@ -2349,19 +2199,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"apK" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/machinery/requests_console{
-	department = "EVA";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "apP" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -2371,7 +2208,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
@@ -2382,8 +2219,7 @@
 /area/medical/genetics)
 "apU" = (
 /obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = 24
+	pixel_y = -23
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
@@ -2423,7 +2259,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
@@ -2446,7 +2282,7 @@
 /area/crew_quarters/bar)
 "aqF" = (
 /obj/machinery/firealarm{
-	pixel_y = -24
+	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -2541,15 +2377,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"ard" = (
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
 "are" = (
 /obj/machinery/keycard_auth{
 	pixel_y = -24
@@ -2559,12 +2386,6 @@
 /obj/item/pinpointer/nuke,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"arg" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 30
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "arh" = (
 /obj/machinery/computer/rdconsole/experiment{
 	dir = 8
@@ -2580,7 +2401,7 @@
 	pixel_y = -30
 	},
 /obj/machinery/light_switch{
-	pixel_x = 28
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -2648,18 +2469,6 @@
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"arM" = (
-/obj/structure/rack,
-/obj/item/storage/briefcase,
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/obj/machinery/camera{
-	c_tag = "Law Office";
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/lawoffice)
 "arN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2695,21 +2504,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"asa" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "asb" = (
 /obj/docking_port/stationary{
 	dwidth = 1;
@@ -2767,15 +2561,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
-"asF" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/filingcabinet/security,
-/obj/machinery/requests_console{
-	department = "Law office";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/brig)
 "asI" = (
 /turf/closed/wall/r_wall,
 /area/janitor)
@@ -2901,7 +2686,7 @@
 /obj/machinery/requests_console{
 	department = "Genetics";
 	name = "Genetics Requests Console";
-	pixel_y = -30
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -3021,19 +2806,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"aut" = (
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/stasis,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/zone2)
 "auv" = (
 /obj/machinery/telecomms/hub/preset,
 /obj/machinery/light/small,
@@ -3379,7 +3151,7 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -3660,17 +3432,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"azl" = (
-/obj/machinery/camera{
-	c_tag = "Chapel South"
-	},
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 4
-	},
-/area/chapel/main)
 "azm" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
@@ -3752,19 +3513,6 @@
 /obj/item/camera_film,
 /turf/open/floor/wood,
 /area/library)
-"azI" = (
-/obj/structure/table,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/requests_console{
-	department = "Custodial Closet";
-	name = "Custodial RC";
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "azJ" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -3848,7 +3596,7 @@
 /obj/machinery/vending/modularpc,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -3879,22 +3627,10 @@
 /obj/item/storage/firstaid,
 /obj/item/storage/firstaid,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"aAt" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
 "aAx" = (
 /obj/machinery/status_display,
 /turf/closed/wall/r_wall,
@@ -3940,7 +3676,7 @@
 	c_tag = "Detective's Office"
 	},
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/item/camera/detective,
 /obj/item/taperecorder,
@@ -4233,8 +3969,7 @@
 /area/lawoffice)
 "aCC" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -4251,19 +3986,17 @@
 /turf/open/floor/circuit,
 /area/science/server)
 "aCK" = (
-/obj/structure/table,
-/obj/machinery/requests_console{
-	department = "Crew Quarters";
-	pixel_y = 30
+/obj/effect/turf_decal/delivery,
+/obj/machinery/mecha_part_fabricator,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/item/multitool,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 6;
-	pixel_y = -5
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
 	},
-/obj/item/clothing/head/soft,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
 "aCM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -4358,7 +4091,7 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -4385,7 +4118,7 @@
 	department = "Telecoms Admin";
 	departmentType = 5;
 	name = "Telecoms RC";
-	pixel_x = 30
+	pixel_y = -32
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
@@ -4395,7 +4128,7 @@
 	},
 /obj/effect/landmark/start/librarian,
 /obj/machinery/newscaster{
-	pixel_y = -28
+	pixel_y = -30
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -4420,7 +4153,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4489,7 +4222,7 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_y = -30;
+	pixel_y = -32;
 	receive_ore_updates = 1
 	},
 /obj/item/multitool,
@@ -4590,6 +4323,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
+"aFl" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aFq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -4720,8 +4463,7 @@
 	},
 /obj/item/storage/belt/utility,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -4794,17 +4536,6 @@
 "aHs" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hor)
-"aHv" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/mecha_part_fabricator,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
 "aHw" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_x = 32
@@ -4972,13 +4703,6 @@
 	},
 /turf/open/floor/circuit,
 /area/science/server)
-"aIU" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/bar)
 "aIX" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -5000,7 +4724,7 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -5041,7 +4765,7 @@
 "aJn" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
-	pixel_y = -24
+	pixel_y = -26
 	},
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2;
@@ -5317,20 +5041,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"aLd" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "aLe" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -26
 	},
 /obj/structure/dresser,
 /obj/machinery/light{
@@ -5466,7 +5180,7 @@
 /obj/structure/closet/secure_closet/courtroom,
 /obj/item/gavelhammer,
 /obj/machinery/light_switch{
-	pixel_x = -27
+	pixel_y = -23
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
@@ -5667,8 +5381,7 @@
 "aNV" = (
 /obj/structure/closet/lasertag/blue,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = -31
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -5861,8 +5574,7 @@
 /obj/item/nanite_scanner,
 /obj/item/nanite_remote,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -5911,32 +5623,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"aPL" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "rnd2";
-	name = "Research Lab Shutter Control";
-	pixel_x = 5;
-	pixel_y = 5;
-	req_access_txt = "47"
-	},
-/obj/machinery/button/door{
-	id = "Biohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -5;
-	pixel_y = 5;
-	req_access_txt = "47"
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Research Director's Desk";
-	departmentType = 5;
-	name = "Research Director's RC";
-	pixel_x = -32;
-	receive_ore_updates = 1
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
 "aPN" = (
 /obj/machinery/computer/bank_machine,
 /obj/effect/turf_decal/bot_white/right,
@@ -5956,21 +5642,6 @@
 /obj/item/clothing/glasses/science,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
-"aQa" = (
-/obj/structure/table/wood,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	name = "Head of Security RC";
-	pixel_x = 30
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/turf/open/floor/carpet/red,
-/area/crew_quarters/heads/hos)
 "aQb" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -6014,7 +5685,7 @@
 	},
 /obj/machinery/washing_machine,
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -6060,25 +5731,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"aQs" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/machinery/camera{
-	c_tag = "Virology Module";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "aQG" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -6110,7 +5762,7 @@
 	department = "Chief Medical Officer's Desk";
 	departmentType = 5;
 	name = "Chief Medical Officer RC";
-	pixel_x = 32
+	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -6183,7 +5835,7 @@
 "aRf" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -6192,7 +5844,7 @@
 /area/crew_quarters/dorms)
 "aRj" = (
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /obj/machinery/computer/mecha{
 	dir = 4
@@ -6205,7 +5857,7 @@
 "aRk" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/security_unit{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/item/storage/box/PDAs{
 	pixel_x = 4;
@@ -6232,17 +5884,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"aRs" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
 "aRt" = (
 /obj/structure/chair/office/light{
 	dir = 8;
@@ -6287,7 +5928,7 @@
 "aRx" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -6491,27 +6132,6 @@
 	},
 /turf/open/floor/carpet,
 /area/security/courtroom)
-"aSJ" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_x = 27;
-	pixel_y = -10
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "aSK" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -6606,12 +6226,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aTq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel,
-/area/medical/medbay/central)
 "aTr" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -6836,7 +6450,7 @@
 	light_color = "#d1dfff"
 	},
 /obj/machinery/firealarm{
-	pixel_y = -24
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -6852,7 +6466,7 @@
 "aUx" = (
 /obj/machinery/vending/autodrobe,
 /obj/machinery/light_switch{
-	pixel_y = 26
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/theatre)
@@ -6974,6 +6588,20 @@
 	dir = 4
 	},
 /area/chapel/main)
+"aVv" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air to External"
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "aVx" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plating,
@@ -7004,17 +6632,6 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"aVG" = (
-/obj/machinery/camera{
-	c_tag = "Tech Storage"
-	},
-/obj/machinery/light_switch{
-	pixel_y = 25
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/service,
-/turf/open/floor/plating,
-/area/storage/tech)
 "aVJ" = (
 /obj/structure/table/wood,
 /obj/item/gavelblock,
@@ -7115,16 +6732,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
-"aWt" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "aWw" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm{
@@ -7673,8 +7280,7 @@
 /area/science/explab)
 "aZt" = (
 /obj/machinery/light_switch{
-	pixel_x = 27;
-	pixel_y = -10
+	pixel_y = -23
 	},
 /obj/item/radio/intercom{
 	pixel_x = 25
@@ -7685,13 +7291,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
-"aZx" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "aZI" = (
 /obj/machinery/computer/teleporter{
 	dir = 1
@@ -7746,6 +7345,20 @@
 /obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/circuit,
 /area/science/lab)
+"baC" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "baE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7871,6 +7484,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"bff" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "bfg" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -8082,15 +7706,6 @@
 	},
 /turf/open/space,
 /area/space)
-"bpm" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bps" = (
 /obj/structure/closet/toolcloset,
 /obj/structure/cable{
@@ -8561,7 +8176,7 @@
 	department = "Head of Personnel's Desk";
 	departmentType = 5;
 	name = "Head of Personnel RC";
-	pixel_y = -30
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -8743,7 +8358,7 @@
 	},
 /obj/item/crowbar,
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -8999,10 +8614,24 @@
 /area/engine/atmos)
 "cez" = (
 /obj/machinery/firealarm{
-	pixel_y = -24
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ceP" = (
+/obj/structure/table,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/requests_console{
+	department = "Custodial Closet";
+	dir = 1;
+	name = "Custodial RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "cfk" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9184,6 +8813,23 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"cmK" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/mecha_part_fabricator,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/requests_console{
+	department = "Robotics";
+	departmentType = 2;
+	dir = 1;
+	name = "Robotics RC";
+	pixel_y = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
 "cnc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9233,7 +8879,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -26
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9752,6 +9398,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"cJv" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/obj/structure/curtain/cloth/grey,
+/obj/item/toy/plush/beeplushie,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cJx" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -9825,6 +9483,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"cPs" = (
+/obj/machinery/requests_console{
+	department = "AI";
+	departmentType = 5;
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "cPR" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "arr1";
@@ -9882,6 +9549,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"cQX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cRi" = (
 /obj/structure/chair{
 	dir = 8
@@ -9920,7 +9609,7 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_y = -25
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -9932,27 +9621,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"cVf" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cVT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -10195,6 +9863,32 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"deT" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"deY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dfp" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/rack,
@@ -10278,17 +9972,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"dlN" = (
-/obj/structure/closet/wardrobe/miner,
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "dlO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -10302,7 +9985,7 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_x = -27
+	pixel_y = -23
 	},
 /obj/item/storage/firstaid/o2{
 	pixel_x = 3;
@@ -10687,6 +10370,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"dFY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/requests_console{
+	department = "Law office";
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "dFZ" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -10721,6 +10418,14 @@
 	},
 /turf/open/space,
 /area/space)
+"dGK" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "dGN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -10828,6 +10533,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"dKE" = (
+/obj/machinery/computer/cargo{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Quartermaster's Desk";
+	dir = 4;
+	name = "Quartermaster RC";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "dKO" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -11377,7 +11097,7 @@
 "efw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm{
-	pixel_y = -24
+	pixel_y = -26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -11660,11 +11380,43 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"eqx" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/grimy,
+/area/chapel/main)
 "eqy" = (
 /obj/item/flashlight,
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"eqQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/wood,
+/area/library)
 "erz" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -11887,6 +11639,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"eBf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Virology Module";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "eBk" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L3"
@@ -12262,22 +12034,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"eON" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/mecha_part_fabricator,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Robotics";
-	departmentType = 2;
-	name = "Robotics RC";
-	pixel_y = 30;
-	receive_ore_updates = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
 "eOX" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -13071,7 +12827,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/light_switch{
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/item/hand_labeler,
 /obj/item/hand_labeler,
@@ -13169,18 +12925,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"fvp" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "fvH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/structure/disposalpipe/segment,
@@ -13281,6 +13025,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"fyO" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "fzc" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/rack,
@@ -13328,7 +13080,7 @@
 /area/storage/tech)
 "fAa" = (
 /obj/machinery/firealarm{
-	pixel_y = -24
+	pixel_y = -26
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13647,6 +13399,20 @@
 "fPV" = (
 /turf/closed/wall,
 /area/maintenance/solars/port/fore)
+"fQo" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "fQK" = (
 /obj/item/shard,
 /obj/item/stack/rods,
@@ -13788,6 +13554,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"fVx" = (
+/obj/structure/closet/wardrobe/miner,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "fWD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -13818,19 +13596,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"fWV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/requests_console{
-	department = "Law office";
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/lawoffice)
 "fWW" = (
 /obj/structure/closet/emcloset{
 	anchored = 1
@@ -14044,7 +13809,7 @@
 /area/crew_quarters/heads/chief)
 "ged" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -29
+	pixel_y = -30
 	},
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/bot,
@@ -14148,16 +13913,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ggv" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/camera/autoname,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "ggB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -14348,7 +14103,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -29
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -14595,7 +14350,7 @@
 	pixel_x = -12
 	},
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/sleeper)
@@ -15008,20 +14763,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
-"gXY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gYq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -15096,6 +14837,30 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"han" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/science,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Virology";
+	dir = 8;
+	name = "Virology Requests Console";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "haW" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/fore/secondary)
@@ -15270,6 +15035,13 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"hgF" = (
+/obj/machinery/newscaster/security_unit{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "hhh" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/particle_accelerator/particle_emitter/center,
@@ -15446,19 +15218,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"hmH" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/computer/bounty{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/head_of_personnel)
 "hnb" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -15724,21 +15483,6 @@
 	icon_state = "wood-broken"
 	},
 /area/maintenance/department/crew_quarters/bar)
-"hzq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "hzM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -16049,7 +15793,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm{
-	pixel_y = -24
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -16222,6 +15966,20 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/janitor)
+"hPG" = (
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/machinery/requests_console{
+	department = "EVA";
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "hQs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -16350,6 +16108,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"hUI" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/medical/medbay/central)
 "hUM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -16465,7 +16230,7 @@
 /area/solar/starboard/aft)
 "hXp" = (
 /obj/machinery/light_switch{
-	pixel_x = -26
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -16960,8 +16725,7 @@
 "isM" = (
 /obj/machinery/disposal/bin,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -17174,27 +16938,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"iAC" = (
-/obj/machinery/vending/tool,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "iBp" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -17458,6 +17201,18 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/engine,
 /area/maintenance/fore/secondary)
+"iNM" = (
+/obj/machinery/camera{
+	c_tag = "Tech Storage"
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/service,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "iOk" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -17541,6 +17296,21 @@
 /obj/machinery/igniter/incinerator_atmos,
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
+"iUq" = (
+/obj/machinery/pdapainter,
+/obj/machinery/camera{
+	c_tag = "Head of Personnel's Office";
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/head_of_personnel)
 "iUA" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -17597,6 +17367,16 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iWT" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/filingcabinet/security,
+/obj/machinery/requests_console{
+	department = "Law office";
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/brig)
 "iXl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -17775,6 +17555,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"jfC" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jfY" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -18266,7 +18059,7 @@
 /area/crew_quarters/bar)
 "jzT" = (
 /obj/machinery/light_switch{
-	pixel_y = -28
+	pixel_y = -23
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18718,7 +18511,7 @@
 /area/crew_quarters/kitchen)
 "jRL" = (
 /obj/machinery/firealarm{
-	pixel_y = -24
+	pixel_y = -26
 	},
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4
@@ -19008,7 +18801,7 @@
 /area/engine/engineering)
 "knu" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /obj/structure/table,
 /obj/machinery/camera{
@@ -19033,6 +18826,17 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"knx" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmospherics_engine)
 "knN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -19380,6 +19184,22 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"kzf" = (
+/obj/structure/rack,
+/obj/item/storage/briefcase,
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/machinery/camera{
+	c_tag = "Law Office";
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "kzg" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/structure/cable{
@@ -19569,6 +19389,19 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"kKk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kKX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -19837,6 +19670,20 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"kUN" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/computer/med_data,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "kUW" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
@@ -20139,6 +19986,16 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"llm" = (
+/obj/machinery/computer/robotics{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "llw" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -20174,6 +20031,26 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
+"llR" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/chem_master,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/pharmacy)
 "lme" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8;
@@ -20189,6 +20066,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"lmQ" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "lnH" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/head_of_personnel";
@@ -20281,6 +20168,16 @@
 "loX" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
+"lps" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lpw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -20396,44 +20293,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"lsn" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 4;
-	name = "Chief Engineer RC";
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
-"lss" = (
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/chapel/main)
 "lsB" = (
 /obj/machinery/firealarm{
-	pixel_y = -24
+	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -21142,7 +21004,7 @@
 /obj/item/stack/rods/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 29
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -21367,6 +21229,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mdR" = (
+/obj/machinery/computer/arcade,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "mel" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -21458,13 +21329,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/aft)
-"mjp" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "mjy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -21857,7 +21721,7 @@
 /area/hallway/secondary/entry)
 "mvT" = (
 /obj/machinery/firealarm{
-	pixel_y = -24
+	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -21865,6 +21729,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"mwa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mwh" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/station_engineer,
@@ -22205,6 +22079,20 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
+"mLW" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/stasis,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/zone2)
 "mLX" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/westleft,
@@ -22404,19 +22292,6 @@
 "mSa" = (
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"mTj" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mTx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -22542,13 +22417,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"mZU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nai" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -22606,6 +22474,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"nbi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "nbA" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/unary/relief_valve/atmos/atmos_waste{
@@ -22619,7 +22496,7 @@
 	department = "Bridge";
 	departmentType = 5;
 	name = "Bridge RC";
-	pixel_y = -30
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -22636,16 +22513,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"ncJ" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Kitchen Cold Room"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "ncT" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -22958,6 +22825,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"npN" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "npX" = (
 /obj/structure/closet/malf/suits,
 /obj/structure/cable{
@@ -22983,7 +22871,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
-	pixel_y = -26
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/aft)
@@ -23345,6 +23233,33 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"nBy" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "rnd2";
+	name = "Research Lab Shutter Control";
+	pixel_x = 5;
+	pixel_y = 5;
+	req_access_txt = "47"
+	},
+/obj/machinery/button/door{
+	id = "Biohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = -5;
+	pixel_y = 5;
+	req_access_txt = "47"
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Research Director's Desk";
+	departmentType = 5;
+	dir = 8;
+	name = "Research Director's RC";
+	pixel_x = -32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "nBI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -23701,19 +23616,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"nOh" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "nOZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23932,21 +23834,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
-"nZq" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/library)
 "nZD" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -24156,6 +24043,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"oil" = (
+/obj/machinery/vending/tool,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "oiA" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -24289,6 +24197,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"onV" = (
+/obj/machinery/camera{
+	c_tag = "Chapel South"
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
+/area/chapel/main)
 "ooC" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -24415,8 +24335,7 @@
 /area/quartermaster/storage)
 "otk" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = -31
+	pixel_y = -30
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -25042,7 +24961,7 @@
 	network = list("ss13","medbay")
 	},
 /obj/machinery/light_switch{
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -25099,6 +25018,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"oYk" = (
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar)
 "oYN" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -25224,16 +25151,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"pdw" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "pdG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -25246,15 +25163,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"pdZ" = (
-/obj/machinery/requests_console{
-	department = "Engineering";
-	departmentType = 4;
-	name = "Engineering RC";
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pep" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -25940,7 +25848,7 @@
 	pixel_x = 24
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -29
+	pixel_y = -30
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/tile/neutral{
@@ -25978,6 +25886,19 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"pKV" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -26533,6 +26454,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"qjt" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	dir = 4;
+	name = "Head of Security RC";
+	pixel_x = 32
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "qjE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -27800,22 +27737,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"rfW" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "rgx" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
@@ -28263,6 +28184,28 @@
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"rCS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "rCW" = (
 /obj/machinery/airalarm/directional/south{
 	pixel_y = -24
@@ -28315,6 +28258,22 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"rGA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "rIo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -28389,14 +28348,6 @@
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"rKy" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/computer/arcade,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "rLE" = (
 /obj/machinery/power/apc/auto_name/east{
 	pixel_x = 24
@@ -28649,6 +28600,16 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"rTn" = (
+/obj/machinery/requests_console{
+	department = "Engineering";
+	departmentType = 4;
+	dir = 1;
+	name = "Engineering RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rTN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
@@ -28694,21 +28655,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"rVC" = (
-/obj/machinery/computer/cargo{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Quartermaster's Desk";
-	name = "Quartermaster RC";
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "rVK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -28799,6 +28745,28 @@
 	},
 /turf/open/floor/plating,
 /area/bridge/meeting_room)
+"sah" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/book/manual/wiki/grenades,
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/construction/plumbing,
+/obj/item/stack/ducts/fifty,
+/obj/item/plunger,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/pharmacy)
 "sap" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -28830,7 +28798,7 @@
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -26
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -29189,7 +29157,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -26
 	},
 /obj/item/taperecorder,
 /obj/item/camera,
@@ -29274,6 +29242,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"swg" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass{
+	amount = 20;
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "swh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
@@ -29352,7 +29341,7 @@
 "sAg" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 27
+	pixel_y = 26
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29837,6 +29826,19 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
+"sWz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/computer/bounty{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/head_of_personnel)
 "sWA" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/engineering_hacking{
@@ -29945,19 +29947,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"tcQ" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "tcU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -29984,7 +29973,7 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
-	pixel_x = 30
+	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -30135,15 +30124,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"tib" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "tiX" = (
 /obj/machinery/light{
 	dir = 4
@@ -30163,6 +30143,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"tjk" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
 "tjP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -30304,20 +30297,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"tqL" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Air to External"
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "tqM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -30819,6 +30798,21 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/circuit/green,
 /area/science/robotics/lab)
+"tMs" = (
+/obj/structure/table,
+/obj/item/multitool,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/item/clothing/head/soft,
+/obj/machinery/requests_console{
+	department = "Crew Quarters";
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "tMF" = (
 /obj/machinery/smartfridge/bloodbank/preloaded,
 /turf/closed/wall,
@@ -30831,7 +30825,7 @@
 /area/engine/engineering)
 "tNi" = (
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/structure/chair{
 	dir = 4
@@ -30939,6 +30933,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"tSe" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tSh" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -30961,7 +30965,7 @@
 /obj/machinery/requests_console{
 	department = "Chemistry";
 	departmentType = 2;
-	pixel_y = -30;
+	pixel_y = -32;
 	receive_ore_updates = 1
 	},
 /obj/structure/sink{
@@ -31022,6 +31026,23 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"tVP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -31703,6 +31724,17 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
+"uAO" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "uBi" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -32099,15 +32131,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"uOh" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/stripes/end,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "uOk" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 1
@@ -32795,7 +32818,7 @@
 /area/engine/atmospherics_engine)
 "vnz" = (
 /obj/machinery/light_switch{
-	pixel_y = 26
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -33071,20 +33094,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"vFE" = (
-/obj/machinery/pdapainter,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Head of Personnel's Office";
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/head_of_personnel)
 "vFM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -33143,16 +33152,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"vJF" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmospherics_engine)
 "vKa" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Pharmacy";
@@ -33211,6 +33210,15 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
+"vMw" = (
+/obj/effect/turf_decal/stripes/end,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "vMH" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
@@ -33234,6 +33242,27 @@
 	},
 /turf/closed/wall,
 /area/maintenance/aft/secondary)
+"vNL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 4;
+	dir = 1;
+	name = "Chief Engineer RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "vPc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -33659,6 +33688,17 @@
 /obj/item/wallframe/camera,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"wgV" = (
+/obj/machinery/camera{
+	c_tag = "Kitchen Cold Room"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "wgX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34394,7 +34434,7 @@
 /obj/machinery/vending/coffee,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 27
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -34428,6 +34468,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"wYd" = (
+/obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/grimy,
+/area/bridge/meeting_room)
 "wYx" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
@@ -34609,6 +34663,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"xeD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xeF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -35020,6 +35084,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"xtu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/gateway)
 "xtF" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
@@ -35077,8 +35151,7 @@
 /area/space/nearstation)
 "xvo" = (
 /obj/machinery/light_switch{
-	pixel_x = 27;
-	pixel_y = -10
+	pixel_y = -23
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/security/main";
@@ -35313,27 +35386,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"xDT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "xDU" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office";
@@ -35389,19 +35441,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"xEQ" = (
-/obj/machinery/photocopier,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -27
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/bridge/meeting_room)
 "xFL" = (
 /obj/machinery/meter/atmos,
 /obj/machinery/atmospherics/pipe/manifold4w/dark/visible,
@@ -60189,7 +60228,7 @@ ajd
 ajd
 ajd
 lZy
-tib
+aFl
 aSO
 piG
 awz
@@ -60711,7 +60750,7 @@ aAA
 aOH
 azV
 afD
-fWV
+dFY
 pWH
 ahk
 aFY
@@ -61226,7 +61265,7 @@ syJ
 arz
 afD
 wgM
-arM
+kzf
 ajG
 jCA
 hXc
@@ -61976,7 +62015,7 @@ ajd
 ajd
 ajd
 akf
-rKy
+mdR
 kDl
 soM
 rJj
@@ -63269,7 +63308,7 @@ qCX
 efp
 efp
 efp
-nOh
+baC
 fEx
 isu
 lvT
@@ -63277,7 +63316,7 @@ eBk
 wYx
 ndn
 anA
-azI
+ceP
 aYS
 awb
 abL
@@ -63793,9 +63832,9 @@ tHe
 ngR
 qtc
 sTS
-apK
+hPG
 aul
-aZx
+fyO
 awQ
 aWR
 aOb
@@ -64028,7 +64067,7 @@ aZu
 dNL
 hqt
 wJT
-dlN
+fVx
 ntK
 adS
 aMe
@@ -64054,7 +64093,7 @@ cIJ
 qbc
 oNz
 pme
-uOh
+vMw
 xNB
 uBz
 sSY
@@ -64592,7 +64631,7 @@ xpu
 xpu
 frg
 qhg
-lsn
+vNL
 oKB
 nkx
 phF
@@ -65042,7 +65081,7 @@ aTj
 jnz
 abq
 adr
-rVC
+dKE
 pPR
 arQ
 aXy
@@ -65067,7 +65106,7 @@ moU
 aev
 azg
 azg
-nZq
+eqQ
 oud
 cTg
 azg
@@ -65313,14 +65352,14 @@ tkz
 vbb
 ale
 aaL
-aAt
+tjk
 aRM
 agu
 vWM
 aSw
 aaL
-aWt
-aLd
+deT
+nbi
 aev
 sZw
 azg
@@ -65328,7 +65367,7 @@ xsq
 azg
 azg
 azg
-asa
+rGA
 pwn
 gOG
 jZo
@@ -65549,7 +65588,7 @@ xQs
 xjM
 pLs
 aHw
-ard
+xtu
 yla
 aSu
 aTj
@@ -65884,7 +65923,7 @@ cez
 fOx
 lYO
 kyt
-gXY
+lps
 eWf
 dzo
 ptl
@@ -66076,7 +66115,7 @@ avP
 jnz
 aTp
 aIZ
-adF
+swg
 tAT
 lqF
 xSL
@@ -66139,7 +66178,7 @@ pKc
 bHP
 gTG
 fOx
-mZU
+mwa
 afO
 gcT
 nLU
@@ -66333,7 +66372,7 @@ avP
 cMF
 aNS
 aIZ
-aCK
+tMs
 aMS
 jbE
 koO
@@ -66870,13 +66909,13 @@ pNb
 aev
 cyX
 qmd
-hzq
+deY
 rbW
 tvb
 auW
 hWm
-hmH
-vFE
+sWz
+iUq
 akw
 auW
 egu
@@ -67086,7 +67125,7 @@ amb
 nnG
 sJY
 pMR
-xEQ
+wYd
 pBO
 cnL
 pli
@@ -67360,7 +67399,7 @@ aJm
 avP
 jnz
 aUw
-mjp
+dGK
 cTX
 cTX
 xJS
@@ -67370,7 +67409,7 @@ oVf
 ars
 ars
 aaL
-tcQ
+fQo
 glW
 snd
 avX
@@ -67416,7 +67455,7 @@ qNp
 hDb
 hBE
 mFV
-pdZ
+rTn
 pXG
 cVT
 mFV
@@ -67874,7 +67913,7 @@ fOf
 avP
 qWA
 aUw
-ggv
+bff
 rRK
 rRK
 yaE
@@ -68186,7 +68225,7 @@ sdz
 pDi
 ixm
 qcI
-iAC
+oil
 aTO
 vRw
 rMH
@@ -68968,7 +69007,7 @@ jZS
 mEv
 pOn
 ekE
-vJF
+knx
 aZn
 iyN
 vmY
@@ -69220,7 +69259,7 @@ pXG
 rEZ
 fOx
 fOx
-cVf
+cQX
 jck
 mEv
 pOn
@@ -69433,7 +69472,7 @@ qmd
 wNN
 aeW
 aeW
-lss
+eqx
 auZ
 azv
 aeW
@@ -69451,7 +69490,7 @@ uRp
 bvc
 aAz
 aSx
-ncJ
+wgV
 nfc
 tjP
 awo
@@ -69465,7 +69504,7 @@ rlm
 eAw
 bPk
 eMQ
-tqL
+aVv
 nlk
 iNc
 lvx
@@ -70439,7 +70478,7 @@ lVw
 wQx
 eoi
 acj
-rfW
+tVP
 aJp
 lbP
 lon
@@ -70454,7 +70493,7 @@ gmM
 xZn
 iWi
 acj
-fvp
+kKk
 gEB
 lqN
 qmd
@@ -70501,7 +70540,7 @@ wpO
 fgz
 rQx
 iIH
-mTj
+pKV
 iWb
 iWb
 uCC
@@ -70952,7 +70991,7 @@ aNt
 eJg
 hIF
 auC
-aeX
+jfC
 icI
 acj
 aUc
@@ -70974,7 +71013,7 @@ bTd
 qmd
 fpH
 aeW
-azl
+onV
 akd
 sPX
 aCP
@@ -70982,7 +71021,7 @@ akd
 aKP
 ahG
 aeW
-bpm
+xeD
 seA
 qLz
 aCm
@@ -71255,7 +71294,7 @@ lVj
 aUN
 aPq
 aqt
-aVG
+iNM
 ahp
 vod
 tlt
@@ -71723,7 +71762,7 @@ atb
 yky
 evj
 aBP
-apD
+cJv
 mvT
 aXF
 atF
@@ -71757,7 +71796,7 @@ hOL
 hOL
 rhE
 aCm
-aIU
+oYk
 aZt
 amS
 avu
@@ -72249,7 +72288,7 @@ ayv
 aYj
 aXF
 avL
-asF
+iWT
 aAI
 kGH
 aos
@@ -73273,7 +73312,7 @@ mYi
 aPD
 aKH
 aaz
-aQa
+qjt
 aKN
 aPD
 hdp
@@ -73534,7 +73573,7 @@ aPD
 aPD
 aPD
 aUw
-pdw
+tSe
 cqa
 cqa
 cqa
@@ -73806,7 +73845,7 @@ aGL
 hIv
 llw
 aLl
-aut
+mLW
 nyx
 alk
 aaO
@@ -73815,7 +73854,7 @@ jhC
 jcL
 avo
 agq
-aRs
+uAO
 aLz
 aig
 aRL
@@ -74067,7 +74106,7 @@ aaO
 hTU
 aLl
 aLl
-xDT
+rCS
 uRO
 awX
 aNI
@@ -74313,14 +74352,14 @@ xRh
 hGK
 aTf
 apB
-aHv
+aCK
 amR
 akQ
 akb
 aGL
 pJo
 aPs
-aib
+kUN
 sBw
 abd
 aOa
@@ -74333,7 +74372,7 @@ aBp
 agh
 anK
 aKY
-afe
+sah
 aNI
 sQZ
 els
@@ -74560,7 +74599,7 @@ aUQ
 aDr
 aIT
 ayI
-aoh
+lmQ
 ahv
 adY
 aMQ
@@ -74827,7 +74866,7 @@ lXQ
 eMx
 rjk
 bms
-eON
+cmK
 gsV
 ufB
 agB
@@ -75099,7 +75138,7 @@ mpN
 aua
 xcJ
 aNI
-akS
+llR
 apV
 aUA
 ruG
@@ -76858,8 +76897,8 @@ ntM
 aAy
 aAy
 aAy
-arg
-amK
+hgF
+cPs
 dSG
 aOJ
 aPl
@@ -77141,8 +77180,8 @@ dza
 lQJ
 mJf
 aEE
-aPL
-adU
+nBy
+llm
 aRj
 arV
 kMu
@@ -78152,7 +78191,7 @@ ajd
 ajd
 agV
 arc
-aSJ
+npN
 azn
 scL
 aNO
@@ -78432,7 +78471,7 @@ hvs
 ojV
 kMu
 aPs
-aTq
+hUI
 hrr
 aMn
 paN
@@ -81270,7 +81309,7 @@ aZq
 aSr
 mDS
 ang
-aep
+han
 aQK
 avD
 aZq
@@ -82038,7 +82077,7 @@ aMl
 aZq
 aZq
 aZq
-aQs
+eBf
 oTI
 nZj
 bWH

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -272,8 +272,7 @@
 "aaW" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = -2;
-	pixel_y = -27
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -458,39 +457,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
-"acy" = (
-/obj/effect/landmark/start/ai,
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Common Channel";
-	pixel_x = -27;
-	pixel_y = -9
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_y = -31
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel";
-	pixel_x = 27;
-	pixel_y = -9
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -28;
-	pixel_y = -28
-	},
-/obj/machinery/requests_console{
-	department = "AI";
-	departmentType = 5;
-	pixel_x = 28;
-	pixel_y = -28
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "acC" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -638,17 +604,6 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ado" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/item/paper_bin,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adp" = (
@@ -1082,7 +1037,7 @@
 /obj/machinery/computer/bookmanagement,
 /obj/structure/table,
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -1766,8 +1721,8 @@
 	},
 /obj/machinery/light_switch{
 	dir = 9;
-	pixel_x = 24;
-	pixel_y = 4
+	pixel_x = -23;
+	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -1835,19 +1790,6 @@
 "ahL" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
-"ahM" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -27
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "ahN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -1863,15 +1805,6 @@
 "ahP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"ahQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
@@ -1911,7 +1844,7 @@
 "aih" = (
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_y = -30
 	},
 /obj/item/restraints/handcuffs,
 /obj/item/razor,
@@ -1960,7 +1893,8 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/light_switch{
 	dir = 9;
-	pixel_x = -22
+	pixel_x = -23;
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
@@ -2156,24 +2090,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"aiZ" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
 "ajc" = (
 /obj/structure/closet/secure_closet/brig,
 /turf/open/floor/plasteel/dark,
@@ -2273,7 +2189,7 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_y = 30
+	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -2504,7 +2420,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -27
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -2615,35 +2531,6 @@
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
-"akd" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/seccarts{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/storage/box/deputy,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
-"ake" = (
-/obj/structure/closet/secure_closet/hos,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	name = "Head of Security RC";
-	pixel_y = 30
-	},
-/obj/machinery/button/door{
-	id = "hos_spess_shutters";
-	name = "Space shutters";
-	pixel_x = 24;
-	req_access_txt = "1"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -3031,32 +2918,6 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/security/brig)
-"alq" = (
-/obj/item/storage/box/bodybags,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/item/reagent_containers/syringe{
-	name = "steel point"
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "alr" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -3487,18 +3348,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"amZ" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "anc" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -3736,6 +3585,17 @@
 "aoz" = (
 /turf/closed/wall,
 /area/maintenance/fore)
+"aoB" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "aoG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3848,7 +3708,7 @@
 "aoY" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light_switch{
-	pixel_y = -22
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -4141,7 +4001,7 @@
 /area/ai_monitored/nuke_storage)
 "aqM" = (
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = -23
 	},
 /turf/open/floor/circuit/green{
 	luminosity = 2
@@ -4175,20 +4035,6 @@
 /area/ai_monitored/nuke_storage)
 "aqT" = (
 /obj/machinery/computer/arcade,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/dorms)
-"aqU" = (
-/obj/machinery/washing_machine,
-/obj/machinery/requests_console{
-	department = "Crew Quarters";
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -5098,20 +4944,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"aui" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/exile,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
 "auj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -5397,13 +5229,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avk" = (
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"avl" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avm" = (
@@ -5903,44 +5728,9 @@
 	},
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
-"awY" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "axb" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"axe" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/computer/rdconsole{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -6032,7 +5822,7 @@
 /area/hallway/primary/fore)
 "axH" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -6092,18 +5882,6 @@
 /obj/machinery/suit_storage_unit/captain,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
-"axT" = (
-/obj/structure/table/wood,
-/obj/machinery/recharger,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Captain's Desk";
-	departmentType = 5;
-	name = "Captain RC";
-	pixel_y = 30
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
 "axU" = (
 /obj/machinery/computer/card,
 /obj/item/radio/intercom{
@@ -6122,21 +5900,6 @@
 /obj/structure/filingcabinet/employment,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
-"axX" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "axZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6220,16 +5983,6 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"aym" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "ayn" = (
 /obj/structure/chair/comfy{
@@ -6642,7 +6395,8 @@
 /obj/item/flashlight/lamp/green,
 /obj/machinery/light_switch{
 	dir = 9;
-	pixel_x = -22
+	pixel_x = -23;
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
@@ -6724,7 +6478,7 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -6796,16 +6550,6 @@
 "aBd" = (
 /turf/closed/wall,
 /area/security/detectives_office)
-"aBg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aBh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red,
@@ -6827,13 +6571,6 @@
 "aBo" = (
 /obj/structure/chair{
 	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
-"aBp" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
@@ -6902,7 +6639,7 @@
 /obj/machinery/computer/cargo/request,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/head_of_personnel)
@@ -6913,34 +6650,6 @@
 	name = "Monastery Monitor";
 	network = list("monastery");
 	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/head_of_personnel)
-"aBD" = (
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_y = 2
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Head of Personnel's Office"
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/head_of_personnel)
-"aBE" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Personnel's Desk";
-	departmentType = 5;
-	name = "Head of Personnel RC";
-	pixel_y = 30
-	},
-/obj/machinery/pdapainter{
-	pixel_y = 2
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/head_of_personnel)
@@ -7116,16 +6825,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"aCj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Detective's office";
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
 "aCk" = (
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -7148,8 +6847,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/light_switch{
-	pixel_x = -8;
-	pixel_y = 27
+	pixel_y = -23
 	},
 /obj/structure/filingcabinet/security,
 /turf/open/floor/plasteel/grimy,
@@ -7190,35 +6888,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/storage/primary)
-"aCs" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/storage/primary)
-"aCt" = (
-/obj/structure/table,
-/obj/item/wrench,
-/obj/item/analyzer,
-/obj/machinery/requests_console{
-	department = "Tool Storage";
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -7499,15 +7168,6 @@
 	dir = 8
 	},
 /area/crew_quarters/dorms)
-"aDo" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
 "aDp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -7532,17 +7192,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"aDu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aDv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
@@ -7560,17 +7209,6 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aDA" = (
-/turf/open/floor/plasteel,
-/area/storage/primary)
-"aDB" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aDC" = (
@@ -7667,8 +7305,7 @@
 /area/hallway/primary/central)
 "aEb" = (
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 1
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -7769,7 +7406,8 @@
 	},
 /obj/machinery/light_switch{
 	dir = 9;
-	pixel_x = -22
+	pixel_x = -23;
+	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7975,33 +7613,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/head_of_personnel)
-"aEQ" = (
-/obj/structure/chair/office,
-/obj/machinery/button/flasher{
-	id = "foflash";
-	pixel_x = 38;
-	pixel_y = -25
-	},
-/obj/machinery/button/door{
-	id = "head_of_personnel";
-	name = "Privacy Shutters Control";
-	pixel_x = 25;
-	pixel_y = -26;
-	req_access_txt = "28"
-	},
-/obj/machinery/button/door{
-	id = "foqueue";
-	name = "Queue Shutters Control";
-	pixel_x = 25;
-	pixel_y = -36;
-	req_access_txt = "28"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 38;
-	pixel_y = -35
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/head_of_personnel)
 "aES" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway Vault";
@@ -8045,13 +7656,7 @@
 /area/crew_quarters/toilet/restrooms)
 "aFb" = (
 /obj/machinery/light_switch{
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
-"aFc" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
@@ -8169,22 +7774,6 @@
 /obj/item/taperecorder,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aFF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-20";
-	pixel_y = 3
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
 "aFG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -8765,7 +8354,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -8812,7 +8401,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -8870,6 +8459,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aIW" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "aIZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -9129,12 +8734,6 @@
 	dir = 4
 	},
 /area/hallway/primary/central)
-"aKh" = (
-/obj/machinery/light_switch{
-	pixel_x = -25
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
 "aKj" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -9475,27 +9074,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aMd" = (
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_x = -32
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 30
-	},
-/obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
 "aMe" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/light{
@@ -9695,7 +9273,8 @@
 	},
 /obj/machinery/light_switch{
 	dir = 9;
-	pixel_x = -22
+	pixel_x = -23;
+	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -9716,7 +9295,8 @@
 	},
 /obj/machinery/light_switch{
 	dir = 9;
-	pixel_x = -22
+	pixel_x = -23;
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/cafeteria)
@@ -9959,23 +9539,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"aNM" = (
-/obj/item/storage/box,
-/obj/item/storage/box,
-/obj/item/storage/box,
-/obj/item/hand_labeler,
-/obj/item/hand_labeler,
-/obj/structure/table,
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "aNO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -9987,7 +9550,7 @@
 /area/quartermaster/warehouse)
 "aNQ" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_y = -30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -10203,24 +9766,6 @@
 	},
 /turf/open/space,
 /area/solar/port)
-"aOB" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "EVA";
-	pixel_x = -32
-	},
-/obj/machinery/camera{
-	c_tag = "EVA Storage";
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/storage/eva)
 "aOC" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/stripes/end,
@@ -10247,7 +9792,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/blue{
@@ -10393,6 +9938,21 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
+"aPp" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	dir = 8;
+	name = "Medbay RC";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "aPq" = (
 /obj/machinery/light{
 	dir = 4
@@ -10458,7 +10018,7 @@
 "aPH" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -10609,23 +10169,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"aQb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Mailroom";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -10863,14 +10406,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
-"aRh" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light_switch{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "aRi" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
@@ -11182,14 +10717,6 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
-"aSA" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "aSC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11326,7 +10853,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -11492,6 +11019,14 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
+"aTN" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "aTO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
@@ -11500,18 +11035,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aTP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aTQ" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -11565,13 +11091,13 @@
 /obj/machinery/requests_console{
 	department = "Kitchen";
 	departmentType = 2;
-	pixel_y = 30
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aUa" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/item/crowbar,
 /obj/item/wrench,
@@ -11833,43 +11359,9 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"aVf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "aVg" = (
 /obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/table,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"aVh" = (
-/obj/structure/table/glass,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/reagent_containers/food/drinks/bottle/patron{
-	pixel_x = -5;
-	pixel_y = 16
-	},
-/obj/item/reagent_containers/food/drinks/bottle/cognac{
-	pixel_x = -10;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/bottle/grappa{
-	pixel_x = 10;
-	pixel_y = 15
-	},
-/obj/item/reagent_containers/food/drinks/bottle/vodka{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = 22
-	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aVi" = (
@@ -12007,22 +11499,6 @@
 "aVu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aVv" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/conveyor_switch{
-	id = "cargodeliver"
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -12229,15 +11705,6 @@
 	},
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
-"aWb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "aWd" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -12429,7 +11896,7 @@
 /obj/effect/landmark/start/janitor,
 /obj/item/bedsheet/purple,
 /obj/machinery/light_switch{
-	pixel_x = 24
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12471,7 +11938,7 @@
 /obj/machinery/requests_console{
 	department = "Hydroponics";
 	departmentType = 2;
-	pixel_y = 30
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -12479,20 +11946,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 21
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"aWT" = (
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 38
-	},
-/obj/structure/sink/kitchen{
-	name = "utility sink";
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -12580,52 +12033,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"aXl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Theatre Storage";
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
-"aXm" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	sortType = 18
-	},
-/obj/machinery/requests_console{
-	department = "Theatre";
-	name = "theatre RC";
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
 "aXn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12695,20 +12102,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aXv" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Foyer";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "aXw" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -12768,7 +12161,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -28
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -13084,23 +12477,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
-"aYn" = (
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_x = -32
-	},
-/obj/machinery/computer/cargo{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "aYo" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -13160,20 +12536,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"aYu" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -13258,29 +12620,6 @@
 "aYG" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
-"aYH" = (
-/obj/machinery/computer/security{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
 "aYI" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -13399,28 +12738,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"aZa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "aZb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13492,7 +12809,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -13506,27 +12823,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"aZg" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"aZh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aZi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
@@ -13751,20 +13047,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/janitor)
-"aZR" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "aZS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -13875,8 +13157,7 @@
 "ban" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 1
+	pixel_y = -30
 	},
 /obj/structure/chair/wood,
 /obj/effect/turf_decal/tile/neutral{
@@ -13918,30 +13199,6 @@
 	icon_state = "carpetsymbol"
 	},
 /area/crew_quarters/bar)
-"bar" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bas" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
-/obj/item/paper_bin{
-	layer = 2.9
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "bat" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -14530,23 +13787,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"bcD" = (
-/obj/structure/closet/wardrobe/miner,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "bcF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/brown{
@@ -14623,20 +13863,6 @@
 "bdh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/janitor)
-"bdi" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
-	},
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = 22
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -14764,17 +13990,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"bdM" = (
-/obj/machinery/requests_console{
-	department = "Mining";
-	pixel_x = 32
-	},
-/obj/machinery/computer/security/mining{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "bdR" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -14828,7 +14043,7 @@
 	},
 /obj/item/storage/box/mousetraps,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+	pixel_y = -30
 	},
 /obj/item/clothing/head/crown,
 /obj/effect/decal/cleanable/dirt,
@@ -15165,16 +14380,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"bfb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -29
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "bfj" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -15273,7 +14478,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 24
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
@@ -15286,7 +14491,7 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = -30
+	pixel_y = -32
 	},
 /obj/item/pen,
 /obj/effect/turf_decal/tile/brown{
@@ -15310,7 +14515,7 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/item/cartridge/quartermaster{
 	pixel_x = 6;
@@ -15491,18 +14696,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
-"bgn" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bgo" = (
 /obj/structure/table,
 /obj/item/trash/plate,
@@ -15567,7 +14760,7 @@
 "bgx" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 27
+	pixel_y = 26
 	},
 /obj/structure/chair,
 /obj/item/clothing/mask/cigarette,
@@ -15761,7 +14954,7 @@
 "bhv" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -15786,15 +14979,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"bhF" = (
-/obj/structure/chair/comfy/beige{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/lounge)
 "bhG" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/lounge)
@@ -15808,16 +14992,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/lounge)
-"bhJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = -1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bhL" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=BrigS1";
@@ -15939,17 +15113,6 @@
 "bik" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bil" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
@@ -16267,28 +15430,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"bjX" = (
-/obj/structure/filingcabinet,
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/medical)
 "bjY" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -16391,33 +15532,6 @@
 "bkh" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bki" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bkm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bkn" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Sci3";
@@ -16537,14 +15651,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"bkT" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "bkW" = (
 /obj/item/hemostat,
 /obj/item/retractor,
@@ -16553,12 +15659,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"bkX" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/freezer,
-/area/storage/emergency/port)
 "blc" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -16588,7 +15688,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -16646,15 +15746,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"blp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26;
-	pixel_y = 28
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -16734,18 +15825,6 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bly" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26;
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -16855,22 +15934,6 @@
 /obj/structure/sink/kitchen{
 	name = "utility sink";
 	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
-"blI" = (
-/obj/machinery/requests_console{
-	department = "Robotics";
-	departmentType = 2;
-	name = "Robotics RC";
-	pixel_y = 30;
-	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -17153,7 +16216,7 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -17300,35 +16363,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/storage/emergency/port)
-"bny" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-11"
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/storage/emergency/port)
-"bnz" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/storage/fancy/candle_box,
-/obj/machinery/light_switch{
-	pixel_x = 22
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "bnC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -17422,27 +16456,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bnO" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
 "bnP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -17585,7 +16598,7 @@
 /obj/machinery/vending/clothing,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 27
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -17750,32 +16763,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
-"boU" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -2;
-	pixel_y = -27
-	},
-/obj/machinery/camera{
-	c_tag = "Research Division Lobby";
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/aft)
 "boX" = (
 /obj/machinery/computer/rdconsole/robotics{
 	dir = 4
@@ -17788,8 +16775,7 @@
 	req_access_txt = "29"
 	},
 /obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = -8
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -18096,24 +17082,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"bqo" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
 "bqp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -18180,14 +17148,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"bqC" = (
-/obj/machinery/monkey_recycler,
-/obj/structure/window/reinforced,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "bqE" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -18295,6 +17255,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"bri" = (
+/obj/structure/closet/l3closet,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "brj" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
@@ -18429,20 +17409,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"bru" = (
-/obj/machinery/holopad,
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "brv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/airalarm/unlocked{
@@ -18561,7 +17527,7 @@
 	name = "Connector Port (Air Supply)"
 	},
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -18759,7 +17725,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -26
+	pixel_x = 26
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -18913,20 +17879,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"bsN" = (
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "bsR" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
@@ -18944,21 +17896,6 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bsV" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -19050,25 +17987,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/science/server)
-"btg" = (
-/obj/structure/rack,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/item/multitool,
-/obj/item/multitool,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/item/book/manual/wiki/experimentor,
-/turf/open/floor/plasteel/white,
-/area/science/explab)
 "bth" = (
 /obj/effect/turf_decal/bot/right,
 /obj/structure/cable/yellow{
@@ -19318,24 +18236,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"buj" = (
-/obj/machinery/chem_heater,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/obj/machinery/camera{
-	c_tag = "Chemistry";
-	dir = 4;
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "buk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -19400,19 +18300,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"buw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/kirbyplants/photosynthetic{
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
 "buy" = (
 /obj/item/kirbyplants/photosynthetic{
 	pixel_y = 10
@@ -19502,21 +18389,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"buU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -29
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
 "bva" = (
 /turf/closed/wall,
 /area/maintenance/department/engine)
@@ -19543,27 +18415,6 @@
 /obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
-"bvj" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 3;
-	name = "Atmos RC";
-	pixel_y = 30
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bvp" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -19625,21 +18476,6 @@
 "bvB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bvC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = 34
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -19844,7 +18680,7 @@
 "bwc" = (
 /obj/machinery/chem_master,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
@@ -19895,7 +18731,7 @@
 	pixel_y = 24
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -19948,24 +18784,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"bwB" = (
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/masks,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/zone2)
 "bwD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20121,34 +18939,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"bwW" = (
-/obj/structure/rack,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"bxa" = (
-/obj/structure/table/glass,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/item/book/manual/wiki/research_and_development,
-/obj/item/disk/tech_disk,
-/obj/item/disk/design_disk,
-/turf/open/floor/plasteel/dark,
-/area/science/lab)
 "bxd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -20268,7 +19058,7 @@
 /area/hallway/secondary/entry)
 "bya" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -20322,27 +19112,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"byk" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/storage/box/monkeycubes,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "byl" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+	pixel_y = -30
 	},
 /obj/machinery/light{
 	dir = 8
@@ -20920,26 +19692,6 @@
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
 /area/crew_quarters/heads/cmo)
-"bAa" = (
-/obj/machinery/computer/crew,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer RC";
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/cmo)
 "bAc" = (
 /obj/machinery/computer/card/minor/cmo,
 /obj/machinery/airalarm{
@@ -21133,21 +19885,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"bAV" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Genetics";
-	name = "Genetics Requests Console";
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "bAW" = (
 /turf/closed/wall,
 /area/medical/virology)
@@ -21332,19 +20069,6 @@
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/engine,
 /area/science/storage)
-"bBH" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
 "bBJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/purple,
@@ -21353,17 +20077,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"bBK" = (
-/obj/structure/closet/bombcloset,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/mixing)
 "bBL" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/airalarm{
@@ -21404,29 +20117,13 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"bBT" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+"bBR" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/mixing)
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "bBU" = (
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
@@ -21505,7 +20202,7 @@
 "bCi" = (
 /obj/structure/table/glass,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+	pixel_y = -30
 	},
 /obj/item/book/manual/wiki/medicine,
 /obj/item/stack/medical/gauze,
@@ -21632,7 +20329,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -28
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -21740,31 +20437,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/mixing)
-"bDd" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science Requests Console";
-	pixel_x = 32;
-	receive_ore_updates = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/item/wrench,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -22082,33 +20754,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"bEd" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/dark,
-/area/science/mixing)
 "bEf" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -22170,19 +20815,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"bEv" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/rnd/production/techfab/department/medical,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bEw" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/brute{
@@ -22319,29 +20951,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"bEG" = (
-/obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Medical Officer"
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/cmo)
 "bEH" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-16"
 	},
 /obj/machinery/light_switch{
-	pixel_y = -22
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -22378,7 +20993,8 @@
 	},
 /obj/machinery/light_switch{
 	dir = 9;
-	pixel_x = -22
+	pixel_x = -23;
+	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -22397,7 +21013,7 @@
 	department = "Research Director's Desk";
 	departmentType = 5;
 	name = "Research Director RC";
-	pixel_y = -30;
+	pixel_y = -32;
 	receive_ore_updates = 1
 	},
 /obj/machinery/light,
@@ -22576,26 +21192,6 @@
 "bFl" = (
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"bFp" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/mixing)
 "bFr" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -22730,20 +21326,6 @@
 "bFO" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay/central)
-"bFP" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bFQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -22794,37 +21376,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/security/checkpoint/science)
-"bGd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bGe" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/aft)
 "bGf" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -22872,8 +21423,7 @@
 "bGm" = (
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 8
+	pixel_x = -23
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -23115,31 +21665,6 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
-"bGS" = (
-/obj/machinery/doorButtons/airlock_controller{
-	idExterior = "virology_airlock_exterior";
-	idInterior = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_x = 8;
-	pixel_y = 22;
-	req_access_txt = "39"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bGV" = (
 /obj/machinery/shower{
 	dir = 4
@@ -23174,31 +21699,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bHa" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"bHb" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/surgery)
 "bHc" = (
 /obj/machinery/computer/med_data,
 /obj/machinery/status_display/evac{
@@ -23210,7 +21710,7 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+	pixel_y = -30
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -23615,7 +22115,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/machinery/light_switch{
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -23959,28 +22459,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"bJk" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/infections,
-/obj/item/hand_labeler,
-/obj/item/radio/headset/headset_med,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bJl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -23991,35 +22469,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"bJn" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"bJo" = (
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_x = -30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bJp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -24116,23 +22565,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bJH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -29
-	},
-/obj/machinery/camera{
-	c_tag = "Research Division Entrance";
-	dir = 1
-	},
-/obj/machinery/light,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -24618,24 +23050,6 @@
 /obj/item/clothing/gloves/color/latex,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"bLE" = (
-/obj/structure/table/glass,
-/obj/machinery/requests_console{
-	department = "Virology";
-	name = "Virology Requests Console";
-	pixel_x = 32;
-	receive_ore_updates = 1
-	},
-/obj/item/paper_bin{
-	layer = 2.9
-	},
-/obj/item/pen/red,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bLF" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -24646,7 +23060,7 @@
 	layer = 3.2
 	},
 /obj/machinery/light_switch{
-	pixel_x = -22
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/medbay/central)
@@ -24710,7 +23124,7 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/suit/apron/surgical,
 /obj/machinery/light_switch{
-	pixel_x = -22
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -25407,31 +23821,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/asteroid/monastery)
-"bNt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/machinery/light/small,
-/obj/machinery/camera{
-	c_tag = "Monastery Dock";
-	dir = 1;
-	network = list("ss13","monastery")
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/dock)
 "bNu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -25801,16 +24190,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"bOK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bOL" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -26115,20 +24494,6 @@
 "bPE" = (
 /turf/closed/wall,
 /area/storage/tech)
-"bPG" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bPI" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
@@ -26203,18 +24568,6 @@
 /area/engine/atmos)
 "bPS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bPT" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Air to Port"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPU" = (
@@ -26307,7 +24660,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
@@ -26334,7 +24687,7 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+	pixel_y = -30
 	},
 /obj/item/aicard,
 /obj/item/aiModule/reset,
@@ -26362,7 +24715,7 @@
 /obj/item/stock_parts/cell/high/plus,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -26709,25 +25062,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bRu" = (
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 3;
-	name = "Atmos RC";
-	pixel_x = 30
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/computer/atmos_alert{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -27121,18 +25455,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bSR" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Filter"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bSS" = (
 /obj/item/beacon,
 /turf/open/floor/plasteel,
@@ -27501,7 +25823,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -27794,7 +26116,7 @@
 	department = "Chief Engineer's Desk";
 	departmentType = 4;
 	name = "Chief Engineer RC";
-	pixel_x = -32
+	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -27843,7 +26165,7 @@
 /obj/machinery/computer/station_alert,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -27881,28 +26203,6 @@
 "bUU" = (
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
-"bUV" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_x = -32
-	},
-/obj/item/paper_bin{
-	layer = 2.9
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "bVb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28141,20 +26441,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"bVU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 27;
-	pixel_y = -25
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bVW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -28249,20 +26535,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"bWn" = (
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/item/clothing/glasses/meson/gar,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "bWo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -28272,19 +26544,6 @@
 "bWp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
-"bWr" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = 22
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -28501,7 +26760,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_x = 25
+	pixel_y = -23
 	},
 /obj/machinery/button/door{
 	desc = "A remote control-switch for secure storage.";
@@ -28949,7 +27208,7 @@
 /area/engine/atmos)
 "bZO" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -29350,31 +27609,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ccc" = (
-/obj/structure/closet/radiation,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cce" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
-"cch" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cci" = (
 /obj/structure/chair/stool,
@@ -29392,23 +27631,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"ccp" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
 "ccr" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/dark,
@@ -30638,7 +28860,7 @@
 /area/maintenance/department/chapel/monastery)
 "ckk" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+	pixel_y = -30
 	},
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plating,
@@ -30730,7 +28952,7 @@
 /obj/structure/chair/wood,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -28
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
@@ -30989,6 +29211,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"clY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cme" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -31018,7 +29259,7 @@
 	department = "Telecomms Admin";
 	departmentType = 5;
 	name = "Telecomms RC";
-	pixel_y = 30
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -31759,8 +30000,7 @@
 	req_access_txt = "28"
 	},
 /obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = -24
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -32039,7 +30279,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
@@ -32349,32 +30589,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"csn" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/obj/machinery/requests_console{
-	department = "Chapel";
-	departmentType = 2;
-	pixel_x = -32
-	},
-/obj/structure/closet,
-/obj/item/storage/backpack/cultpack,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplainsuit/nun,
-/obj/item/clothing/suit/chaplainsuit/holidaypriest,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "cso" = (
 /obj/structure/table/wood,
 /obj/item/nullrod,
@@ -32500,23 +30714,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"csY" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "cta" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32703,26 +30900,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"cuc" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Xenobiology Central";
-	dir = 1;
-	network = list("ss13","rd")
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -29
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
 "cuh" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -32794,18 +30971,6 @@
 /area/chapel/main/monastery)
 "cut" = (
 /obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
-/area/chapel/main/monastery)
-"cuu" = (
-/obj/item/storage/bag/plants,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/storage/bag/plants/portaseeder,
 /turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cuv" = (
@@ -33086,6 +31251,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"cvA" = (
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/lounge)
 "cvB" = (
 /obj/structure/chair/wood,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -33347,8 +31522,7 @@
 /area/space/nearstation)
 "cxn" = (
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
@@ -33533,7 +31707,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -33564,6 +31738,24 @@
 /obj/structure/displaycase/trophy,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"czf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "czh" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/engineering{
@@ -33630,7 +31822,7 @@
 /area/library)
 "czw" = (
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -33980,7 +32172,7 @@
 /area/maintenance/department/crew_quarters/dorms)
 "cBn" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+	pixel_y = -30
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -34026,6 +32218,20 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/department/crew_quarters/dorms)
+"cBx" = (
+/obj/machinery/rnd/production/techfab/department/medical,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "cBA" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating{
@@ -34679,6 +32885,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"cWk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "cWC" = (
 /obj/machinery/power/turbine{
 	dir = 4;
@@ -34792,6 +33012,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"daH" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "daY" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -34830,27 +33059,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"dbn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
 "dbs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -34971,6 +33179,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"dgC" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
 "dhr" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/nanite";
@@ -35042,6 +33271,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"dkz" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dkD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -35162,6 +33404,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
+"doK" = (
+/obj/machinery/computer/security/mining{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/requests_console{
+	department = "Mining";
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "dpb" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
@@ -35262,8 +33516,7 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_x = 36;
-	pixel_y = 6
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -35436,6 +33689,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"duA" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "duF" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -35526,6 +33793,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"dxg" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/seccarts{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/storage/box/deputy,
+/obj/machinery/newscaster/security_unit{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "dxo" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -35639,24 +33919,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
-"dDo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "dDD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -35700,6 +33962,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"dEI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "dGL" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage";
@@ -35911,6 +34187,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"dLO" = (
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
+	dir = 1;
+	name = "Captain RC";
+	pixel_y = 32
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain)
 "dLW" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Storage"
@@ -35977,6 +34266,24 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"dNO" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/machinery/computer/rdconsole{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "dOz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -36071,6 +34378,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"dSn" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dSr" = (
 /obj/item/chair,
 /turf/open/floor/wood,
@@ -36084,6 +34402,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"dSA" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/exile,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/gateway)
 "dSD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -36356,6 +34688,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"ebQ" = (
+/obj/machinery/photocopier,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "ecr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -36484,6 +34824,36 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
+"ejg" = (
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/storage/fancy/candle_box,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
+"ejX" = (
+/obj/structure/rack,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "eki" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -36545,6 +34915,23 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"emq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "emP" = (
 /obj/machinery/ai_slipper{
 	uses = 8
@@ -36790,6 +35177,15 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"exi" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "eya" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37326,6 +35722,30 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"eLJ" = (
+/obj/machinery/camera{
+	c_tag = "Research Division Lobby";
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "eMp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37496,20 +35916,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"eQq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/item/storage/toolbox,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plating,
-/area/storage/emergency/starboard)
 "eQN" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37638,43 +36044,27 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_y = -28
+	pixel_y = -30
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"eYr" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+"eXx" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Experimentation Lab Central";
-	network = list("ss13","rd")
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science Requests Console";
-	pixel_y = 30;
-	receive_ore_updates = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
+/turf/open/floor/plasteel,
+/area/janitor)
 "eYM" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -38220,6 +36610,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fsh" = (
+/obj/item/storage/box/bodybags,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/glass,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/obj/item/reagent_containers/syringe{
+	name = "steel point"
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal,
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "fsB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -38248,6 +36665,25 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
+"ftJ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/table/glass,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/masks,
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	dir = 8;
+	name = "Medbay RC";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/zone2)
 "ftW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -38319,8 +36755,7 @@
 	dir = 9
 	},
 /obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = 24
+	pixel_y = -23
 	},
 /obj/structure/mirror{
 	pixel_x = 28;
@@ -38537,6 +36972,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"fBM" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "fCC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -38663,6 +37116,26 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
+"fFX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/computer/atmos_alert{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 3;
+	dir = 4;
+	name = "Atmos RC";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fGa" = (
 /mob/living/carbon/monkey,
 /turf/open/floor/grass,
@@ -38715,7 +37188,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38747,6 +37220,22 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/asteroid/monastery)
+"fIH" = (
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_y = 2
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Head of Personnel's Office"
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/head_of_personnel)
 "fIN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -39393,7 +37882,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -39429,7 +37918,7 @@
 "gdL" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -28
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -39654,20 +38143,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
-"gkR" = (
-/obj/item/kirbyplants/random,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "gkS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -39859,6 +38334,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"grN" = (
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/obj/structure/closet,
+/obj/item/storage/backpack/cultpack,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplainsuit/nun,
+/obj/item/clothing/suit/chaplainsuit/holidaypriest,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Chapel";
+	departmentType = 2;
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "gsx" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/engineering/glass{
@@ -40108,6 +38610,20 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"gyz" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/chief)
 "gyP" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -40195,6 +38711,16 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"gCs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "gCX" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -40277,33 +38803,25 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
+"gFJ" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/explab)
 "gGy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"gGA" = (
-/obj/machinery/requests_console{
-	department = "Chemistry";
-	departmentType = 2;
-	pixel_x = 32;
-	receive_ore_updates = 1
-	},
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "gHe" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Supplies";
@@ -40402,7 +38920,7 @@
 /area/crew_quarters/heads/chief)
 "gLa" = (
 /obj/machinery/light_switch{
-	pixel_x = 25
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40605,6 +39123,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"gOJ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "gPV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -40782,6 +39317,24 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"gVO" = (
+/obj/item/storage/box,
+/obj/item/storage/box,
+/obj/item/storage/box,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "gWk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -40865,6 +39418,15 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"gYN" = (
+/obj/machinery/monkey_recycler,
+/obj/structure/window/reinforced,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "gYR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41049,7 +39611,7 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = 32;
+	pixel_y = -32;
 	receive_ore_updates = 1
 	},
 /turf/open/floor/plasteel,
@@ -41559,6 +40121,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"hwJ" = (
+/obj/structure/table/glass,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/drinks/bottle/patron{
+	pixel_x = -5;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/food/drinks/bottle/cognac{
+	pixel_x = -10;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/bottle/grappa{
+	pixel_x = 10;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "hxn" = (
 /obj/structure/chair,
 /obj/item/clothing/glasses/regular,
@@ -41622,6 +40211,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"hzG" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Air to Port"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hzW" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Departure Lounge"
@@ -41969,7 +40571,7 @@
 	light_color = "#c1caff"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	pixel_y = -30
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42293,6 +40895,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"hYO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "hYW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/disposalpipe/segment,
@@ -42540,6 +41160,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ikQ" = (
+/obj/structure/filingcabinet,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/medical)
 "ilm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42602,6 +41245,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"inJ" = (
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "virology_airlock_exterior";
+	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = 8;
+	pixel_y = 22;
+	req_access_txt = "39"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "ioj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -42954,6 +41623,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"iDI" = (
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Crew Quarters";
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/dorms)
 "iDN" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -42964,6 +41648,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/chapel/office)
+"iEP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iEQ" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -42986,30 +41689,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
-"iGa" = (
-/obj/machinery/power/apc/highcap/ten_k{
-	dir = 1;
-	name = "Research Division APC";
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
 "iGK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -43033,6 +41712,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"iGO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "iGX" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -43282,7 +41969,7 @@
 /area/science/xenobiology)
 "iPz" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+	pixel_y = -30
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -43703,6 +42390,20 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"jeC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "jfo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -43735,6 +42436,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"jgp" = (
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "jgF" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Firing Range"
@@ -43776,6 +42495,32 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"jhF" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/item/wrench,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	dir = 4;
+	name = "Science Requests Console";
+	pixel_x = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/mixing)
 "jhH" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "rndshutters";
@@ -43978,6 +42723,17 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/lounge)
+"jmz" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/research_and_development,
+/obj/item/disk/tech_disk,
+/obj/item/disk/design_disk,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/lab)
 "jmE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc/highcap/ten_k{
@@ -44103,7 +42859,7 @@
 	department = "Engineering";
 	departmentType = 3;
 	name = "Engineering RC";
-	pixel_x = -32
+	pixel_y = -32
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/shower{
@@ -44290,6 +43046,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"jxX" = (
+/obj/structure/closet/secure_closet/hos,
+/obj/machinery/button/door{
+	id = "hos_spess_shutters";
+	name = "Space shutters";
+	pixel_x = 24;
+	req_access_txt = "1"
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	dir = 1;
+	name = "Head of Security RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "jyb" = (
 /obj/item/book/manual/wiki/engineering_hacking{
 	pixel_x = 3;
@@ -44331,6 +43105,23 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"jAe" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "jAh" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow,
@@ -44365,6 +43156,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"jAP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Port to Filter"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "jBh" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty{
@@ -44413,6 +43217,23 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"jEA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "Cargo Mailroom";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "jFu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -44580,6 +43401,19 @@
 /obj/structure/particle_accelerator/end_cap,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"jLj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	pixel_x = 32;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "jLT" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
@@ -44735,6 +43569,19 @@
 /obj/structure/sign/departments/science,
 /turf/closed/wall,
 /area/maintenance/department/engine)
+"jSF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "jSG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -44892,7 +43739,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 27
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
@@ -45776,18 +44623,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kDJ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "EngLoad"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kDX" = (
 /obj/machinery/door/airlock{
 	name = "Dormitories"
@@ -45872,13 +44707,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"kEW" = (
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "kFm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -45914,26 +44742,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"kFD" = (
-/obj/structure/closet/l3closet,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -27
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
 "kFR" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -45995,6 +44803,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"kHI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	dir = 8;
+	name = "Medbay RC";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "kHP" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -46693,6 +45518,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
+"lfN" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "lhn" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
@@ -46719,6 +45551,17 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"lhL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "lib" = (
 /obj/structure/chair/comfy/brown,
 /obj/structure/disposalpipe/segment{
@@ -46732,6 +45575,27 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
+"lih" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/mixing)
 "lje" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plating,
@@ -46789,6 +45653,24 @@
 	},
 /turf/closed/wall,
 /area/maintenance/department/engine)
+"lne" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "lnn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -46858,6 +45740,21 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"lpY" = (
+/obj/structure/table,
+/obj/item/pen,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/obj/item/paper_bin{
+	layer = 2.9
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "lqc" = (
 /obj/item/toy/gun,
 /obj/effect/decal/cleanable/oil,
@@ -46877,6 +45774,22 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"lsH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "lsI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/directions/engineering{
@@ -47065,6 +45978,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"lzT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "lAd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -47163,6 +46083,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"lFJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/exit/departure_lounge)
 "lGp" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plasteel/dark,
@@ -47801,6 +46733,23 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/asteroid/monastery)
+"mkj" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "mkv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -47932,7 +46881,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/light_switch{
-	pixel_x = 22
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -47946,6 +46895,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"mqZ" = (
+/obj/item/storage/bag/plants,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/chapel/main/monastery)
 "mrx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced/shutters,
@@ -48157,6 +47119,29 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"mxM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "mxR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
@@ -48174,21 +47159,6 @@
 	},
 /turf/closed/wall,
 /area/science/mixing)
-"myJ" = (
-/obj/machinery/camera{
-	c_tag = "Toxins Storage";
-	dir = 8;
-	network = list("ss13","rd")
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/science/storage)
 "mzb" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Eng3";
@@ -48222,6 +47192,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/department/engine)
+"mzZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-20";
+	pixel_y = 3
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/captain)
 "mAe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -48293,19 +47280,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"mCH" = (
-/obj/machinery/camera{
-	c_tag = "Captain's Office";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
 "mDk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48332,6 +47306,28 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"mDy" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Chemistry";
+	departmentType = 2;
+	dir = 4;
+	pixel_x = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "mDG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/security{
@@ -48364,6 +47360,17 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"mEL" = (
+/obj/structure/closet/bombcloset,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/mixing)
 "mET" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -48453,23 +47460,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"mGH" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -27
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "mHk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -48510,6 +47500,25 @@
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
+"mKI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/kirbyplants{
+	icon_state = "plant-11"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1"
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/storage/emergency/port)
 "mKU" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -48713,6 +47722,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/lawoffice)
+"mXE" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/captain)
 "mXI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -48847,11 +47863,22 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"naC" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "naE" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/light_switch{
 	dir = 9;
-	pixel_x = -22
+	pixel_x = -23;
+	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -49163,6 +48190,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"nhp" = (
+/obj/structure/rack,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/multitool,
+/obj/item/multitool,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/item/book/manual/wiki/experimentor,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "nhM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -49263,6 +48309,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"njD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "njK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -49327,6 +48382,25 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
+"nmg" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "nmw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -49642,6 +48716,39 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"nxn" = (
+/obj/effect/landmark/start/ai,
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Common Channel";
+	pixel_x = -27;
+	pixel_y = -9
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_y = -31
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_x = 27;
+	pixel_y = -9
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32;
+	pixel_y = -30
+	},
+/obj/machinery/requests_console{
+	department = "AI";
+	departmentType = 5;
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "nxT" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/plasteel,
@@ -49658,7 +48765,7 @@
 /obj/item/restraints/handcuffs,
 /obj/item/clothing/mask/muzzle,
 /obj/machinery/light_switch{
-	pixel_y = -22
+	pixel_y = -23
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -49825,24 +48932,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"nFj" = (
-/obj/machinery/requests_console{
-	department = "Bar";
-	departmentType = 2;
-	pixel_y = 30;
-	receive_ore_updates = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Bar Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "nFq" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -50308,6 +49397,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nVA" = (
+/obj/structure/sink/kitchen{
+	name = "utility sink";
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "nVU" = (
 /obj/item/spear,
 /turf/open/floor/plating,
@@ -50542,6 +49641,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"odz" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "odH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50620,6 +49733,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"ogd" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Xenobiology Central";
+	dir = 1;
+	network = list("ss13","rd")
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "ogU" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm3";
@@ -50700,6 +49832,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"olq" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "omc" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig Control";
@@ -50999,6 +50146,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"osT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "oti" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51168,7 +50326,7 @@
 	department = "Bridge";
 	departmentType = 5;
 	name = "Bridge RC";
-	pixel_y = -30
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -51359,6 +50517,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"oER" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/restrooms)
 "oEW" = (
 /obj/machinery/button/door{
 	id = "misclab";
@@ -51502,6 +50667,30 @@
 	},
 /turf/closed/wall/r_wall,
 /area/chapel/dock)
+"oLO" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs)
 "oMk" = (
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -51671,6 +50860,27 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"oRl" = (
+/obj/machinery/computer/crew,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	dir = 1;
+	name = "Chief Medical Officer RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/cmo)
 "oRt" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/structure/cable{
@@ -51709,6 +50919,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"oSM" = (
+/obj/machinery/power/apc/highcap/ten_k{
+	dir = 1;
+	name = "Research Division APC";
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/explab)
 "oSV" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -52012,6 +51242,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"pcr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "pcx" = (
 /obj/structure/grille/broken,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -52348,6 +51582,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
+"pta" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ptY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -52456,6 +51699,23 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"pxz" = (
+/obj/structure/closet/wardrobe/miner,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "pzN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52644,7 +51904,7 @@
 "pIU" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -26
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -52798,24 +52058,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"pRK" = (
-/obj/machinery/camera{
-	c_tag = "Research and Development Lab";
-	dir = 8;
-	network = list("ss13","rd")
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "pRS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -52854,6 +52096,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"pTc" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "pTt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -52915,6 +52172,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"pVj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/kirbyplants/photosynthetic{
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/explab)
 "pVD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -53092,6 +52366,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
+"pZW" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/requests_console{
+	department = "Detective's office";
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "qac" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/stripes/line{
@@ -53279,6 +52564,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/gateway)
+"qfZ" = (
+/obj/machinery/camera{
+	c_tag = "Bar Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/requests_console{
+	department = "Bar";
+	departmentType = 2;
+	dir = 1;
+	pixel_y = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "qgb" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -53400,6 +52704,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"qkX" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/freezer,
+/area/storage/emergency/port)
 "qkY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
@@ -53814,6 +53125,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"qCH" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 3;
+	dir = 1;
+	name = "Atmos RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "qCU" = (
 /obj/machinery/button/crematorium{
 	pixel_x = 25
@@ -53837,6 +53170,23 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/grass,
 /area/medical/medbay/central)
+"qEH" = (
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/analyzer,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Tool Storage";
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "qEN" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/structure/window/reinforced{
@@ -53893,6 +53243,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"qGW" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "qGY" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -53908,6 +53275,32 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
+"qHl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/obj/machinery/camera{
+	c_tag = "Monastery Dock";
+	dir = 1;
+	network = list("ss13","monastery")
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/dock)
 "qHN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -54170,6 +53563,23 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/engine,
 /area/science/explab)
+"qUS" = (
+/obj/structure/closet/l3closet/janitor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/requests_console{
+	department = "Janitorial";
+	departmentType = 1;
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "qVk" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -54442,6 +53852,28 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
+"rhV" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 30
+	},
+/obj/machinery/computer/security,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/supply)
 "riA" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 1";
@@ -54701,6 +54133,17 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
+"rrL" = (
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rrU" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -54817,18 +54260,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/chapel/dock)
-"rxw" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/gateway)
 "rxK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54856,7 +54287,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 27
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -55224,6 +54655,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"rMT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rMV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -55315,6 +54757,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rQd" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/obj/machinery/newscaster/security_unit{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/freezer,
+/area/medical/surgery)
 "rQA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55366,22 +54817,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
-"rSl" = (
-/obj/structure/closet/l3closet/janitor,
-/obj/machinery/requests_console{
-	department = "Janitorial";
-	departmentType = 1;
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "rSD" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -55405,25 +54840,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"rTV" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "rVd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -55465,6 +54881,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"rXG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rXR" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /obj/structure/cable{
@@ -55514,6 +54939,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"rZQ" = (
+/obj/machinery/chem_heater,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Chemistry";
+	dir = 4;
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "sam" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -55670,6 +55114,16 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
+"sce" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sci" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -56107,7 +55561,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -56189,6 +55643,23 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
+"suf" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Robotics";
+	departmentType = 2;
+	dir = 1;
+	name = "Robotics RC";
+	pixel_y = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "sut" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external{
@@ -56258,7 +55729,7 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_x = -32
+	pixel_y = -32
 	},
 /mob/living/simple_animal/pet/dog/pug{
 	name = "McGriff"
@@ -56398,7 +55869,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -56408,6 +55879,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"sBJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "sBP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -56960,22 +56440,6 @@
 /obj/item/cigbutt/cigarbutt,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"sXL" = (
-/obj/structure/bedsheetbin,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/dorms)
 "sXR" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -57028,6 +56492,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"sZZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/explab)
 "tat" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -57103,7 +56589,7 @@
 /obj/item/hand_labeler,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
+	pixel_x = -26
 	},
 /obj/machinery/light{
 	dir = 4
@@ -57146,6 +56632,67 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/janitor)
+"tek" = (
+/obj/machinery/camera{
+	c_tag = "Cargo Foyer";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"tem" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Theatre Storage";
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Theatre";
+	name = "theatre RC";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
+"teQ" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/storage/box/monkeycubes,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "teW" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -57231,6 +56778,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"thd" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/mixing)
 "thH" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -57403,6 +56974,23 @@
 	icon_state = "1-4"
 	},
 /turf/closed/wall/r_wall,
+/area/bridge)
+"tnK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "tnP" = (
 /obj/machinery/power/smes/engineering,
@@ -57666,6 +57254,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"txx" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Genetics";
+	dir = 4;
+	name = "Genetics Requests Console";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "txS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57782,6 +57386,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"tEi" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "tEl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -57828,6 +57446,23 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"tGc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch{
+	id = "cargodeliver"
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "tGp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/spawner/structure/window/reinforced/shutters,
@@ -57978,6 +57613,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"tMI" = (
+/obj/machinery/chem_dispenser{
+	layer = 2.7
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "tML" = (
 /obj/item/book/manual/wiki/engineering_singulo_tesla{
 	pixel_x = 3;
@@ -58023,24 +57672,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/eva)
-"tNT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "tOb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock{
@@ -58058,12 +57689,50 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"tOZ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "tPm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/engine/engineering)
+"tPq" = (
+/obj/machinery/camera{
+	c_tag = "Research and Development Lab";
+	dir = 8;
+	network = list("ss13","rd")
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "tPR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -58074,6 +57743,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"tPV" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "EVA Storage";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "EVA";
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/storage/eva)
 "tQb" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/tcommsat/server";
@@ -58102,6 +57790,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"tQY" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Medical Officer"
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/cmo)
 "tQZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -58150,6 +57854,21 @@
 /mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
+"tTh" = (
+/obj/machinery/holopad,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "tTl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -58221,6 +57940,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"tWz" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "tWJ" = (
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58289,6 +58026,20 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space)
+"tYH" = (
+/obj/machinery/pdapainter{
+	pixel_y = 2
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Personnel's Desk";
+	departmentType = 5;
+	dir = 1;
+	name = "Head of Personnel RC";
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/head_of_personnel)
 "tYP" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -58616,6 +58367,18 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"ugO" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "ugZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc/highcap/fifteen_k{
@@ -58654,6 +58417,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"uhA" = (
+/obj/structure/bedsheetbin,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/dorms)
 "uhD" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Departure Lounge"
@@ -59040,6 +58820,25 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/chapel/asteroid/monastery)
+"utU" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	layer = 2.9
+	},
+/obj/item/pen/red,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Virology";
+	dir = 4;
+	name = "Virology Requests Console";
+	pixel_x = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "utV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -59391,6 +59190,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"uDW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "uEg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59726,6 +59536,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"uNs" = (
+/obj/machinery/camera{
+	c_tag = "Captain's Office";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/captain)
 "uNL" = (
 /obj/item/radio/intercom{
 	frequency = 1485;
@@ -59987,23 +59811,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"uZM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = -22
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "vay" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -60249,6 +60056,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"vjc" = (
+/obj/structure/table,
+/obj/item/pen,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/paper_bin{
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "vjd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -60515,6 +60345,29 @@
 /obj/item/assembly/mousetrap,
 /turf/open/floor/engine,
 /area/science/explab)
+"vxH" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/infections,
+/obj/item/hand_labeler,
+/obj/item/radio/headset/headset_med,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "vye" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -60840,23 +60693,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"vMg" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_y = 32
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "vMx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -60895,6 +60731,17 @@
 /obj/machinery/air_sensor/atmos/oxygen_tank,
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
+"vNM" = (
+/obj/structure/table,
+/obj/item/pen,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/paper_bin,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/turret_protected/aisat_interior)
 "vOz" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Chamber Observation";
@@ -61004,6 +60851,17 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"vQz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "vRd" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -61065,6 +60923,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"vTb" = (
+/obj/item/storage/toolbox,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plating,
+/area/storage/emergency/starboard)
 "vTi" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "space-bridge access"
@@ -61109,6 +60982,23 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"vTV" = (
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	sortType = 18
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "vVa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
@@ -61237,6 +61127,37 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"wbm" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Experimentation Lab Central";
+	network = list("ss13","rd")
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	dir = 1;
+	name = "Science Requests Console";
+	pixel_y = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "wbA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -61277,6 +61198,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"wbV" = (
+/obj/machinery/camera{
+	c_tag = "Toxins Storage";
+	dir = 8;
+	network = list("ss13","rd")
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "wcs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -61376,6 +61312,22 @@
 /obj/machinery/meter,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"weh" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Research Division Entrance";
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "weL" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -61436,6 +61388,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"wfu" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wfv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61818,6 +61780,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"wpN" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "EngLoad"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wpO" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -61853,14 +61828,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"wrU" = (
-/obj/machinery/photocopier,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/open/floor/wood,
-/area/lawoffice)
 "wsB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor/border_only{
@@ -61956,6 +61923,17 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"wvy" = (
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
+/obj/structure/table,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "wwx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -62090,6 +62068,19 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"wAb" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
+/area/gateway)
 "wAI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -62873,7 +62864,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -63099,17 +63090,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"xhE" = (
+"xhq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+	dir = 8;
+	pixel_x = -27
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "xhU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -63846,6 +63837,31 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"xFd" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
+"xFH" = (
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/item/clothing/glasses/meson/gar,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/chief)
 "xFJ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Research Security Post";
@@ -64126,6 +64142,33 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main/monastery)
+"xRS" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/meter,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/mixing)
 "xSQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -64395,6 +64438,33 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"yaw" = (
+/obj/structure/chair/office,
+/obj/machinery/button/flasher{
+	id = "foflash";
+	pixel_x = 38;
+	pixel_y = -25
+	},
+/obj/machinery/button/door{
+	id = "head_of_personnel";
+	name = "Privacy Shutters Control";
+	pixel_x = 25;
+	pixel_y = -26;
+	req_access_txt = "28"
+	},
+/obj/machinery/button/door{
+	id = "foqueue";
+	name = "Queue Shutters Control";
+	pixel_x = 25;
+	pixel_y = -36;
+	req_access_txt = "28"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 39;
+	pixel_y = -36
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/head_of_personnel)
 "yaY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -75983,9 +76053,9 @@ aaa
 aaa
 bZY
 bZY
-csn
+grN
 ceF
-csY
+fBM
 bZY
 bZY
 aaa
@@ -78304,7 +78374,7 @@ bZY
 cfN
 bWV
 cfC
-cuu
+mqZ
 chU
 cuR
 ciy
@@ -81360,7 +81430,7 @@ pbm
 iMz
 cqH
 bLn
-bNt
+qHl
 bNw
 bNw
 bQe
@@ -83337,7 +83407,7 @@ ahj
 nvq
 mLJ
 aix
-aiZ
+jAe
 ajH
 akx
 alm
@@ -84132,7 +84202,7 @@ ebD
 sbY
 tFQ
 pXT
-wrU
+ebQ
 mpy
 aiu
 urS
@@ -84368,7 +84438,7 @@ aiB
 ajc
 agy
 akB
-alq
+fsh
 alZ
 fEF
 xrN
@@ -85166,7 +85236,7 @@ aiu
 xcI
 aiu
 riF
-xhE
+lFJ
 ftW
 aJE
 coN
@@ -86174,7 +86244,7 @@ hto
 vcR
 qVX
 vXE
-dDo
+iEP
 gYR
 xDs
 dSD
@@ -86443,7 +86513,7 @@ ayL
 aAi
 aBd
 aCi
-aDo
+daH
 xjK
 nJu
 sdW
@@ -86477,7 +86547,7 @@ bhE
 bfY
 biI
 bfY
-bkT
+pta
 bfY
 bns
 bfY
@@ -86699,7 +86769,7 @@ axG
 ayL
 aAi
 aBd
-aCj
+pZW
 aDp
 aEm
 fsB
@@ -86978,16 +87048,16 @@ dYX
 geU
 aWJ
 aXK
-aYH
+oLO
 aZF
 baQ
 aXH
 bdd
 bdY
-bfb
+rXG
 bfZ
 bgU
-bhF
+cvA
 bib
 biK
 bfZ
@@ -88225,7 +88295,7 @@ ajT
 akP
 alA
 uJf
-amZ
+ugO
 anJ
 amX
 aoY
@@ -88497,9 +88567,9 @@ jXJ
 axK
 ayM
 aAj
-aBg
+osT
 aCp
-aDu
+lhL
 aEs
 aFr
 fFp
@@ -88529,7 +88599,7 @@ vnD
 aCZ
 nVz
 aAL
-bhJ
+wfu
 bif
 biO
 bjL
@@ -88730,14 +88800,14 @@ aaa
 agP
 cnJ
 ahq
-ahq
-ahM
+lfN
+sBJ
 ain
 dJa
 ajk
 ylP
-rTV
-mGH
+tOZ
+gOJ
 wLT
 naE
 uxk
@@ -88790,7 +88860,7 @@ qeK
 ylh
 mrA
 bjL
-bkX
+qkX
 rXi
 bjL
 bov
@@ -89029,7 +89099,7 @@ aKI
 aQC
 aKI
 aKI
-aTP
+njD
 aNR
 aVR
 gpu
@@ -89066,7 +89136,7 @@ bvc
 bFI
 bGO
 bHU
-bJk
+vxH
 bKn
 bLz
 bMF
@@ -89783,7 +89853,7 @@ axG
 ayP
 aAn
 aBi
-aCs
+duA
 vpk
 uRz
 lLi
@@ -89828,9 +89898,9 @@ bsv
 btY
 bvc
 bwA
-byk
+teQ
 bzL
-bAV
+txx
 fvy
 bDn
 bvc
@@ -90040,7 +90110,7 @@ axG
 ayQ
 axG
 aBi
-aCt
+qEH
 aDy
 aDA
 aDA
@@ -90064,9 +90134,9 @@ aWO
 aXP
 aVS
 ngj
-rSl
+qUS
 bbY
-bdi
+eXx
 bee
 aVS
 bgi
@@ -90341,7 +90411,7 @@ sNz
 bsx
 btZ
 bvf
-bwB
+ftJ
 byl
 bzM
 bAW
@@ -90349,7 +90419,7 @@ fJA
 bDo
 cQW
 bEr
-bGS
+inJ
 bHZ
 bGW
 bKq
@@ -90570,14 +90640,14 @@ aKP
 aNm
 tDJ
 aRL
-aSA
+aTN
 aTQ
 aUS
 aRL
 aWP
 aXQ
 ydZ
-aZR
+odz
 aYN
 aYN
 ydZ
@@ -90787,7 +90857,7 @@ agP
 cnQ
 ahq
 ahq
-ahQ
+xFd
 ais
 agP
 ajr
@@ -90848,7 +90918,7 @@ biX
 bjR
 blc
 biX
-bny
+mKI
 boB
 dnZ
 fKt
@@ -90865,7 +90935,7 @@ bEu
 bFN
 mqI
 bIb
-bJn
+jSF
 bKs
 bKs
 bMI
@@ -91375,13 +91445,13 @@ aaU
 aaV
 bCi
 bDr
-bEv
-bFP
+cBx
+aPp
 bGV
 bIc
 bFO
 bKu
-bLE
+utU
 bMJ
 bEr
 bEr
@@ -91401,7 +91471,7 @@ bXk
 mbe
 kIk
 hUv
-kDJ
+wpN
 oYj
 uMo
 bXk
@@ -91582,8 +91652,8 @@ axQ
 ayV
 aAs
 aBj
-gkR
-aDB
+olq
+aoB
 aEw
 aFv
 ulu
@@ -91614,7 +91684,7 @@ bfm
 bgj
 bhe
 aDZ
-bil
+sce
 biY
 bjT
 ble
@@ -91859,7 +91929,7 @@ aSF
 aXS
 aXS
 aRL
-aWT
+nVA
 aXV
 aXS
 aZW
@@ -92076,7 +92146,7 @@ aaa
 aaa
 abI
 ajs
-akd
+dxg
 akX
 alJ
 cAQ
@@ -92095,7 +92165,7 @@ imy
 hfX
 lfz
 qLF
-aFF
+mzZ
 aCy
 aDC
 aEx
@@ -92116,7 +92186,7 @@ aSG
 aTW
 aUW
 aRL
-kEW
+wvy
 aXW
 aXS
 aZX
@@ -92333,7 +92403,7 @@ aaa
 aaa
 abI
 ajs
-ake
+jxX
 akX
 alM
 eIb
@@ -92390,7 +92460,7 @@ biY
 qrc
 blg
 bmr
-bnz
+ejg
 boD
 ibk
 biY
@@ -92606,7 +92676,7 @@ atL
 lKB
 avN
 awU
-axT
+dLO
 ayZ
 aAv
 aBm
@@ -92901,7 +92971,7 @@ tWc
 aAL
 bin
 bja
-bjX
+ikQ
 blh
 bms
 jru
@@ -92921,7 +92991,7 @@ nEh
 bFS
 bGZ
 bCn
-bJo
+kHI
 bGZ
 bLJ
 bMK
@@ -92936,7 +93006,7 @@ bTp
 bPB
 bUI
 bVD
-bWn
+xFH
 bXf
 bUH
 bYI
@@ -93380,8 +93450,8 @@ awW
 axW
 azc
 aAy
-aBp
-mCH
+mXE
+uNs
 kKr
 aBm
 aFz
@@ -93433,7 +93503,7 @@ bCp
 bpP
 paS
 bFT
-bHa
+qGW
 bIi
 bJp
 bKA
@@ -93890,9 +93960,9 @@ tnx
 atQ
 eHM
 avS
-awY
-axX
-uZM
+mkj
+aIW
+tnK
 cSB
 wrP
 orS
@@ -93947,7 +94017,7 @@ ruy
 eyt
 bED
 bFU
-bHb
+rQd
 bIk
 bJr
 bKB
@@ -93964,7 +94034,7 @@ qnQ
 bPB
 bUM
 pYF
-bWr
+gyz
 bXj
 dik
 nmT
@@ -94198,7 +94268,7 @@ nYu
 seB
 bwP
 byu
-bAa
+oRl
 gvI
 bCs
 bDu
@@ -94428,7 +94498,7 @@ aRP
 aSM
 aUb
 aVc
-aWb
+gCs
 aWX
 iOP
 aYV
@@ -94716,7 +94786,7 @@ bAc
 pUz
 bCu
 bDw
-bEG
+tQY
 bFU
 bFU
 bIn
@@ -94952,7 +95022,7 @@ baa
 baa
 beu
 bgk
-bgn
+dkz
 aJI
 aDZ
 aHN
@@ -94999,7 +95069,7 @@ uwc
 bZA
 osq
 cbi
-ccc
+rrL
 ccV
 cdR
 siH
@@ -95456,7 +95526,7 @@ pWs
 aSP
 aSP
 aPE
-nFj
+qfZ
 aXb
 aPE
 aYY
@@ -95479,7 +95549,7 @@ boM
 bpV
 brj
 bsJ
-buj
+rZQ
 bvr
 bwS
 wGQ
@@ -95728,8 +95798,8 @@ aJI
 aDZ
 bih
 jGd
-bki
-blp
+emq
+pcr
 bmz
 bnG
 boN
@@ -96230,7 +96300,7 @@ aPE
 syN
 aPE
 aPE
-aZa
+mxM
 bah
 bag
 bah
@@ -96483,7 +96553,7 @@ mOC
 tSj
 hDP
 esu
-aVf
+iGO
 aWi
 bah
 aYe
@@ -96506,7 +96576,7 @@ cqd
 boO
 bpV
 brm
-bsN
+tMI
 bun
 mcf
 nnf
@@ -96765,8 +96835,8 @@ bpY
 bpY
 bpY
 pSc
-gGA
-bwW
+mDy
+ejX
 byA
 bAi
 bpY
@@ -96974,7 +97044,7 @@ mPX
 atX
 auT
 awb
-axe
+dNO
 ayd
 jmE
 uIf
@@ -96991,13 +97061,13 @@ aJQ
 aKZ
 aLQ
 aNp
-aOB
+tPV
 aPH
 aQY
 aKY
 drS
 aPE
-aVh
+hwJ
 bah
 bah
 aYg
@@ -97032,21 +97102,21 @@ hVx
 xDj
 bva
 jCv
-bOK
+xhq
 bEN
 mxR
 bEN
 bHf
 mst
-bOK
-bPG
+xhq
+tEi
 gjK
 bBm
 dUx
 bSL
 bTC
 bUi
-bUV
+vjc
 xgH
 bWA
 ian
@@ -97055,7 +97125,7 @@ uwc
 bZA
 cav
 cbl
-cch
+dSn
 cdc
 pKP
 fEM
@@ -97701,7 +97771,7 @@ abO
 abO
 sbb
 acr
-acy
+nxn
 abO
 abO
 acD
@@ -97794,7 +97864,7 @@ pYw
 gFo
 cSK
 duF
-bxa
+jmz
 eIA
 vTS
 uxt
@@ -98222,7 +98292,7 @@ qaK
 tfF
 abO
 add
-ado
+vNM
 adA
 adL
 adZ
@@ -98520,7 +98590,7 @@ aht
 aaa
 aaa
 aAH
-aBD
+fIH
 aaT
 wyB
 aEO
@@ -98543,7 +98613,7 @@ aVk
 oXI
 aXk
 jXi
-aZg
+naC
 ban
 bbt
 bcr
@@ -98589,7 +98659,7 @@ kxU
 pps
 bUn
 bVb
-bVU
+jLj
 yao
 bXq
 bYo
@@ -98777,7 +98847,7 @@ axi
 aaa
 aaa
 aAH
-aBE
+tYH
 aCS
 hrO
 vwA
@@ -98798,7 +98868,7 @@ iZz
 aUf
 aVl
 sHg
-aXl
+tem
 aUf
 aUf
 aPE
@@ -98812,8 +98882,8 @@ aJI
 aDZ
 bih
 fWJ
-bkm
-bly
+czf
+lzT
 bmD
 bJI
 boS
@@ -99037,7 +99107,7 @@ aAH
 aBF
 jCP
 ygS
-aEQ
+yaw
 jSG
 aGx
 aHl
@@ -99055,7 +99125,7 @@ iZz
 aUf
 aVm
 qpr
-aXm
+vTV
 aYk
 aUf
 bao
@@ -99332,9 +99402,9 @@ bmI
 byK
 boT
 yic
-bru
+tTh
 rmt
-pRK
+tPq
 xQd
 uwh
 mdL
@@ -99587,7 +99657,7 @@ bkp
 blA
 bmJ
 bnL
-boU
+eLJ
 cCl
 cCl
 cCl
@@ -99868,7 +99938,7 @@ bOi
 bOQ
 bPP
 bQG
-bRu
+fFX
 bSd
 bLW
 bTJ
@@ -100085,8 +100155,8 @@ aVo
 aMb
 aXq
 aMb
-aZh
-bar
+vQz
+rMT
 aMb
 aSX
 aMb
@@ -100117,7 +100187,7 @@ fGl
 xFJ
 mjL
 gxg
-bJH
+weh
 bJN
 bJN
 xst
@@ -100311,7 +100381,7 @@ etw
 eIJ
 pHU
 awF
-rxw
+wAb
 qBF
 cQT
 muE
@@ -100361,7 +100431,7 @@ bko
 lsI
 ubF
 bko
-bsV
+pTc
 buu
 bvB
 tvK
@@ -100620,7 +100690,7 @@ bkt
 oDd
 bkt
 bkt
-bvC
+lsH
 tvK
 cqt
 bAu
@@ -100871,7 +100941,7 @@ bjm
 bAj
 blE
 bmL
-bnO
+dgC
 boX
 bqg
 brw
@@ -100885,7 +100955,7 @@ bsU
 cqk
 bsU
 bsU
-bGd
+jeC
 bHq
 dVK
 bJK
@@ -101083,7 +101153,7 @@ cBU
 cBU
 asa
 atd
-aui
+dSA
 avc
 awm
 ldd
@@ -101101,7 +101171,7 @@ rHw
 kDE
 nzC
 aLe
-aMd
+rhV
 aND
 erX
 aPT
@@ -101112,9 +101182,9 @@ aOT
 aVp
 aWs
 aPW
-aYn
+jgp
 aZj
-bas
+lpY
 aLf
 bcx
 bdz
@@ -101394,7 +101464,7 @@ bAj
 bvF
 dwp
 byN
-tNT
+clY
 bko
 bko
 bko
@@ -101656,7 +101726,7 @@ bBB
 bCN
 bDK
 bEZ
-bGe
+lne
 bHt
 bIE
 bJN
@@ -101897,7 +101967,7 @@ bhR
 biu
 bju
 bkt
-blI
+suf
 bmO
 bnQ
 boY
@@ -101922,11 +101992,11 @@ bMe
 bNh
 bOo
 bOY
-bPT
+hzG
 bQL
 bRy
 bSf
-bSR
+jAP
 bTM
 bMf
 bKX
@@ -102133,7 +102203,7 @@ aMg
 aNH
 aOS
 aPX
-aRh
+exi
 nNP
 aTc
 aOT
@@ -102431,7 +102501,7 @@ bAA
 fMq
 bAA
 bHw
-bvj
+qCH
 bMf
 bMf
 bOk
@@ -102635,7 +102705,7 @@ apX
 aBO
 aDd
 apX
-eQq
+vTb
 uSC
 tHN
 erf
@@ -102879,7 +102949,7 @@ cnX
 aiS
 cvp
 apX
-aqU
+iDI
 rmO
 ath
 apX
@@ -102933,7 +103003,7 @@ bkt
 bkt
 bkt
 bkt
-iGa
+oSM
 sWN
 byT
 bAB
@@ -102966,7 +103036,7 @@ tHJ
 bZO
 caI
 cbA
-ccp
+hYO
 aac
 aae
 fFy
@@ -103143,7 +103213,7 @@ auk
 avh
 awr
 axo
-aym
+uDW
 awr
 aAO
 aBP
@@ -103189,7 +103259,7 @@ bpa
 tiw
 brD
 bte
-buw
+pVj
 bvM
 jze
 byU
@@ -103394,7 +103464,7 @@ noT
 aiS
 apX
 dlB
-sXL
+uhA
 atj
 apX
 avi
@@ -103415,17 +103485,17 @@ uTv
 aJI
 lAs
 aMl
-aNM
+gVO
 dse
-aQb
+jEA
 ugZ
 tJO
 uwY
 aUr
-aVv
+tGc
 aWw
-aXv
-aYu
+tek
+cWk
 aOT
 aPY
 bbD
@@ -103712,7 +103782,7 @@ bBG
 bCR
 irB
 kSm
-myJ
+wbV
 ssJ
 phL
 bHw
@@ -103934,7 +104004,7 @@ aOX
 lAs
 aRm
 aLg
-vMg
+tWz
 aUt
 aVw
 aWx
@@ -103961,7 +104031,7 @@ bjw
 bjw
 bjw
 bod
-dbn
+sZZ
 gXc
 nZZ
 bAA
@@ -104214,15 +104284,15 @@ blP
 bmV
 sEj
 bpd
-bqo
+nmg
 brG
-btg
+nhp
 fjs
 bvQ
 req
 byY
 kfB
-bBH
+gFJ
 bCT
 kpG
 bCT
@@ -104697,7 +104767,7 @@ aGF
 aGF
 aGF
 aUC
-aKh
+aFb
 aEd
 diu
 aNO
@@ -104939,7 +105009,7 @@ aaa
 apX
 apX
 apX
-avl
+bBR
 awv
 avk
 aIh
@@ -105228,7 +105298,7 @@ aTj
 aZr
 qxb
 bbI
-bcD
+pxz
 bdJ
 beM
 bfE
@@ -105242,7 +105312,7 @@ aaj
 aaj
 aaj
 bjw
-eYr
+wbm
 bqs
 hTz
 wlK
@@ -105250,7 +105320,7 @@ bvU
 bxD
 bzc
 bAF
-bBK
+mEL
 bCW
 wpj
 bFh
@@ -105462,7 +105532,7 @@ axw
 aBT
 atn
 aEf
-aFc
+oER
 aUC
 aGF
 cVC
@@ -106000,7 +106070,7 @@ cCT
 baF
 bbI
 bcG
-bdM
+doK
 beP
 bfH
 bfH
@@ -107563,10 +107633,10 @@ bwc
 bxL
 bzj
 bAF
-bBT
-bDd
-bEd
-bFp
+thd
+jhF
+xRS
+lih
 bGv
 xAu
 bIM
@@ -109097,7 +109167,7 @@ taT
 lWH
 wfs
 pfP
-bqC
+gYN
 brW
 vMx
 xzp
@@ -111413,7 +111483,7 @@ bnj
 bnj
 itl
 gdh
-cuc
+ogd
 bnj
 bnj
 bnj
@@ -112441,7 +112511,7 @@ bnj
 bnj
 bsf
 job
-buU
+dEI
 bnj
 bnj
 bnj
@@ -114494,7 +114564,7 @@ aEj
 wpf
 bkF
 bkF
-kFD
+bri
 eIL
 bYu
 pMG

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3397,7 +3397,7 @@
 "iS" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -3550,7 +3550,7 @@
 "jj" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 27
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3837,7 +3837,7 @@
 /area/centcom/supply)
 "jR" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3868,7 +3868,7 @@
 "jV" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4127,7 +4127,7 @@
 /area/centcom/control)
 "kn" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4233,7 +4233,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4553,7 +4553,7 @@
 "lp" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -26
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -4616,7 +4616,7 @@
 /area/centcom/control)
 "lx" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4772,7 +4772,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -5060,7 +5060,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/machinery/light{
 	dir = 4
@@ -5388,7 +5388,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
@@ -5427,7 +5427,9 @@
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
 "ni" = (
-/obj/machinery/newscaster/security_unit,
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -30
+	},
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
 "nj" = (
@@ -5568,7 +5570,7 @@
 /area/centcom/control)
 "nv" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -5671,7 +5673,7 @@
 /area/centcom/supply)
 "nF" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/computer/cargo{
 	dir = 1
@@ -5708,11 +5710,11 @@
 "nI" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/structure/closet/crate/bin,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -5729,7 +5731,7 @@
 "nJ" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -26
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -5806,7 +5808,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -5828,7 +5830,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -6075,7 +6077,7 @@
 	department = "Captain's Desk";
 	departmentType = 5;
 	name = "Captain RC";
-	pixel_y = 32
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
@@ -6115,7 +6117,7 @@
 /obj/item/melee/chainofcommand,
 /obj/item/stamp/captain,
 /obj/machinery/newscaster/security_unit{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -6567,13 +6569,13 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 24
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "pf" = (
 /obj/machinery/light_switch{
-	pixel_x = -24
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
@@ -6767,7 +6769,7 @@
 "pt" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -6800,7 +6802,7 @@
 "pv" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -6819,7 +6821,7 @@
 	icon_state = "plant-22"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -6957,7 +6959,7 @@
 "pM" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -6984,7 +6986,7 @@
 /obj/item/clothing/glasses/eyepatch,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
@@ -7140,7 +7142,7 @@
 /obj/item/lighter,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7165,7 +7167,7 @@
 	icon_state = "plant-22"
 	},
 /obj/machinery/light_switch{
-	pixel_y = -24
+	pixel_y = -23
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
@@ -7214,7 +7216,7 @@
 	},
 /obj/item/storage/lockbox/medal,
 /obj/machinery/newscaster/security_unit{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7317,7 +7319,7 @@
 "qp" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -26
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7806,7 +7808,7 @@
 	icon_state = "plant-22"
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7822,7 +7824,7 @@
 /area/centcom/ferry)
 "ru" = (
 /obj/machinery/light_switch{
-	pixel_y = 24
+	pixel_y = -23
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
@@ -7921,7 +7923,7 @@
 /obj/item/crowbar/power,
 /obj/item/storage/belt/security/full,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -7989,25 +7991,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
-/area/centcom/control)
-"rL" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "rM" = (
 /obj/structure/filingcabinet/medical,
@@ -8097,7 +8080,7 @@
 /obj/item/storage/box/silver_ids,
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
@@ -8775,7 +8758,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -8828,7 +8811,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
@@ -8840,7 +8823,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9080,7 +9063,7 @@
 	dir = 1
 	},
 /obj/machinery/newscaster/security_unit{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -9114,11 +9097,11 @@
 "uo" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/structure/closet/crate/bin,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -9170,7 +9153,7 @@
 "uu" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -9413,7 +9396,7 @@
 "uW" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light_switch{
-	pixel_y = -24
+	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -9441,7 +9424,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -9490,7 +9473,9 @@
 /turf/open/floor/grass,
 /area/centcom/ferry)
 "vc" = (
-/obj/machinery/newscaster,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
 "vd" = (
@@ -9657,13 +9642,13 @@
 /area/centcom/ferry)
 "vE" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -10968,7 +10953,7 @@
 	pixel_x = 4.5
 	},
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -11070,7 +11055,7 @@
 	pixel_x = -4
 	},
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = -26
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -11276,7 +11261,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -11476,7 +11461,7 @@
 /area/centcom/ferry)
 "Al" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -11540,21 +11525,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/centcom/control)
-"As" = (
-/obj/machinery/computer/communications{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/centcom/control)
 "At" = (
 /turf/open/floor/plasteel/yellowsiding,
@@ -11885,7 +11855,7 @@
 /area/centcom/ferry)
 "BD" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12239,7 +12209,7 @@
 /obj/item/folder/red,
 /obj/item/lighter,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12374,7 +12344,7 @@
 	icon_state = "plant-21"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12482,7 +12452,7 @@
 /obj/item/taperecorder,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12549,7 +12519,7 @@
 /obj/structure/filingcabinet/medical,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12614,7 +12584,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12750,25 +12720,6 @@
 "De" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/handcuffs,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
-"Df" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -13142,7 +13093,7 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -13174,7 +13125,7 @@
 /area/centcom/control)
 "DX" = (
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -14453,7 +14404,7 @@
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/newscaster{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -14632,7 +14583,7 @@
 	},
 /obj/item/kitchen/knife,
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -14663,7 +14614,7 @@
 "Hq" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
@@ -14706,7 +14657,7 @@
 "Hu" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -15275,7 +15226,7 @@
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/reagent_containers/glass/rag,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -15980,7 +15931,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -16217,7 +16168,7 @@
 /obj/item/folder/red,
 /obj/item/lighter,
 /obj/machinery/newscaster{
-	pixel_y = -32
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -16975,6 +16926,22 @@
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"Na" = (
+/obj/machinery/computer/communications{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/control)
 "Nd" = (
 /turf/closed/indestructible{
 	icon = 'icons/turf/walls/wood_wall.dmi';
@@ -17448,6 +17415,26 @@
 /obj/item/melee/transforming/energy/ctf,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"QV" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
 "QW" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
 	locked = 0
@@ -17791,6 +17778,13 @@
 /obj/machinery/door/window/eastright,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"TE" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "TK" = (
 /obj/structure/table/wood/bar,
 /obj/structure/mirror{
@@ -17877,7 +17871,7 @@
 /area/centcom/supplypod)
 "UJ" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 32
+	pixel_y = -30
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
@@ -18036,6 +18030,26 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"Ws" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/control)
 "Wt" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -18280,12 +18294,6 @@
 "Yf" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/chawanmushi,
-/turf/open/floor/wood,
-/area/centcom/holding)
-"Yh" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Ym" = (
@@ -44498,7 +44506,7 @@ CT
 CT
 CT
 CT
-Yh
+TE
 CT
 Nd
 Nd
@@ -64522,7 +64530,7 @@ jG
 iu
 qv
 iu
-rL
+Ws
 sK
 iC
 uu
@@ -66076,7 +66084,7 @@ wI
 yA
 iu
 zK
-As
+Na
 zJ
 BL
 iu
@@ -68394,7 +68402,7 @@ AZ
 qx
 Ce
 CP
-Df
+QV
 Cc
 Yn
 OP

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3394,20 +3394,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"iS" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/centcom/supply)
 "iT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3835,18 +3821,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jR" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
 "jS" = (
 /obj/machinery/computer/prisoner/management,
 /obj/effect/turf_decal/stripes/line,
@@ -3863,19 +3837,6 @@
 "jU" = (
 /obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"jV" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "jW" = (
@@ -4227,26 +4188,6 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kB" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/control)
 "kC" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4550,17 +4491,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"lp" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/supply)
 "lq" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -4613,22 +4543,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
-/area/centcom/control)
-"lx" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "ly" = (
 /obj/effect/turf_decal/stripes/line,
@@ -4765,26 +4679,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/centcom/control)
-"lQ" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "lR" = (
 /obj/effect/turf_decal/tile/red{
@@ -5054,18 +4948,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/centcom/control)
-"mq" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
 /area/centcom/control)
 "mr" = (
 /turf/closed/indestructible/abductor{
@@ -5383,15 +5265,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
-"na" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/grimy,
-/area/centcom/control)
 "nb" = (
 /turf/closed/indestructible/abductor,
 /area/abductor_ship)
@@ -5568,18 +5441,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
-"nv" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/control)
 "nw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -5707,41 +5568,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/supply)
-"nI" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/structure/closet/crate/bin,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/supply)
-"nJ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/supply)
 "nK" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -5788,50 +5614,6 @@
 /area/centcom/control)
 "nP" = (
 /obj/machinery/vending/snack,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/control)
-"nQ" = (
-/obj/machinery/door/window/brigdoor{
-	base_state = "rightsecure";
-	name = "CentCom Stand";
-	req_access_txt = "109"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/control)
-"nR" = (
-/obj/machinery/door/window/brigdoor{
-	base_state = "rightsecure";
-	name = "CentCom Stand";
-	req_access_txt = "109"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -6068,18 +5850,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
-"ol" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Captain's Desk";
-	departmentType = 5;
-	name = "Captain RC";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "om" = (
 /obj/machinery/computer/card/centcom,
@@ -7316,23 +7086,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"qp" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/supply)
 "qq" = (
 /obj/machinery/button/door/indestructible{
 	id = "XCCsec3";
@@ -7822,12 +7575,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
-"ru" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/turf/open/floor/wood,
-/area/centcom/ferry)
 "rv" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -7912,18 +7659,6 @@
 /obj/item/gun/ballistic/automatic/ar,
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"rE" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/handcuffs,
-/obj/item/crowbar/red,
-/obj/item/crowbar/power,
-/obj/item/storage/belt/security/full,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -8717,6 +8452,19 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
+"tz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
 "tA" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
@@ -8799,35 +8547,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"tF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"tG" = (
-/obj/item/storage/box/handcuffs,
-/obj/item/ammo_box/a357,
-/obj/item/ammo_box/a357,
-/obj/item/gun/ballistic/revolver/mateba,
-/obj/structure/table/reinforced,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "tH" = (
@@ -9094,27 +8813,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
-"uo" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/structure/closet/crate/bin,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "up" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -9138,23 +8836,6 @@
 /area/centcom/ferry)
 "ut" = (
 /obj/structure/fans/tiny,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/control)
-"uu" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -9377,6 +9058,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"uU" = (
+/obj/structure/table/wood,
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/tdome/tdomeobserve)
 "uV" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -9637,21 +9337,6 @@
 "vD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"vE" = (
-/obj/machinery/firealarm{
-	pixel_y = -26
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
@@ -10082,6 +9767,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
+"wy" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/tdome/tdomeadmin)
 "wz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -10472,6 +10177,23 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/firingrange)
+"xF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "xG" = (
 /turf/open/floor/plasteel/dark,
 /area/syndicate_mothership/control)
@@ -10675,6 +10397,20 @@
 /obj/structure/sign/warning/vacuum,
 /turf/open/floor/plating,
 /area/centcom/ferry)
+"yo" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/centcom/supply)
 "yp" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -10999,6 +10735,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"zc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/control)
 "zd" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -11042,20 +10794,6 @@
 /obj/item/flashlight/seclite,
 /obj/structure/noticeboard{
 	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"zh" = (
-/obj/structure/table/reinforced,
-/obj/item/grenade/c4{
-	pixel_x = 6
-	},
-/obj/item/grenade/c4{
-	pixel_x = -4
-	},
-/obj/machinery/firealarm{
-	pixel_y = -26
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -11255,22 +10993,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/control)
-"zK" = (
-/obj/machinery/computer/med_data{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/centcom/control)
 "zL" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -11458,22 +11180,6 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/centcom/ferry)
-"Al" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "Am" = (
 /obj/item/kirbyplants{
@@ -12175,6 +11881,19 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"Cm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
 "Co" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -12446,26 +12165,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"CH" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/taperecorder,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/control)
 "CI" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -12514,24 +12213,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/centcom/control)
-"CM" = (
-/obj/structure/filingcabinet/medical,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "CN" = (
 /obj/structure/table/reinforced,
@@ -13805,6 +13486,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
+"FB" = (
+/obj/structure/filingcabinet/medical,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/control)
 "FD" = (
 /obj/machinery/shower{
 	dir = 4
@@ -14401,23 +14100,21 @@
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeobserve)
 "GS" = (
-/obj/structure/table/wood,
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/computer/med_data{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/tdome/tdomeobserve)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/control)
 "GT" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/neutral{
@@ -14611,13 +14308,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
-"Hq" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/white,
-/area/tdome/tdomeobserve)
 "Hr" = (
 /obj/structure/table/wood,
 /obj/structure/plaque/static_plaque/thunderdome{
@@ -14653,17 +14343,6 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/grimy,
-/area/tdome/tdomeobserve)
-"Hu" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
 "Hv" = (
 /obj/machinery/light,
@@ -15405,6 +15084,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena)
+"IO" = (
+/obj/item/storage/box/handcuffs,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/gun/ballistic/revolver/mateba,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
 "IP" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
@@ -15769,6 +15462,19 @@
 "JI" = (
 /turf/closed/indestructible/fakeglass,
 /area/tdome/tdomeadmin)
+"JJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
 "JK" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/ert_spawn,
@@ -15918,20 +15624,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
-"JX" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeadmin)
-"JZ" = (
+"JW" = (
 /obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
+	icon_state = "plant-22"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -15943,7 +15638,18 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/dark,
+/area/centcom/control)
+"JX" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/tdome/tdomeadmin)
 "Ka" = (
 /turf/open/floor/plasteel/grimy,
@@ -15973,6 +15679,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
+"Ke" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/control)
 "Kg" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Thunderdome Admin"
@@ -16854,6 +16577,16 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"MA" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/centcom/supply)
 "MD" = (
 /obj/effect/light_emitter{
 	set_cap = 1;
@@ -17042,6 +16775,19 @@
 "NO" = (
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"NR" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/centcom/supply)
 "NT" = (
 /obj/structure/window/paperframe{
 	CanAtmosPass = 0
@@ -17148,6 +16894,16 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"Pd" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/control)
 "Pe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17441,6 +17197,22 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"QY" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/supply)
 "Rd" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/green{
@@ -17669,6 +17441,19 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"SK" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/control)
 "SN" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -17684,6 +17469,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/one)
+"ST" = (
+/obj/machinery/door/window/brigdoor{
+	base_state = "rightsecure";
+	name = "CentCom Stand";
+	req_access_txt = "109"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/control)
 "SU" = (
 /obj/structure/table/wood,
 /obj/item/camera/detective{
@@ -17858,6 +17665,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"UB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/control)
 "UE" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
@@ -17925,6 +17745,45 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/three)
+"Vo" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/taperecorder,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/control)
+"Vt" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/control)
 "Vu" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -17953,6 +17812,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"VB" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs,
+/obj/item/crowbar/red,
+/obj/item/crowbar/power,
+/obj/item/storage/belt/security/full,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
 "VF" = (
 /obj/structure/rack,
 /obj/item/nullrod/scythe/vibro{
@@ -18024,6 +17896,19 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership/control)
+"Wl" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
 "Wm" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -18084,6 +17969,27 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
+"WN" = (
+/obj/structure/closet/crate/bin,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "WQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -18155,6 +18061,13 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Xa" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/tdome/tdomeobserve)
 "Xd" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -18248,6 +18161,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
+"Xz" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"XA" = (
+/obj/structure/closet/crate/bin,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/supply)
 "XD" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -18393,6 +18338,19 @@
 /mob/living/simple_animal/chicken,
 /turf/open/floor/grass,
 /area/centcom/holding)
+"YO" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
+	dir = 1;
+	name = "Captain RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "YQ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker,
@@ -18473,6 +18431,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"Zg" = (
+/obj/machinery/door/window/brigdoor{
+	base_state = "rightsecure";
+	name = "CentCom Stand";
+	req_access_txt = "109"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/control)
 "Zh" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -18490,6 +18470,13 @@
 	},
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/basketball)
+"Zr" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/wood,
+/area/centcom/ferry)
 "Zs" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
@@ -18516,6 +18503,23 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"ZC" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
@@ -18616,6 +18620,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
+"ZZ" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/c4{
+	pixel_x = 6
+	},
+/obj/item/grenade/c4{
+	pixel_x = -4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
 
 (1,1,1) = {"
 aa
@@ -54510,9 +54529,9 @@ mD
 rq
 sv
 tt
-uo
+WN
 mD
-vE
+ZC
 wt
 xg
 wt
@@ -56306,7 +56325,7 @@ pb
 pJ
 qe
 mD
-ru
+Zr
 pJ
 oB
 oB
@@ -56814,7 +56833,7 @@ mD
 nk
 nC
 mD
-ol
+YO
 oG
 pc
 oI
@@ -58364,7 +58383,7 @@ ql
 nT
 Uc
 sG
-tF
+Cm
 mD
 uY
 oe
@@ -58878,7 +58897,7 @@ qm
 nU
 rC
 sI
-tG
+IO
 mD
 va
 oe
@@ -58886,7 +58905,7 @@ su
 ws
 ts
 mD
-zh
+ZZ
 ZP
 Ak
 AR
@@ -59390,7 +59409,7 @@ iY
 lo
 mg
 nT
-rE
+VB
 sw
 tI
 mD
@@ -59402,7 +59421,7 @@ xS
 mD
 zj
 pR
-Al
+xF
 ZS
 BD
 pR
@@ -59639,7 +59658,7 @@ iF
 mh
 mJ
 lq
-nI
+XA
 iF
 os
 iR
@@ -60148,7 +60167,7 @@ iY
 jp
 kw
 iY
-lp
+MA
 iF
 mi
 kj
@@ -60191,7 +60210,7 @@ Gh
 Ep
 GJ
 Hd
-Hq
+Xa
 Gx
 GM
 HW
@@ -60207,7 +60226,7 @@ IE
 Is
 JI
 JP
-JZ
+wy
 JG
 Kn
 Iv
@@ -60416,7 +60435,7 @@ mg
 oN
 iZ
 lq
-qp
+QY
 iF
 iX
 iF
@@ -60650,7 +60669,7 @@ aa
 aa
 aa
 iF
-iS
+yo
 iZ
 jf
 jq
@@ -60667,7 +60686,7 @@ iF
 mj
 jf
 iZ
-nJ
+NR
 iF
 ov
 oO
@@ -60948,7 +60967,7 @@ tL
 io
 iu
 io
-CH
+Vo
 vM
 Ds
 DG
@@ -63004,7 +63023,7 @@ tL
 io
 iu
 io
-CM
+FB
 Da
 Dv
 DJ
@@ -63742,7 +63761,7 @@ iT
 jz
 iT
 iT
-jR
+JJ
 iT
 iT
 kS
@@ -63789,7 +63808,7 @@ Gp
 Ep
 GQ
 Hf
-Hu
+Xz
 Gx
 GM
 HW
@@ -64301,7 +64320,7 @@ Ep
 FH
 Gq
 Ep
-GS
+uU
 Hf
 Hf
 HD
@@ -64533,7 +64552,7 @@ iu
 Ws
 sK
 iC
-uu
+zc
 io
 vQ
 wG
@@ -64796,8 +64815,8 @@ mO
 nq
 nq
 nq
-qs
-vc
+Wl
+io
 zI
 nq
 Ar
@@ -65798,7 +65817,7 @@ iU
 jB
 iU
 iU
-jV
+tz
 iU
 iU
 kV
@@ -66083,7 +66102,7 @@ xq
 wI
 yA
 iu
-zK
+GS
 Na
 zJ
 BL
@@ -66831,7 +66850,7 @@ kk
 iC
 kW
 iC
-lQ
+Vt
 io
 kb
 km
@@ -67856,18 +67875,18 @@ aa
 io
 jZ
 iC
-kB
+JW
 in
-lx
+Ke
 lR
 ml
 mW
-nv
-nQ
+UB
+Zg
 iC
 iC
 iC
-lQ
+Vt
 io
 qy
 qz
@@ -70944,10 +70963,10 @@ kJ
 in
 lA
 lW
-mq
-na
+SK
+Pd
 lW
-nR
+ST
 iC
 oz
 oR

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -172,6 +172,6 @@ The console is located at computer/gulag_teleporter.dm
 	name = "labor camp bluespace beacon"
 	desc = "A receiving beacon for bluespace teleportations."
 	icon = 'icons/turf/floors.dmi'
-	icon_state = "light_on-w"
+	icon_state = "light_on-8"
 	resistance_flags = INDESTRUCTIBLE
 	anchored = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Applies directional fixes for extinguisher cabinets, light switches, fire alarms, RC consoles, newscasters. 
Fixes gulag beacon icon on Lavaland 
Switches AACs on Lavaland with lavaland variant 
Sets safety_mode variable on Lavaland shuttle airlocks to 1 so they can be forced open in the event of power outage. 

Maps completed: 

- [x] Box 
~~- [ ] Meta~~ 
- [x] Pubby 
- [x] Packed 
- [x] Delta 
- [x] Central
- [x] Lavaland

## Changelog
:cl:
fix: Extinguisher cabinets, light switchs, fire alarms, request consoles, and newscasters should not be on walls once again
fix: Lavaland: Replaced AAC with lavaland variant, fixes gulag beacon icon, safety setting on shuttle dock airlocks for power outages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
