### PR TITLE
Minor Preferences Bugfix

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -168,7 +168,6 @@ GLOBAL_LIST_INIT(backpacklist, list(DBACKPACK, DSATCHEL, DCOURIERBAG, DDUFFELBAG
 #define PREF_GREYSUIT "Grey Jumpsuit"
 #define PREF_LOADOUT "Loadout uniform"
 GLOBAL_LIST_INIT(jumpsuitlist, list(PREF_SUIT, PREF_SKIRT, PREF_ALTSUIT, PREF_GREYSUIT, PREF_LOADOUT))
-GLOBAL_LIST_INIT(jumpsuitlistrandom, list(PREF_SUIT, PREF_SKIRT, PREF_ALTSUIT, PREF_GREYSUIT))
 
 	//Exowear
 #define PREF_NOEXOWEAR "No Exowear/Loadout Exowear"

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -263,7 +263,7 @@
 	var/duffelbag = /obj/item/storage/backpack/duffelbag
 	var/courierbag = /obj/item/storage/backpack/messenger
 
-	var/alt_uniform = /obj/item/clothing/under
+	var/alt_uniform
 
 	var/alt_suit = null
 	var/dcoat = /obj/item/clothing/suit/hooded/wintercoat
@@ -295,7 +295,7 @@
 	switch(H.jumpsuit_style)
 		if(PREF_SKIRT)
 			holder = "[uniform]/skirt"
-		if(PREF_ALTSUIT)
+		if(PREF_ALTSUIT && alt_uniform)
 			holder = "[alt_uniform]"
 		if(PREF_GREYSUIT)
 			holder = "/obj/item/clothing/under/color/grey"

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -295,8 +295,9 @@
 	switch(H.jumpsuit_style)
 		if(PREF_SKIRT)
 			holder = "[uniform]/skirt"
-		if(PREF_ALTSUIT && alt_uniform)
-			holder = "[alt_uniform]"
+		if(PREF_ALTSUIT)
+			if(alt_uniform)
+				holder = "[alt_uniform]"
 		if(PREF_GREYSUIT)
 			holder = "/obj/item/clothing/under/color/grey"
 		// WaspStation Edit - Fix Loadout Uniforms not spawning ID/PDA

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -33,19 +33,25 @@ Assistant
 	if(uniform != /obj/item/clothing/under/color/grey)
 		return
 	if (CONFIG_GET(flag/grey_assistants))
-		if(H.jumpsuit_style == PREF_SUIT)
-			uniform = /obj/item/clothing/under/color/grey
-		else if(H.jumpsuit_style == PREF_ALTSUIT)
-			uniform = /obj/item/clothing/under/misc/assistantformal
-		else
-			uniform = /obj/item/clothing/under/color/jumpskirt/grey
+		switch(H.jumpsuit_style)
+			if(PREF_SUIT)
+				uniform = /obj/item/clothing/under/color/grey
+			if(PREF_ALTSUIT)
+				uniform = /obj/item/clothing/under/misc/assistantformal
+			if(PREF_SKIRT)
+				uniform = /obj/item/clothing/under/color/jumpskirt/grey
+			else
+				uniform = /obj/item/clothing/under/color/grey
 	else
-		if(H.jumpsuit_style == PREF_SUIT)
-			uniform = /obj/item/clothing/under/color/random
-		else if(H.jumpsuit_style == PREF_ALTSUIT)
-			uniform = /obj/item/clothing/under/misc/assistantformal
-		else
-			uniform = /obj/item/clothing/under/color/jumpskirt/random
+		switch(H.jumpsuit_style)
+			if(PREF_SUIT)
+				uniform = /obj/item/clothing/under/color/random
+			if(PREF_ALTSUIT)
+				uniform = /obj/item/clothing/under/misc/assistantformal
+			if(PREF_SKIRT)
+				uniform = /obj/item/clothing/under/color/jumpskirt/random
+			else
+				uniform = /obj/item/clothing/under/color/grey
 
 /datum/outfit/job/assistant/businessman
 	name = "Assistant (Businessman)"

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -80,7 +80,6 @@
 	suit = /obj/item/clothing/suit/hazardvest
 	accessory = /obj/item/clothing/accessory/armband/engine
 	r_pocket = /obj/item/stack/cable_coil
-	l_pocket = /obj/item/flashlight
 
 /datum/outfit/job/engineer/juniorengineer
 	name = "Station Engineer (Junior Engineer)"

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -22,9 +22,9 @@
 	if(randomise[RANDOM_BACKPACK])
 		backpack = random_backpack()
 	if(randomise[RANDOM_JUMPSUIT_STYLE])
-		jumpsuit_style = pick(GLOB.jumpsuitlistrandom)
+		jumpsuit_style = PREF_SUIT
 	if(randomise[RANDOM_EXOWEAR_STYLE])
-		exowear = pick(GLOB.exowearlist)
+		exowear = PREF_EXOWEAR
 	if(randomise[RANDOM_HAIRSTYLE])
 		hairstyle = random_hairstyle(gender)
 	if(randomise[RANDOM_FACIAL_HAIRSTYLE])


### PR DESCRIPTION

## Changelog
:cl:
fix: The maintenance technician alt title will now actually spawn with a PDA.
fix: Assistants shouldn't ever spawn with the UNDER anymore.
tweak: Randomized characters start with normal jumpsuits and exowear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
