### PR TITLE
[Port] Updates Box Brig to Citadel's

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -4990,12 +4990,6 @@
 "aAQ" = (
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"aAS" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "aAT" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plasteel,
@@ -6517,15 +6511,6 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"aHg" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel Office"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/chapel/office)
 "aHi" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/window/reinforced{
@@ -7091,20 +7076,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aJg" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aJh" = (
 /turf/open/floor/plasteel,
 /area/gateway)
@@ -7572,15 +7543,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"aKW" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "aKX" = (
 /obj/machinery/door/window/eastright{
 	name = "Hydroponics Delivery";
@@ -9429,13 +9391,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aSl" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/plating,
-/area/storage/emergency/port)
 "aSm" = (
 /turf/open/floor/plating,
 /area/storage/emergency/port)
@@ -10400,14 +10355,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"aVH" = (
-/obj/machinery/processor,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "aVI" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -10876,6 +10823,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/quartermaster/warehouse)
+"aXK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table/wood,
+/obj/item/hand_labeler{
+	pixel_x = 5
+	},
+/obj/item/storage/box/evidence,
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "aXL" = (
 /turf/open/floor/carpet,
 /area/vacant_room/office)
@@ -12561,35 +12521,6 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/sorting)
-"beW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/obj/structure/table/reinforced,
-/obj/item/stack/wrapping_paper{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/stack/packageWrap{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "beY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -13001,14 +12932,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"bgF" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/pharmacy)
 "bgG" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway West";
@@ -14055,13 +13978,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"bkC" = (
-/obj/effect/decal/cleanable/oil,
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "bkE" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/r_wall,
@@ -14097,24 +14013,6 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/office)
-"bkO" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/item/radio/off,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/medical)
 "bkX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -14453,15 +14351,6 @@
 	},
 /obj/structure/dresser,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"bmB" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -14939,35 +14828,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bou" = (
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
-"bov" = (
-/obj/structure/table,
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/crowbar,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/item/radio/headset/headset_sci{
-	pixel_x = -3
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "box" = (
@@ -15558,6 +15418,22 @@
 "brd" = (
 /turf/open/floor/plasteel,
 /area/medical/genetics)
+"brf" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/storage/tools)
 "bri" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -17236,19 +17112,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"bzd" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/pen,
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bze" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -17558,17 +17421,6 @@
 "bAl" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
-"bAp" = (
-/obj/structure/closet/secure_closet/medical1,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bAr" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -18889,19 +18741,6 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/medical/sleeper)
-"bFA" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
-	},
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bFB" = (
 /obj/structure/closet/secure_closet/medical2,
@@ -22398,28 +22237,6 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
-"bWf" = (
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/color/latex,
-/obj/machinery/requests_console{
-	department = "Virology";
-	name = "Virology Requests Console";
-	pixel_y = -32
-	},
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/hud/health,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/clothing/glasses/science,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bWg" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -22794,6 +22611,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"bXS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "bXU" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
@@ -26810,6 +26636,17 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"cMj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/department/electrical)
 "cMk" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -27107,6 +26944,22 @@
 /obj/item/kirbyplants,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"cSb" = (
+/obj/item/kirbyplants/random,
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	dir = 9;
+	name = "Science Requests Console";
+	pixel_x = -32;
+	pixel_y = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/nanite)
 "cSu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28269,6 +28122,17 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"dCc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	dir = 8;
+	name = "Atmos RC";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "dCy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -28281,6 +28145,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"dCH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "dCJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -29147,6 +29022,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"eli" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/teleporter)
 "emD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30117,16 +30002,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"eVL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "eWq" = (
 /obj/machinery/gulag_item_reclaimer{
 	pixel_y = 24
@@ -30495,6 +30370,36 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"fjR" = (
+/obj/structure/table,
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/crowbar,
+/obj/item/radio/headset/headset_sci{
+	pixel_x = -3
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "fkm" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
@@ -30691,6 +30596,35 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"fqa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/wrapping_paper{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/stack/packageWrap{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "fqG" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -31092,18 +31026,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"fBs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/table/wood,
-/obj/item/hand_labeler{
-	pixel_x = 5
-	},
-/obj/item/storage/box/evidence,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
 "fCp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable{
@@ -31584,6 +31506,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"fTo" = (
+/obj/machinery/camera{
+	c_tag = "Toxins Lab East";
+	dir = 8;
+	network = list("ss13","rd");
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "fTK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -31628,6 +31567,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"fWw" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/obj/machinery/light_switch{
+	dir = 5;
+	pixel_x = 23;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/science/nanite)
 "fWF" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory North"
@@ -33522,6 +33477,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"hhL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain)
 "hiC" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -33658,6 +33623,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hld" = (
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/radio/off,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/medical)
 "hms" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -33960,6 +33944,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hul" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hur" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/open/floor/plasteel,
@@ -35153,19 +35145,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"inM" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel/white,
-/area/science/nanite)
 "ioC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -35338,6 +35317,20 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"iui" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	dir = 4;
+	name = "Medbay RC";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "iuB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -36062,6 +36055,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"iYK" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/pharmacy)
 "iZg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -36806,22 +36808,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jwv" = (
-/obj/machinery/camera{
-	c_tag = "Toxins Lab East";
-	dir = 8;
-	network = list("ss13","rd");
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "jww" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -38796,6 +38782,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"kMP" = (
+/obj/machinery/processor,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "kNm" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
@@ -41561,16 +41555,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"mBY" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/department/electrical)
 "mCv" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel,
@@ -41976,14 +41960,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"mKO" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "mLh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -42884,6 +42860,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"nip" = (
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/pen,
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	dir = 1;
+	name = "Medbay RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "nju" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -43998,16 +43988,6 @@
 	},
 /turf/closed/wall,
 /area/science/lab)
-"nQk" = (
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "nQy" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/exit";
@@ -44025,20 +44005,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit)
-"nQI" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/radio/headset/headset_med,
-/turf/open/floor/plasteel/white,
-/area/medical/pharmacy)
-"nQK" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "nQY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
@@ -44098,21 +44064,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"nTU" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/emergency,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel,
-/area/storage/tools)
 "nUe" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -44246,20 +44197,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"nZF" = (
-/obj/item/kirbyplants/random,
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science Requests Console";
-	pixel_y = -32;
-	receive_ore_updates = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/nanite)
 "nZT" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -44509,6 +44446,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"ogx" = (
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/radio/headset/headset_med,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/pharmacy)
 "ogA" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -44635,6 +44581,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"oiV" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Common Channel";
+	pixel_x = -27;
+	pixel_y = -3
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_x = 29;
+	pixel_y = -4
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_x = 1;
+	pixel_y = 27
+	},
+/obj/machinery/button/door{
+	id = "AI Door";
+	name = "AI Chamber Blast Door";
+	pixel_x = 28;
+	pixel_y = 28;
+	req_access_txt = "16"
+	},
+/obj/effect/landmark/start/ai,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "oju" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -45322,6 +45302,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"oEi" = (
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "oEo" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -46061,6 +46049,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"pcK" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "pdw" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -48093,6 +48088,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qnY" = (
+/obj/machinery/camera{
+	c_tag = "Chapel Office"
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/grimy,
+/area/chapel/office)
 "qoq" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -48148,43 +48153,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qqG" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Common Channel";
-	pixel_x = -27;
-	pixel_y = -3
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel";
-	pixel_x = 29;
-	pixel_y = -4
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_x = 1;
-	pixel_y = 27
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -30
-	},
-/obj/machinery/button/door{
-	id = "AI Door";
-	name = "AI Chamber Blast Door";
-	pixel_x = 28;
-	pixel_y = 28;
-	req_access_txt = "16"
-	},
-/obj/effect/landmark/start/ai,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "qqH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -49631,6 +49599,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"rmN" = (
+/obj/item/storage/box/lights/mixed,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plating,
+/area/storage/emergency/port)
 "rmX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -49715,35 +49691,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"rri" = (
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_x = -24;
-	pixel_y = -6;
-	req_access_txt = "10"
-	},
-/obj/item/radio/off,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = -23
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "rrm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50272,6 +50219,36 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"rIH" = (
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for the engineering security doors.";
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_x = -24;
+	pixel_y = -6;
+	req_access_txt = "10"
+	},
+/obj/item/radio/off,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = -23;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "rJL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -51343,8 +51320,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 26;
-	pixel_y = -29
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -52166,6 +52142,17 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
+"sWC" = (
+/obj/structure/closet/secure_closet/medical1,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "sWE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -56387,6 +56374,21 @@
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"vCi" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "vCF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -57414,6 +57416,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"wlm" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -30
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "wlI" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/dark,
@@ -58001,6 +58012,29 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
+"wDC" = (
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/clothing/glasses/science,
+/obj/machinery/requests_console{
+	department = "Virology";
+	dir = 8;
+	name = "Virology Requests Console";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "wDR" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/nanite_chamber,
@@ -58734,6 +58768,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"xcq" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "xcu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -59178,16 +59222,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"xra" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "xrc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -59995,15 +60029,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"xOg" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/teleporter)
 "xOQ" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -74936,7 +74961,7 @@ aNf
 aNf
 aLA
 aQD
-xra
+bXS
 czK
 aUQ
 aUW
@@ -75207,7 +75232,7 @@ beT
 bdQ
 beZ
 bje
-bkC
+oEi
 cAJ
 beO
 aaa
@@ -76722,7 +76747,7 @@ aaf
 atO
 eLZ
 azF
-aAS
+pcK
 aFP
 aAQ
 aAQ
@@ -82389,7 +82414,7 @@ iHL
 uRo
 tsw
 aPK
-aSl
+rmN
 aTH
 aPK
 xHr
@@ -82927,7 +82952,7 @@ bjv
 btv
 tia
 bxz
-eVL
+dCH
 uXa
 byy
 bBa
@@ -84701,7 +84726,7 @@ fRs
 iHL
 aOz
 aPQ
-nTU
+brf
 aTL
 aTP
 tav
@@ -84713,7 +84738,7 @@ nXi
 bcV
 bcV
 bfn
-beW
+fqa
 bfR
 bKF
 bNH
@@ -87506,7 +87531,7 @@ npE
 anR
 aow
 qHT
-fBs
+aXK
 dyN
 wUs
 qHT
@@ -89335,7 +89360,7 @@ aWT
 dWX
 cva
 rfO
-nQK
+wlm
 cva
 cva
 cva
@@ -89594,7 +89619,7 @@ cva
 dIq
 ngQ
 cva
-qqG
+oiV
 dmc
 ggh
 wNr
@@ -91687,7 +91712,7 @@ bUI
 wPl
 bWQ
 nbK
-rri
+rIH
 cmp
 bTi
 caA
@@ -91913,7 +91938,7 @@ bgV
 bim
 bjG
 aZV
-bmB
+hhL
 bnZ
 bpl
 bqH
@@ -92148,7 +92173,7 @@ aDG
 aFd
 auk
 uFJ
-aJg
+vCi
 aKo
 aLO
 edR
@@ -92719,10 +92744,10 @@ cbA
 gno
 olz
 hut
-mKO
+hul
 hyU
 rol
-nQk
+dCc
 cbA
 bQt
 bLQ
@@ -92945,7 +92970,7 @@ wfP
 ybk
 wfP
 cwL
-xOg
+eli
 kIb
 buZ
 buZ
@@ -94479,9 +94504,9 @@ ddj
 wzp
 ddj
 bfF
-nQI
+ogx
 jNM
-bgF
+iYK
 blf
 bmF
 bob
@@ -96035,7 +96060,7 @@ bvh
 bwC
 bxN
 bze
-bAp
+sWC
 bvh
 bCG
 bBd
@@ -98353,7 +98378,7 @@ bvj
 bCN
 bEa
 pHl
-bFA
+iui
 bIm
 bJD
 bib
@@ -98595,7 +98620,7 @@ toc
 biy
 bjY
 bjN
-bkO
+hld
 bmU
 bnH
 bqQ
@@ -99651,7 +99676,7 @@ bNd
 bfJ
 bUb
 bVa
-bWf
+wDC
 bWX
 bOP
 bNd
@@ -99891,7 +99916,7 @@ bsN
 bvo
 bzl
 bua
-bzd
+nip
 bhh
 btT
 bCU
@@ -100124,7 +100149,7 @@ aJI
 aRH
 aVz
 aVz
-aVH
+kMP
 fRC
 aYN
 aJI
@@ -100373,7 +100398,7 @@ cVb
 hxM
 aIk
 aIp
-aKW
+xcq
 aMG
 aIp
 aIp
@@ -106049,7 +106074,7 @@ biP
 bko
 blE
 udD
-bov
+fjR
 bpU
 brq
 bsW
@@ -106538,7 +106563,7 @@ asB
 aCK
 dua
 aFw
-aHg
+qnY
 aIA
 aJT
 aLc
@@ -106595,7 +106620,7 @@ dIJ
 oHa
 uek
 dYq
-inM
+fWw
 wDR
 oVW
 bvv
@@ -108137,7 +108162,7 @@ oNT
 tQL
 ngb
 dYq
-nZF
+cSb
 wDR
 hnc
 qdO
@@ -108327,7 +108352,7 @@ aaa
 aaa
 asB
 ije
-mBY
+cMj
 avO
 awU
 ayj
@@ -109923,7 +109948,7 @@ rbk
 sgc
 myK
 iRS
-jwv
+fTo
 iVm
 hKU
 cNW

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -34,6 +34,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"aak" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/closed/wall/r_wall,
+/area/security/warden)
 "aal" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -44,100 +53,12 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"aan" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/ambrosia,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aat" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aau" = (
-/obj/machinery/biogenerator,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaw" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"aax" = (
-/mob/living/simple_animal/mouse/brown/Tom,
-/turf/open/floor/plating,
-/area/security/prison)
 "aay" = (
 /turf/open/floor/plating,
-/area/security/prison)
-"aaz" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plating,
-/area/security/prison)
-"aaA" = (
-/obj/machinery/seed_extractor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaB" = (
-/obj/structure/window/reinforced,
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/potato,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaC" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison)
-"aaD" = (
-/obj/structure/window/reinforced,
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/grass,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaE" = (
-/obj/structure/window/reinforced,
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaF" = (
-/obj/structure/window/reinforced,
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "aaG" = (
 /obj/machinery/light{
@@ -159,40 +80,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aaK" = (
-/obj/machinery/washing_machine,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"aaN" = (
-/obj/structure/table,
-/obj/item/pen,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaO" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaP" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aaR" = (
 /obj/structure/lattice,
 /obj/structure/sign/warning/securearea{
@@ -210,36 +97,6 @@
 /obj/structure/grille,
 /turf/open/space,
 /area/space/nearstation)
-"aaU" = (
-/obj/machinery/computer/arcade,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaV" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaW" = (
-/obj/structure/table,
-/obj/item/toy/cards/deck,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaX" = (
-/obj/machinery/washing_machine,
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aaZ" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
@@ -301,38 +158,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"abk" = (
-/obj/machinery/keycard_auth{
-	pixel_x = 24;
-	pixel_y = 10
-	},
-/obj/structure/table/wood,
-/obj/machinery/photocopier/faxmachine{
-	department = "Head of Security"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
-"abl" = (
-/obj/machinery/vending/security,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"abm" = (
-/obj/structure/table,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
-/obj/item/key/security,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "abo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -340,9 +165,6 @@
 "abp" = (
 /turf/closed/wall,
 /area/security/main)
-"abq" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/hos)
 "abt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -380,11 +202,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"abx" = (
-/obj/machinery/vending/cola/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aby" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -437,110 +254,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"abH" = (
-/obj/structure/table,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
-	},
-/obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"abI" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"abJ" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "abK" = (
 /obj/structure/chair/stool,
 /obj/machinery/light/small{
@@ -582,67 +295,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"abN" = (
-/obj/structure/closet/secure_closet/lethalshots,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "abO" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"abP" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"abQ" = (
-/obj/structure/rack,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/hooded/ablative,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"abR" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"abS" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
-"abU" = (
-/obj/machinery/computer/card/minor/hos,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
-"abW" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "abY" = (
 /obj/structure/grille,
 /turf/open/space,
@@ -675,49 +330,6 @@
 "acd" = (
 /turf/closed/wall,
 /area/security/prison)
-"aci" = (
-/obj/vehicle/ridden/secway,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"acj" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/suit_storage_unit/hos,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
-"ack" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
-"acl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
-"acn" = (
-/obj/item/storage/secure/safe/HoS{
-	pixel_x = 35
-	},
-/obj/structure/closet/secure_closet/hos,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
-"aco" = (
-/obj/structure/closet/bombcloset/security,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"acp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"acq" = (
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "acr" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet,
@@ -729,12 +341,6 @@
 "acu" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"acv" = (
-/obj/structure/closet/secure_closet/contraband/armory,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/effect/spawner/lootdrop/armory_contraband/metastation,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "acw" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
@@ -836,41 +442,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"acK" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
-"acL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
-"acM" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "acN" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/tile/bar,
@@ -879,35 +450,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"acO" = (
-/obj/structure/closet/l3closet/security,
-/obj/machinery/camera{
-	c_tag = "Brig Equipment Room";
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"acP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "acQ" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/stamp/hos,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
-"acR" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	on = 0;
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "acU" = (
@@ -992,62 +538,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"adi" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"adj" = (
-/obj/structure/rack,
-/obj/item/gun/energy/disabler{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/disabler,
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
-"adk" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "adn" = (
 /obj/structure/chair{
 	dir = 1
@@ -1111,12 +601,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"adB" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/turf/open/space,
-/area/space/nearstation)
 "adC" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1160,24 +644,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/prison)
-"adK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
-"adL" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "adM" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/yellow,
@@ -1192,16 +658,6 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"adO" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/event_spawn,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"adQ" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "adR" = (
 /turf/closed/wall/r_wall,
 /area/security/main)
@@ -1289,19 +745,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"aef" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aeg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -1432,20 +875,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aes" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
-"aet" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "aeu" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Access"
@@ -1453,44 +882,12 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aev" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"aew" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"aez" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aeA" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
-/area/security/main)
-"aeB" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/pen,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aeD" = (
@@ -1600,18 +997,6 @@
 "afc" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"afd" = (
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"afe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "aff" = (
@@ -1742,18 +1127,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"afz" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "afA" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
@@ -1831,30 +1204,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"afL" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "afM" = (
-/turf/open/floor/plasteel,
-/area/security/brig)
-"afN" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "afQ" = (
@@ -1955,35 +1305,21 @@
 "agn" = (
 /turf/closed/wall/r_wall,
 /area/security/warden)
-"ago" = (
-/obj/machinery/computer/security,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "agp" = (
 /obj/machinery/computer/prisoner/management,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "agr" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"ags" = (
-/obj/structure/chair{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/warden)
 "agt" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"agu" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "agv" = (
@@ -1994,21 +1330,6 @@
 /obj/machinery/computer/security/mining,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"agw" = (
-/obj/structure/table,
-/obj/machinery/syndicatebomb/training,
-/obj/item/gun/energy/laser/practice,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "agx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -2044,12 +1365,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/main)
-"agE" = (
-/obj/structure/table,
-/obj/item/folder/red,
-/obj/item/pen,
-/turf/open/floor/plasteel,
-/area/security/main)
 "agG" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -2066,68 +1381,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"agH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"agI" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"agJ" = (
-/obj/item/cigbutt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"agK" = (
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"agL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"agM" = (
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"agN" = (
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/regular,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "agO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -2162,38 +1415,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"agS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"agU" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"agW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/warden)
-"agX" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"agY" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "agZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -2223,17 +1444,6 @@
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
 	sortType = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
-"ahh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2277,89 +1487,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"ahl" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	dir = 8;
-	freq = 1400;
-	location = "Security"
-	},
-/obj/structure/plasticflaps/opaque,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/main)
-"ahm" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "ahn" = (
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
-"aho" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"ahp" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"ahq" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"ahr" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"ahs" = (
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"aht" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "ahv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2398,17 +1528,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"ahD" = (
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Brig Infirmary"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "ahJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow{
@@ -2423,198 +1542,37 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
-"ahP" = (
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"ahR" = (
-/obj/structure/chair/office,
-/obj/effect/landmark/start/warden,
-/obj/machinery/button/door{
-	id = "Prison Gate";
-	name = "Prison Wing Lockdown";
-	pixel_x = -27;
-	pixel_y = 8;
-	req_access_txt = "2"
-	},
-/obj/machinery/button/door{
-	id = "Secure Gate";
-	name = "Cell Shutters";
-	pixel_x = -27;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"ahS" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "ahT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"ahU" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"ahV" = (
-/obj/structure/table,
-/obj/item/folder/red,
-/obj/item/taperecorder,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"ahW" = (
-/obj/machinery/camera{
-	c_tag = "Brig Infirmary";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/closet/secure_closet/brig_phys,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"ahX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/machinery/computer/crew{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"aia" = (
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -27
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
-"aid" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"aie" = (
-/obj/structure/table,
-/obj/item/folder/red,
-/obj/item/pen,
-/obj/item/hand_labeler,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"aih" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aii" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/window/reinforced{
+	layer = 2.9
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/warden)
-"aij" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"ail" = (
-/obj/machinery/camera{
-	c_tag = "Brig Interrogation";
-	dir = 8;
-	network = list("interrogation")
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/prison)
-"aim" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
-"aip" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
-"aiq" = (
-/obj/machinery/camera{
-	c_tag = "Security Office";
-	dir = 1
-	},
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/area/ai_monitored/security/armory)
 "ais" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2629,92 +1587,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"ait" = (
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
-/obj/machinery/computer/security{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
-"aiv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
-"aiw" = (
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Brig Infirmary"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "aiy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aiB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"aiC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"aiD" = (
-/obj/structure/bodycontainer/morgue,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"aiE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"aiF" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"aiH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -2731,57 +1605,12 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aiO" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"aiP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/security/main)
-"aiQ" = (
-/obj/machinery/camera{
-	c_tag = "Brig East"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aiR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aiS" = (
 /obj/item/stack/rods,
 /turf/open/space,
 /area/space/nearstation)
 "aiT" = (
 /turf/closed/wall,
-/area/security/processing)
-"aiU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
 /area/security/processing)
 "aiV" = (
 /turf/closed/wall/r_wall,
@@ -2794,18 +1623,6 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ajc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"ajd" = (
-/obj/structure/plaque/static_plaque/golden{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -2890,58 +1707,6 @@
 /obj/machinery/gulag_teleporter,
 /turf/open/floor/plasteel,
 /area/security/processing)
-"ajt" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/storage/box/prisoner,
-/obj/machinery/camera{
-	c_tag = "Labor Shuttle Dock North"
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"aju" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/computer/security/labor,
-/turf/open/floor/plasteel,
-/area/security/processing)
-"ajv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"ajw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/security/brig)
-"ajC" = (
-/obj/item/storage/toolbox/drone,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "ajE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -2953,27 +1718,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"ajF" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"ajG" = (
-/obj/machinery/light,
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	name = "Cell 1";
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ajH" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -3007,22 +1751,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ajM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/courtroom)
-"ajN" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ajO" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -3073,29 +1801,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"ajS" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/window/southleft{
-	name = "Court Cell";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
 "ajY" = (
 /obj/effect/mapping_helpers/dead_body_placer,
 /turf/open/floor/plasteel/dark,
@@ -3107,21 +1812,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"aka" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"akg" = (
-/obj/machinery/camera{
-	c_tag = "Brig West";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aki" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3142,29 +1832,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"akk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"akl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"akm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "akn" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -3175,84 +1842,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"ako" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	name = "Cell 2";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"akp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"akq" = (
-/obj/machinery/camera{
-	c_tag = "Brig Central";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"akr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aks" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"akt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aku" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -3266,16 +1855,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"akx" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/button/flasher{
-	id = "cell4";
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aky" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3289,11 +1868,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"akz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "akA" = (
 /obj/structure/chair{
 	dir = 8;
@@ -3338,13 +1912,6 @@
 /obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"akU" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "akV" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/eastright{
@@ -3446,18 +2013,7 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"alp" = (
-/turf/open/floor/plating,
-/area/security/processing)
 "alq" = (
-/turf/open/floor/plasteel,
-/area/security/processing)
-"alr" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "als" = (
@@ -3466,10 +2022,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"alt" = (
-/obj/structure/reagent_dispensers/peppertank,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/security/armory)
 "alu" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/tile/neutral{
@@ -3484,77 +2036,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
-"alw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aly" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -25;
-	pixel_y = -2;
-	prison_radio = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"alz" = (
-/obj/machinery/button/door{
-	id = "briggate";
-	name = "Desk Shutters";
-	pixel_x = -26;
-	pixel_y = 6
-	},
-/obj/machinery/button/flasher{
-	id = "brigentry";
-	pixel_x = -28;
-	pixel_y = -8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"alA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/machinery/door/window/eastleft{
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"alB" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"alC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "alD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3622,15 +2103,6 @@
 "alU" = (
 /turf/closed/wall,
 /area/maintenance/port/fore)
-"alV" = (
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"alW" = (
-/obj/item/cigbutt/cigarbutt,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "alX" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -3659,126 +2131,6 @@
 /mob/living/simple_animal/hostile/retaliate/gator/steppy,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"amf" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_x = -28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"amg" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"amh" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"ami" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"amj" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/machinery/flasher{
-	id = "Cell 3";
-	pixel_x = -28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"amk" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aml" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "outerbrig";
-	name = "Brig Exterior Doors Control";
-	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = -5;
-	req_access_txt = "63"
-	},
-/obj/machinery/button/door{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "innerbrig";
-	name = "Brig Interior Doors Control";
-	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = 5;
-	req_access_txt = "63"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"amm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/machinery/door/window/eastright{
-	name = "Brig Desk";
-	req_access_txt = "2"
-	},
-/obj/item/restraints/handcuffs,
-/obj/item/radio/off,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"amn" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"amo" = (
-/obj/machinery/flasher{
-	id = "brigentry";
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"amq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "amr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -3849,71 +2201,16 @@
 /obj/item/coin/diamond,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"amG" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/item/toy/sword,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"amH" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 27
-	},
-/obj/item/trash/plate,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "amK" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
 /area/security/processing)
-"amL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/processing)
-"amN" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "amP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"amT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/machinery/door/window/southleft{
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "amU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
@@ -3922,20 +2219,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"amV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/machinery/door/window/southleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "amY" = (
 /obj/structure/chair{
 	dir = 1
@@ -4006,41 +2289,7 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"ano" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"anp" = (
-/obj/item/cigbutt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "anw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"anx" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"any" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -4101,15 +2350,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"anQ" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "anR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
@@ -4122,13 +2362,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"anV" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
 "anX" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -4249,35 +2482,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aoA" = (
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"aoC" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"aoD" = (
-/obj/machinery/camera{
-	c_tag = "Fore Primary Hallway East";
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"aoF" = (
-/obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aoG" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4361,11 +2565,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aoU" = (
-/obj/structure/bed,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aoV" = (
 /turf/open/space,
 /area/space)
@@ -4379,10 +2578,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"apb" = (
-/obj/structure/plasticflaps,
-/turf/open/floor/plating,
-/area/security/processing)
 "apd" = (
 /turf/closed/wall,
 /area/security/detectives_office)
@@ -4517,10 +2712,6 @@
 	dir = 1
 	},
 /area/science/explab)
-"apR" = (
-/obj/item/paper/fluff/jobs/security/beepsky_mom,
-/turf/open/floor/plating,
-/area/security/processing)
 "apV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4686,17 +2877,6 @@
 "aqR" = (
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aqS" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/potato{
-	name = "\improper Beepsky's emergency battery"
-	},
-/turf/open/floor/plating,
-/area/security/processing)
 "aqZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -4862,12 +3042,6 @@
 /area/maintenance/port/fore)
 "arN" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"arO" = (
-/obj/machinery/monkey_recycler,
-/obj/item/reagent_containers/food/snacks/monkeycube,
-/obj/item/reagent_containers/food/snacks/monkeycube,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arP" = (
@@ -5093,9 +3267,6 @@
 "asB" = (
 /turf/closed/wall,
 /area/maintenance/department/electrical)
-"asC" = (
-/turf/open/floor/plasteel/airless,
-/area/space/nearstation)
 "asE" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
@@ -5167,19 +3338,6 @@
 /area/maintenance/fore)
 "asQ" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"asR" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/closet/secure_closet/chemical,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"asS" = (
-/obj/structure/closet/secure_closet/medical1,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"asT" = (
-/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "asX" = (
@@ -5423,11 +3581,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port/fore)
-"atR" = (
-/obj/effect/landmark/carpspawn,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "atS" = (
 /turf/closed/wall,
 /area/space/nearstation)
@@ -5716,32 +3869,8 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"avd" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "avg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"avl" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -6001,14 +4130,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"awc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "awe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
@@ -6065,6 +4186,30 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"awx" = (
+/obj/machinery/button/door{
+	desc = "A remote control switch for the exit.";
+	id = "laborexit";
+	name = "exit button";
+	normaldoorcontrol = 1;
+	pixel_x = 26;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "awy" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -6355,6 +4500,9 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
+"axV" = (
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "axW" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -7042,6 +5190,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"aBZ" = (
+/obj/structure/table,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "aCc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -7493,21 +5648,6 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
-"aDU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aDV" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8287,6 +6427,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aGH" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "aGI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -8410,13 +6568,6 @@
 	dir = 4
 	},
 /area/chapel/main)
-"aHp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "aHq" = (
 /turf/closed/wall,
 /area/escapepodbay)
@@ -9438,10 +7589,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"aKY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aKZ" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -10870,6 +9017,16 @@
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"aQJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "aQK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -11557,12 +9714,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"aTb" = (
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/turf/open/floor/wood,
-/area/library)
 "aTc" = (
 /obj/machinery/door/window/northright{
 	dir = 8;
@@ -12492,14 +10643,6 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/warehouse)
-"aWI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "aWM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -12555,6 +10698,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"aXb" = (
+/obj/structure/chair{
+	dir = 8;
+	name = "Defense"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "aXf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12876,6 +11033,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"aYy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aYF" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/central";
@@ -14133,6 +12297,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"bdT" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bdU" = (
 /obj/structure/closet/crate/medical,
 /obj/effect/decal/cleanable/dirt,
@@ -14166,6 +12338,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"bee" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/warden)
 "bei" = (
 /obj/machinery/light{
 	dir = 8
@@ -15029,6 +13208,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"bhp" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "bhq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -15852,18 +14039,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"bkA" = (
-/obj/effect/landmark/event_spawn,
-/mob/living/simple_animal/bot/secbot{
-	arrest_type = 1;
-	health = 45;
-	icon_state = "secbot1";
-	idcheck = 1;
-	name = "Sergeant-at-Armsky";
-	weaponscheck = 1
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "bkB" = (
 /obj/machinery/button/door{
 	id = "Disposal Exit";
@@ -17292,21 +15467,6 @@
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/head_of_personnel)
-"bqF" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/fore";
-	dir = 1;
-	name = "Fore Maintenance APC";
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "bqH" = (
 /turf/closed/wall/r_wall,
 /area/teleporter)
@@ -17865,6 +16025,33 @@
 "btG" = (
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
+"btP" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/door/window/southleft{
+	dir = 8;
+	name = "Reception Desk";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	name = "Reception Desk";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "btQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -18796,6 +16983,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"byq" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "byt" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hor)
@@ -19351,6 +17548,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"bAe" = (
+/obj/effect/turf_decal/tile/red,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "bAl" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
@@ -21489,6 +19693,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"bIF" = (
+/obj/structure/plasticflaps,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "bIG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -21631,24 +19839,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"bJd" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/interrogation{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bJe" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -21689,6 +19879,26 @@
 /obj/effect/spawner/lootdrop/techstorage/security,
 /turf/open/floor/plating,
 /area/storage/tech)
+"bJn" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bJp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -21857,6 +20067,18 @@
 /obj/item/stock_parts/subspace/amplifier,
 /turf/open/floor/plating,
 /area/storage/tech)
+"bKv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	name = "Cell 3";
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bKw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -21929,6 +20151,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"bKP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "bKQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -22591,6 +20817,26 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"bNP" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bNQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23303,17 +21549,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"bQT" = (
-/obj/machinery/door/airlock/security{
-	name = "Interrogation";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "bQZ" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
@@ -23637,6 +21872,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"bTJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "bTK" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -25544,6 +23785,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"cdw" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "cdz" = (
 /obj/machinery/light{
 	dir = 4
@@ -25733,6 +23993,17 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ceX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/warden)
 "ceY" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -25860,6 +24131,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"cga" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "cgd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26197,6 +24480,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cjm" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "cjn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26570,16 +24857,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"clI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "clJ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -26629,15 +24906,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"clS" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "clU" = (
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
@@ -26696,6 +24964,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cml" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters{
+	id = "armory3";
+	name = "Armoury Shutter"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "cmn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -26840,6 +25116,31 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"coa" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"coh" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prisoner Processing";
+	req_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "cop" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 1
@@ -26877,24 +25178,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"coS" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
+"coA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/main)
 "coU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -26939,27 +25238,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"cpg" = (
-/obj/item/grenade/barrier{
-	pixel_x = 4
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = -4
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "cph" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -27093,39 +25371,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cqG" = (
-/obj/structure/rack,
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+"cqA" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "cqK" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -27184,6 +25443,15 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"crD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "crP" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -27246,6 +25514,10 @@
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"csV" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cte" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/disposal";
@@ -27317,6 +25589,18 @@
 "cva" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
+"cvh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/button/door{
+	id = "hosspace";
+	name = "Space Shutters Control";
+	pixel_x = 1;
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "cvl" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -27418,29 +25702,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"cwM" = (
-/obj/structure/rack,
-/obj/item/storage/box/teargas{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "cwT" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Escape Pod 2";
@@ -27470,13 +25731,11 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cxe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+"cxc" = (
+/obj/machinery/computer/security,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "cxl" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -27489,12 +25748,6 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
 /area/space/nearstation)
-"cxA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "cxE" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -27812,6 +26065,23 @@
 /obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cAY" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	dir = 8;
+	freq = 1400;
+	location = "Security"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plasteel,
+/area/security/main)
 "cBa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -27977,13 +26247,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"cCh" = (
-/obj/item/bedsheet/red,
-/mob/living/simple_animal/bot/secbot/beepsky{
-	name = "Officer Beepsky"
-	},
-/turf/open/floor/plating,
-/area/security/processing)
 "cCm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -28001,6 +26264,24 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"cCF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "cCG" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -28043,11 +26324,29 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"cCR" = (
+/obj/machinery/washing_machine,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "cCS" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
+"cDk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/security/brig)
 "cDz" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -28185,6 +26484,19 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"cFw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"cFJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "cGg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -28485,6 +26797,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"cLU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "cMk" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -28517,6 +26842,49 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cMr" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/main";
+	dir = 4;
+	name = "Security Office APC";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/computer/cargo/request{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
+"cMM" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/trackimp{
+	pixel_x = -3
+	},
+/obj/item/storage/box/chemimp{
+	pixel_x = 6
+	},
+/obj/item/storage/lockbox/loyalty,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "cMQ" = (
 /obj/machinery/power/solar{
 	id = "starboardsolar";
@@ -28579,15 +26947,6 @@
 "cNG" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"cNH" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "cNI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -28648,6 +27007,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"cPm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "cPs" = (
 /obj/machinery/light_switch{
 	pixel_y = -23
@@ -28694,6 +27057,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cQn" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "cQw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -28799,24 +27168,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"cSR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "cSZ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -29037,21 +27388,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"daD" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Evidence Storage";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "daR" = (
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
@@ -29097,6 +27433,34 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"dcE" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ddf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -29212,6 +27576,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"dhY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "dif" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -29230,19 +27604,6 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"djv" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "djR" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 4;
@@ -29424,6 +27785,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"dod" = (
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/wood,
+/area/library)
 "dof" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -29494,16 +27862,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"drT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+"drc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plating,
+/area/security/warden)
 "drZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29516,6 +27882,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"dsh" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"dsK" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "dtc" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
@@ -29533,6 +27925,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"dtI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Brig Central";
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "dtO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -29586,6 +27993,16 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/storage/tech)
+"duI" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig E.V.A. Storage";
+	req_access_txt = "3"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "duX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29643,6 +28060,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"dwj" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dwo" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -29686,6 +28113,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dxS" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/potato{
+	name = "\improper Beepsky's emergency battery"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "dyg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -29739,6 +28177,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"dzI" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dzM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -29748,15 +28193,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"dAi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "dAI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29860,19 +28296,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"dDx" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "dDz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -29911,28 +28334,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"dFW" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
+"dGx" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "dGD" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation A";
@@ -29951,13 +28359,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/security/processing)
-"dHW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/warden)
 "dIq" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -29991,6 +28392,9 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"dIC" = (
+/turf/closed/wall,
+/area/security/range)
 "dIJ" = (
 /obj/item/radio/intercom{
 	freerange = 1;
@@ -30001,6 +28405,30 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"dIW" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"dIX" = (
+/obj/structure/closet/secure_closet/evidence,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/warden)
 "dJG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -30010,6 +28438,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"dKJ" = (
+/obj/machinery/chem_master/condimaster,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"dKO" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"dKW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/security/brig)
 "dLh" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -30201,16 +28647,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/aft)
-"dQk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "dQz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30242,6 +28678,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"dRD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "dRW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -30251,6 +28703,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"dRX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "dSE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -30265,25 +28724,9 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "dTj" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/area/security/courtroom)
 "dTl" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage";
@@ -30347,6 +28790,18 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
+"dVN" = (
+/obj/item/target,
+/obj/item/target,
+/obj/item/target/clown,
+/obj/item/target/clown,
+/obj/machinery/door/window/brigdoor/westleft{
+	dir = 2;
+	name = "Target Storage";
+	req_access_txt = "63"
+	},
+/turf/open/floor/plating,
+/area/security/range)
 "dWG" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -30371,6 +28826,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing/chamber)
+"dWI" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "dWM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -30378,16 +28848,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"dWN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "dWX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -30398,6 +28858,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"dXY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/brown{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -30448,6 +28915,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"dZW" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "dZY" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -30475,6 +28951,14 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/fitness)
+"eaj" = (
+/obj/structure/rack,
+/obj/item/storage/firstaid,
+/obj/item/clothing/glasses/hud/health,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "eau" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -30495,23 +28979,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"edn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"edC" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = 23
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "edD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -30527,6 +28994,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"edW" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "eeo" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -30676,16 +29147,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"eke" = (
-/obj/structure/closet/secure_closet/warden,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "emD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30767,6 +29228,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"enD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/range)
 "eoF" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -30789,14 +29259,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"eoH" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "eoK" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/white,
@@ -30820,24 +29282,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"eqd" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/warden";
-	dir = 8;
-	name = "Brig Control APC";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "eqh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -30862,19 +29306,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"eqG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/security/brig)
+"eqR" = (
+/obj/structure/window/reinforced,
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/potato,
+/turf/open/floor/grass,
+/area/security/prison)
 "ere" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30929,6 +29366,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"esE" = (
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "esF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/start/atmospheric_technician,
@@ -30962,6 +29414,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"etZ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "armory3";
+	name = "Armory Shutters";
+	pixel_y = 26;
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "euD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30988,6 +29458,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"ewG" = (
+/obj/structure/closet/secure_closet/courtroom,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
+	},
+/obj/item/gavelhammer,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "ewM" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
@@ -31053,13 +29537,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"eyv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "eyP" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -31097,6 +29574,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"ezx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ezD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31115,6 +29607,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ezU" = (
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room";
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "eAe" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -31145,13 +29648,13 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"eBc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
+"eAS" = (
+/obj/item/bedsheet/red,
+/mob/living/simple_animal/bot/secbot/beepsky{
+	name = "Officer Beepsky"
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "eBv" = (
 /obj/structure/target_stake,
 /turf/open/floor/plasteel,
@@ -31325,6 +29828,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"eJw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eKm" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -31347,6 +29857,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"eLc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/range)
 "eLi" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -31399,21 +29915,9 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
-"ePl" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/processing";
-	dir = 8;
-	name = "Labor Shuttle Dock APC";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+"eNq" = (
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ePp" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -31425,19 +29929,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/storage/tech)
-"ePt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "eQb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31545,6 +30036,49 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"eUy" = (
+/obj/structure/window/reinforced{
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "eUV" = (
 /obj/machinery/door/window/southleft{
 	name = "SMES Chamber";
@@ -31573,6 +30107,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"eVv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "eVL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light_switch{
@@ -31636,6 +30180,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"eYY" = (
+/obj/structure/table/wood,
+/obj/item/storage/pill_bottle/dice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eZR" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -31695,16 +30245,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"fcD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+"fci" = (
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fcG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -31757,6 +30304,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"fej" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "fen" = (
 /obj/machinery/newscaster{
 	dir = 1;
@@ -31810,11 +30361,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"ffT" = (
-/obj/effect/landmark/xeno_spawn,
-/mob/living/simple_animal/hostile/retaliate/goose/vomit,
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/bar)
+"ffn" = (
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "63; 42"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fga" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31836,6 +30399,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"fgF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fgH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -31863,6 +30439,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"fib" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fiI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31893,21 +30473,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"fju" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "fjC" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/item/bikehorn/rubberducky,
@@ -31995,6 +30560,30 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"fmq" = (
+/obj/structure/chair/office,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"fmG" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fmJ" = (
 /obj/effect/landmark/observer_start,
 /obj/effect/turf_decal/plaque{
@@ -32011,6 +30600,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fmV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/range)
 "fno" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32144,6 +30742,10 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"fqY" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "frv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32176,6 +30778,13 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port/fore)
+"frV" = (
+/obj/machinery/door/window/southleft{
+	name = "Court Cell";
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "fsn" = (
 /obj/machinery/light/small,
 /obj/structure/cable{
@@ -32239,6 +30848,9 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"fuM" = (
+/turf/closed/wall/r_wall,
+/area/security/range)
 "fuW" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/tile/yellow,
@@ -32251,6 +30863,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"fva" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fvb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -32264,6 +30883,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"fvj" = (
+/obj/structure/closet/secure_closet/brig_phys,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fvt" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -32296,6 +30930,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"fwg" = (
+/obj/machinery/door/window/northright{
+	dir = 2;
+	name = "Security Desk"
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Reception Desk";
+	req_access_txt = "3"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "fwA" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -32339,19 +30994,6 @@
 /obj/machinery/pinpointer_dispenser,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"fxO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "fxR" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister,
@@ -32402,15 +31044,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"fzb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "fzl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -32441,6 +31074,11 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
+"fzM" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "fAX" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -32466,21 +31104,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"fBS" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Head of Security";
-	req_access_txt = "58"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "fCp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable{
@@ -32728,6 +31351,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"fMk" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/warden)
 "fNe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -32744,6 +31378,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"fNN" = (
+/obj/machinery/camera{
+	c_tag = "Prison Common Room";
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/sink{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fNV" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -32757,6 +31411,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fOk" = (
+/obj/machinery/camera{
+	c_tag = "Fore Primary Hallway East";
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "fPm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -32778,26 +31444,28 @@
 	dir = 5
 	},
 /area/science/research)
-"fQc" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 2";
-	name = "Cell 2"
+"fQD" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Equipment Room";
+	req_access_txt = "1"
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "fQP" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -32820,6 +31488,39 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
+"fQZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/folder/red,
+/obj/item/pen,
+/turf/open/floor/plasteel,
+/area/security/main)
+"fRo" = (
+/obj/structure/closet/secure_closet/warden,
+/obj/effect/turf_decal/bot,
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = 20
+	},
+/obj/structure/sign/poster/official/ion_rifle{
+	pixel_y = 32
+	},
+/obj/structure/sign/poster/official/twelve_gauge{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "fRs" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -32907,6 +31608,26 @@
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"fUX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"fVr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/lime{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fWF" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory North"
@@ -32946,6 +31667,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"fXT" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fYM" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L14"
@@ -33060,12 +31786,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
-"gef" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "geh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -33110,6 +31830,15 @@
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
+"gfa" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gfr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -33184,6 +31913,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"ghk" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	layer = 2.9
+	},
+/obj/structure/rack,
+/obj/item/storage/box/teargas{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/storage/box/flashbangs{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ghv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -33251,11 +32009,6 @@
 	},
 /turf/open/floor/plasteel/stairs,
 /area/escapepodbay)
-"gjb" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/courtroom)
 "gjk" = (
 /obj/machinery/camera{
 	c_tag = "Custodial Closet"
@@ -33325,30 +32078,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"gkJ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/brig";
-	dir = 1;
-	name = "Brig APC";
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"glt" = (
+/obj/machinery/camera{
+	c_tag = "Brig East"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/item/radio/intercom{
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"glu" = (
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/pen,
+/obj/item/hand_labeler,
+/turf/open/floor/plasteel,
+/area/security/main)
+"glD" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters{
+	id = "armory2";
+	name = "Armoury Shutter"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "glK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33384,6 +32143,24 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
+"gmH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "gno" = (
 /obj/machinery/power/apc{
 	areastring = "/area/engine/atmos";
@@ -33505,6 +32282,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"grc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/range)
 "grg" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "8;12"
@@ -33523,6 +32309,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"grq" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "grQ" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 1;
@@ -33702,6 +32503,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"gyR" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gzd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -33715,31 +32522,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
-"gzp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Armory Desk";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/window/southleft{
-	name = "Reception Desk";
-	req_access_txt = "63"
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "gzz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -33906,6 +32688,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"gFh" = (
+/obj/effect/landmark/event_spawn,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gFH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -34004,6 +32791,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"gJH" = (
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
+/turf/open/space,
+/area/space)
 "gJR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -34049,6 +32842,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"gLw" = (
+/obj/machinery/door/airlock/security{
+	name = "Labor Shuttle";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"gLN" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "gMb" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -34071,6 +32890,19 @@
 	},
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
+"gMv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gMx" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom";
@@ -34082,6 +32914,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"gML" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
+"gMS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gNu" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -34089,6 +32938,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"gNA" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/plant_analyzer,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "gOf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34101,6 +32958,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"gOt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/warden)
 "gOP" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer";
@@ -34182,16 +33053,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"gQa" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/processing)
 "gRv" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/research";
@@ -34253,6 +33114,33 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"gTe" = (
+/obj/structure/window/reinforced{
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/gun/energy/disabler{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "gTt" = (
 /obj/item/wrench,
 /obj/item/wrench,
@@ -34268,6 +33156,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"gUb" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gUw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34446,16 +33341,6 @@
 /obj/effect/landmark/stationroom/box/engine,
 /turf/open/space/basic,
 /area/space)
-"haI" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "hbl" = (
 /obj/machinery/igniter{
 	id = "Incinerator"
@@ -34475,27 +33360,11 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"hcm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+"hct" = (
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/window/brigdoor/security/holding{
-	id = "Holding Cell";
-	name = "Holding Cell"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/fore)
 "hcH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -34562,6 +33431,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"heY" = (
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "hfc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34590,6 +33470,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"hgd" = (
+/obj/machinery/computer/card/minor/hos,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "hgA" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -34615,6 +33499,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"hht" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "hhu" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
@@ -34651,6 +33543,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"hiW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hjt" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -34710,6 +33613,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hjN" = (
+/obj/structure/closet/secure_closet/chemical,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hjP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -34720,6 +33629,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hjV" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "hkj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -34764,6 +33679,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"hnb" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/magnetic_controller{
+	autolink = 1
+	},
+/obj/item/gun/energy/laser/practice{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/gun/energy/laser/practice{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/turf/open/floor/plasteel,
+/area/security/range)
 "hnc" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
@@ -34819,6 +33757,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"hnZ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "hof" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/chemistry";
@@ -34865,23 +33818,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"hpx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "hpH" = (
 /obj/machinery/light{
 	dir = 4
@@ -34931,12 +33867,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"hqt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "hqv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -34954,16 +33884,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hrb" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "hrE" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -35103,28 +34023,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"hww" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/machinery/hydroponics/soil,
-/obj/item/plant_analyzer,
-/obj/machinery/camera{
-	c_tag = "Prison Common Room";
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hwE" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -35265,6 +34163,62 @@
 	},
 /turf/open/floor/plating,
 /area/science/lab)
+"hBv" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/shield/riot,
+/obj/item/shield/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"hBR" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hBZ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -35309,25 +34263,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"hEp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "hEI" = (
 /obj/machinery/computer/station_alert,
 /obj/item/radio/intercom{
@@ -35364,6 +34299,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hFZ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "hGa" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -35460,6 +34404,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"hMy" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hNp" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -35494,10 +34454,49 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"hON" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "hPk" = (
 /obj/machinery/computer/atmos_control,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"hPv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
+"hPA" = (
+/obj/machinery/door/airlock/security{
+	name = "Shooting Range";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "hQe" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -35519,6 +34518,21 @@
 	dir = 5
 	},
 /area/science/research)
+"hQz" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "hQK" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -35629,15 +34643,6 @@
 "hTU" = (
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
-"hUs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "hUN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -35669,6 +34674,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hWp" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/security/brig)
+"hWv" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hWH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -35704,28 +34723,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"hXI" = (
-/obj/item/storage/box/bodybags,
-/obj/item/reagent_containers/syringe{
-	name = "steel point"
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/table/glass,
+"hXn" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 1
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = -27
+/turf/open/floor/plasteel,
+/area/security/processing)
+"hXw" = (
+/obj/structure/chair{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "hXS" = (
 /obj/structure/chair/office/light{
@@ -35838,10 +34850,43 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"icA" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "icS" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"idf" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "idw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -35869,6 +34914,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"iec" = (
+/obj/machinery/vending/security,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "iel" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -35879,6 +34929,21 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/science/research)
+"ieP" = (
+/obj/structure/chair/sofa/right,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ieQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "ifb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -35965,6 +35030,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"iim" = (
+/obj/machinery/camera{
+	c_tag = "Labor Shuttle Dock South";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "iiJ" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -36022,6 +35101,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"ikV" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/ambrosia,
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "ilk" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -36078,6 +35166,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
+"ioC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"ipk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "ipA" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
@@ -36110,6 +35221,18 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/aft)
+"ird" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "irh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -36215,6 +35338,16 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"iuB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "iuN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -36225,6 +35358,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ivB" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun/dragnet{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/gun/energy/e_gun/dragnet{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ivW" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -36277,6 +35433,18 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"iyN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "izr" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -36349,6 +35517,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
+"iBo" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "iBB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -36361,6 +35534,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"iCG" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters{
+	id = "armory3";
+	name = "Armoury Shutter"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "iDa" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -36389,6 +35571,20 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main)
+"iEn" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iFn" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
@@ -36401,6 +35597,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"iFu" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"iFv" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "iFB" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/fore";
@@ -36457,17 +35673,9 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/department/crew_quarters/bar)
-"iGX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/security/brig)
+"iHz" = (
+/turf/open/floor/grass,
+/area/security/prison)
 "iHD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -36521,6 +35729,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"iJp" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "iKj" = (
 /obj/structure/chair{
 	dir = 1
@@ -36642,6 +35862,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"iOU" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "iPr" = (
 /obj/machinery/photocopier,
 /obj/structure/cable{
@@ -36649,6 +35880,24 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/head_of_personnel)
+"iPB" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "iPR" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -36674,6 +35923,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iRe" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iRE" = (
 /obj/machinery/camera{
 	c_tag = "Experimentor Lab";
@@ -36696,32 +35953,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"iSk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"iTt" = (
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = 25;
-	pixel_y = -2;
-	prison_radio = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "iTJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
@@ -36754,6 +35985,10 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
+"iVk" = (
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/security/main)
 "iVm" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -36791,6 +36026,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iWn" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "iWN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -36800,6 +36044,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"iXM" = (
+/obj/structure/window/reinforced,
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "iYt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/plaque/static_plaque/atmos{
@@ -36807,6 +36062,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"iZg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/range)
 "iZC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=AIW";
@@ -37045,6 +36304,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"jfI" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "jfT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -37070,6 +36343,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jfY" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/vomit,
+/obj/item/toy/sword,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jgf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37116,6 +36397,11 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"jhY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/security/processing)
 "jit" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/bot_white,
@@ -37148,12 +36434,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"jjs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/security/courtroom)
 "jjH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37180,6 +36460,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"jkG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/chemical,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "jkU" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37254,6 +36539,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"jny" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"jnD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jnU" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -37286,23 +36586,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"jnZ" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/glowshroom,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "jpi" = (
 /obj/machinery/door/airlock{
 	name = "Unit 3"
@@ -37328,6 +36611,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"jpy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
+"jqk" = (
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/hos)
 "jqQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37352,6 +36650,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"jrB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jrF" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel/white/side{
@@ -37374,6 +36687,20 @@
 	dir = 1;
 	pixel_y = 32
 	},
+/turf/open/floor/plasteel,
+/area/security/main)
+"jsq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/main)
 "jsP" = (
@@ -37437,6 +36764,16 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
+"juE" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "juH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -37485,14 +36822,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"jwN" = (
-/obj/effect/landmark/start/brig_phys,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"jwP" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply,
-/turf/closed/wall,
-/area/maintenance/fore)
+"jww" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 30
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "jwR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -37530,6 +36872,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"jyB" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "jyD" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37540,25 +36895,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"jyM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "jyQ" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -37654,6 +36990,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"jDt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"jDy" = (
+/obj/structure/table/optable,
+/obj/effect/turf_decal/bot,
+/obj/item/storage/backpack/duffelbag/sec/surgery,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jDN" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
@@ -37731,15 +37090,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"jFQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jGc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -37815,15 +37165,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"jKc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jKo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -37949,6 +37290,21 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"jNj" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jNk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -37956,35 +37312,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jNo" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"jNu" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 1";
-	name = "Cell 1"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jNM" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
@@ -38002,19 +37329,39 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
-"jOg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"jOb" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/barrier{
+	pixel_x = -4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
+	pixel_x = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/ai_monitored/security/armory";
+	dir = 8;
+	name = "Armory APC";
+	pixel_x = -24
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "jOk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38028,6 +37375,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"jOV" = (
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jOW" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -38076,27 +37427,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"jPY" = (
-/obj/machinery/button/door{
-	desc = "A remote control switch for the exit.";
-	id = "laborexit";
-	name = "exit button";
-	normaldoorcontrol = 1;
-	pixel_x = 26;
-	pixel_y = -6
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "jQb" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -38197,6 +37527,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jTR" = (
+/obj/structure/plaque/static_plaque/golden{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jUp" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 4
@@ -38285,6 +37630,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"jWs" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
+"jXr" = (
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "jYe" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -38317,6 +37679,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"jZT" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/security/warden)
 "kbr" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38324,6 +37690,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kbK" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "kcn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -38395,12 +37771,17 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"kdH" = (
-/obj/machinery/computer/warrant{
-	dir = 8
+"kds" = (
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
-/area/security/courtroom)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/security/brig)
 "kdR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/airalarm{
@@ -38556,6 +37937,16 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
+"klJ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "klK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -38567,6 +37958,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"klS" = (
+/obj/machinery/camera/motion{
+	c_tag = "Armory - External";
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "klW" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Holding Area";
@@ -38578,6 +37977,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"kmk" = (
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/secequipment,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "kmq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -38649,21 +38057,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"kpa" = (
-/obj/machinery/camera{
-	c_tag = "Labor Shuttle Dock South";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "kpf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38761,10 +38154,30 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"krN" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "krS" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"krX" = (
+/obj/structure/closet/secure_closet/medical1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ktd" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -38777,15 +38190,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"kti" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "kto" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -38804,6 +38208,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"ktD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ktH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38815,6 +38233,11 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/department/crew_quarters/bar)
+"ktU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kum" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -38843,6 +38266,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"kxr" = (
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 3";
+	name = "Cell 3"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kxF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -38858,6 +38301,16 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard)
+"kyd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "kyi" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper,
@@ -38875,6 +38328,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"kyE" = (
+/obj/machinery/computer/security/labor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "kyS" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel,
@@ -38927,6 +38390,21 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"kAi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "kBb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -39000,6 +38478,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"kCD" = (
+/obj/structure/rack,
+/obj/item/gun/energy/temperature/security,
+/obj/item/gun/energy/ionrifle,
+/obj/item/clothing/suit/hooded/ablative,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "kCT" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/machinery/requests_console{
@@ -39022,6 +38517,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"kDR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/warden)
 "kEy" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral{
@@ -39053,6 +38560,41 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"kFW" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/camera/motion{
+	c_tag = "Armory Motion Sensor";
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "kFY" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 1;
@@ -39107,19 +38649,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"kHx" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "kIb" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -39255,27 +38784,24 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kMr" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "kNm" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"kOr" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Processing";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "kOx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39362,6 +38888,24 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"kQF" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Infirmary";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kRs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -39388,16 +38932,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"kRU" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "kSe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -39424,6 +38958,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"kTn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "kTP" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/genetics";
@@ -39616,6 +39159,13 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"lau" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "laB" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -39649,22 +39199,36 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"lbL" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control";
-	req_access_txt = "3"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+"lbs" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
+"lbG" = (
+/obj/machinery/computer/crew{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "innerbrig";
+	name = "Brig Interior Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = -24;
+	req_access_txt = "63"
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "outerbrig";
+	name = "Brig Exterior Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = -40;
+	req_access_txt = "63"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -39717,27 +39281,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"ldt" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ldx" = (
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 8
@@ -39759,27 +39302,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"len" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "leJ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"lfg" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "lfl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
@@ -39820,6 +39361,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"lgm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/bookmanagement,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lgy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39894,6 +39442,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"lhE" = (
+/obj/machinery/camera{
+	c_tag = "Head of Security's Office";
+	dir = 4
+	},
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "lhH" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -39950,6 +39513,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"liJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "lji" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
@@ -39966,6 +39541,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ljv" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "ljx" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
@@ -40054,6 +39639,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"lls" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "llY" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -40083,6 +39676,23 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lmu" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "lmO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -40093,17 +39703,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"lnL" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "briggate";
-	name = "security blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "lnX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40127,6 +39726,25 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"lpa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lqq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -40162,6 +39780,16 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
+"lrs" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
 "lrA" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -40197,6 +39825,57 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"ltX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 4;
+	name = "Shooting Range";
+	req_access_txt = "63"
+	},
+/turf/open/floor/plating,
+/area/security/range)
+"luI" = (
+/obj/structure/bed,
+/obj/machinery/flasher{
+	id = "Cell 3";
+	pixel_x = -24;
+	pixel_y = -37
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -27;
+	pixel_y = -29;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/item/bedsheet/orange,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"luM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "lvs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -40250,6 +39929,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lxq" = (
+/obj/machinery/camera{
+	c_tag = "Security Office";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/plasteel,
+/area/security/main)
 "lxT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -40284,19 +39979,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"lBh" = (
-/obj/effect/turf_decal/tile/red,
+"lBg" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/item/gun/energy/laser/practice,
+/obj/machinery/syndicatebomb/training,
 /turf/open/floor/plasteel,
-/area/security/processing)
+/area/security/main)
 "lBH" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restroom"
@@ -40336,15 +40030,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"lDW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "lEi" = (
 /obj/structure/table/glass,
 /obj/item/stock_parts/scanning_module,
@@ -40383,6 +40068,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"lEY" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/security/warden)
 "lFc" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -40411,6 +40103,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"lFl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lFO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40427,18 +40137,34 @@
 "lFS" = (
 /turf/closed/wall/r_wall,
 /area/science/nanite)
-"lGm" = (
-/obj/machinery/door/airlock/security{
-	name = "Interrogation";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+"lFX" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/prison)
+/area/ai_monitored/security/armory)
+"lGw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lGK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -40582,6 +40308,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"lMM" = (
+/obj/machinery/computer/security/hos,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "lNk" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -40604,6 +40337,45 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"lNC" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"lND" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/range)
 "lNE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40632,6 +40404,13 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/fitness)
+"lON" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lOW" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -40660,19 +40439,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"lPS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "lQv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -41013,18 +40779,6 @@
 /obj/item/stack/cable_coil/random,
 /turf/open/floor/plasteel,
 /area/storage/art)
-"maj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "mav" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -41047,23 +40801,13 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"mbz" = (
-/obj/machinery/door/window/southleft{
-	name = "Armory";
-	req_access_txt = "3"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+"mcg" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "mct" = (
 /obj/machinery/door/poddoor{
 	id = "AI Door";
@@ -41143,6 +40887,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"meY" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	dir = 9;
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "mfj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41211,21 +40973,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"mgg" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "mgl" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 4
@@ -41257,42 +41004,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"mgJ" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -31
+"mgO" = (
+/obj/item/storage/secure/safe/HoS{
+	pixel_x = 35
 	},
-/obj/structure/table/wood,
-/obj/item/storage/box/seccarts{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/storage/box/deputy,
-/obj/machinery/button/door{
-	id = "hosspace";
-	name = "Space Shutters Control";
-	pixel_x = -26;
-	pixel_y = 34
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	dir = 1;
-	name = "Head of Security RC";
-	pixel_y = 32
-	},
-/turf/open/floor/carpet,
+/obj/structure/closet/secure_closet/hos,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"mgP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "mhR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -41432,6 +41151,26 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"moP" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "moV" = (
 /obj/effect/turf_decal/atmos/plasma,
 /turf/open/floor/engine/plasma,
@@ -41450,19 +41189,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"mpn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
 "mpu" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -41477,6 +41203,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"mpy" = (
+/obj/machinery/door/airlock/security{
+	name = "Interrogation";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mpK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41511,6 +41248,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"mqg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "mrd" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -41561,6 +41310,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"msJ" = (
+/obj/effect/landmark/start/warden,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "msL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41571,6 +41324,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"msQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "mtK" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
@@ -41710,19 +41469,6 @@
 /obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"mxf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "mxA" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd2";
@@ -41751,16 +41497,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"mxY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/warden)
 "myf" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -41772,6 +41508,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"myk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "myK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sign/warning/nosmoking{
@@ -41791,6 +41539,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
+"mAP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "mBI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -41805,15 +41561,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"mBJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "mBY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -41857,6 +41604,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"mDs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "mDu" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -42015,6 +41772,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"mGl" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/security/brig)
 "mGw" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -42113,12 +41884,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"mIi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "mIv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -42164,6 +41929,26 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit)
+"mJT" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/main)
+"mKd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/security/warden)
 "mKe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42209,21 +41994,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"mLD" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/security/armory";
-	dir = 4;
-	name = "Armory APC";
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+"mLC" = (
+/turf/closed/wall,
+/area/security/warden)
 "mLJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -42267,19 +42040,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"mMV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "mNs" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
@@ -42549,6 +42309,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"mUW" = (
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "mVe" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/dorms";
@@ -42573,6 +42336,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"mVY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "mWr" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 25
@@ -42586,6 +42362,20 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"mWG" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "mWI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -42696,6 +42486,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"mYJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mYQ" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -42719,6 +42522,22 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"mZk" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"mZy" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "nan" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Integrity Restorer";
@@ -42738,20 +42557,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"nas" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "naO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42796,6 +42601,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nbC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "nbG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -43035,6 +42844,21 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/cafeteria,
 /area/engine/atmos)
+"nhI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "nhR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43092,6 +42916,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"njV" = (
+/obj/item/target/alien,
+/obj/item/target/alien,
+/obj/item/target/syndicate,
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 2;
+	name = "Target Storage";
+	req_access_txt = "63"
+	},
+/turf/open/floor/plating,
+/area/security/range)
+"njY" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nkc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43167,6 +43013,20 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"nlJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "nlS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43184,12 +43044,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"nmq" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nmC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -43261,6 +43115,44 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"npE" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"nqs" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"nqI" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nqP" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
@@ -43355,18 +43247,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"nsK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/warning/securearea{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "nsL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -43434,6 +43314,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"nvk" = (
+/obj/machinery/computer/secure_data,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "nvU" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -43450,6 +43335,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"nwk" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "nwT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -43564,16 +43454,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"nzl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "nzH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -43616,16 +43496,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"nAr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
 "nAK" = (
 /obj/machinery/light/small,
 /obj/item/radio/intercom{
@@ -43798,6 +43668,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"nDR" = (
+/obj/item/seeds/glowshroom,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/security/prison)
 "nEk" = (
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
@@ -43820,6 +43695,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"nFk" = (
+/obj/structure/window/reinforced,
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/tower,
+/turf/open/floor/grass,
+/area/security/prison)
 "nFD" = (
 /obj/machinery/light{
 	dir = 8
@@ -43884,6 +43765,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"nIX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "nJc" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/navbeacon{
@@ -43935,13 +43829,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"nKI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
+"nKu" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Head of Security";
+	req_access_txt = "58"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
+"nKT" = (
+/obj/effect/landmark/start/brig_phys,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/brig)
 "nLu" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -43993,6 +43900,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"nNb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nNK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -44080,12 +43992,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"nPy" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "nPH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -44133,6 +44039,20 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"nQY" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "nRf" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -44223,6 +44143,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"nVe" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"nVq" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel,
+/area/security/range)
 "nVv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -44245,15 +44181,6 @@
 	},
 /turf/closed/wall,
 /area/vacant_room/commissary)
-"nXR" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "nXX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -44264,6 +44191,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"nXZ" = (
+/obj/structure/bed,
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -24;
+	pixel_y = -38
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -27;
+	pixel_y = -29;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/item/bedsheet/blue,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nYb" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
@@ -44271,6 +44225,14 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"nYz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "nZg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -44409,6 +44371,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"odQ" = (
+/obj/structure/closet/secure{
+	name = "Persuasion Storage";
+	req_access = "list(2)"
+	},
+/obj/item/melee/baton/cattleprod,
+/obj/item/stock_parts/cell/high,
+/obj/item/electropack,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "odY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -44484,6 +44456,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"ofo" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Cell Interior Shutters";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
+"ofq" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ofT" = (
 /obj/machinery/computer/bounty,
 /turf/open/floor/plasteel,
@@ -44518,6 +44509,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"ogA" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ogG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -44525,6 +44523,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"ogI" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ogS" = (
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
@@ -44612,20 +44622,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"oim" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "oip" = (
 /obj/effect/turf_decal/loading_area,
 /obj/structure/cable{
@@ -44649,6 +44645,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"ojv" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ojJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44661,21 +44664,33 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ojX" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+"okj" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
-"okd" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/structure/cable{
-	icon_state = "2-8"
+/area/security/processing)
+"okC" = (
+/obj/machinery/door/airlock/security{
+	name = "Armoury";
+	req_access_txt = "3"
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "okH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/electricshock,
@@ -44718,29 +44733,33 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"omQ" = (
-/obj/machinery/camera{
-	c_tag = "Brig Control Room";
-	dir = 4
+"olJ" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/light_switch{
+	pixel_y = -23
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/structure/rack,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/machinery/button/door{
+	id = "Cell Interior Shutters";
+	name = "Cell Interior Shutters";
+	pixel_x = 6;
+	pixel_y = -40
 	},
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/machinery/button/door{
+	id = "Secure Brig Control";
+	name = "Brig Control Shutters";
+	pixel_x = -6;
+	pixel_y = -40
 	},
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	dir = 1;
-	pixel_y = 32
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -44841,6 +44860,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"opC" = (
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "opD" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -44869,6 +44892,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"oql" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "oqu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -44939,6 +44972,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"otP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "otZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -44957,6 +44996,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"ouq" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "ouv" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -45025,6 +45072,21 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"ovF" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/lethalshots,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ovJ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -45034,9 +45096,46 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ovQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"ovX" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -31
+	},
+/obj/structure/table/wood,
+/obj/item/storage/box/seccarts{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/storage/box/deputy,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	dir = 1;
+	name = "Head of Security RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "owD" = (
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"owJ" = (
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "owN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -45068,6 +45167,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"oyN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ozo" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ozs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -45161,12 +45279,37 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"oCk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"oCM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/brig)
 "oDd" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"oDJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "oEc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -45179,6 +45322,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"oEo" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oEE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -45230,6 +45388,11 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"oGB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "oGP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45293,6 +45456,14 @@
 /obj/item/disk/tech_disk,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"oHq" = (
+/obj/structure/closet/secure_closet/evidence,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/warden)
 "oHw" = (
 /obj/machinery/light{
 	dir = 4
@@ -45320,24 +45491,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"oIt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "oIv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/warning/securearea{
@@ -45460,12 +45613,35 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"oMk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/range)
 "oMN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"oMS" = (
+/obj/structure/bodycontainer/morgue,
+/obj/machinery/camera{
+	c_tag = "Brig Infirmary";
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "oNf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -45550,25 +45726,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"oPd" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "oPj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45799,20 +45956,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
-"oXs" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "armory";
-	name = "Armoury Shutter"
+"oXm" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "oYy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -45824,13 +45974,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"oYB" = (
-/obj/machinery/camera/motion{
-	c_tag = "Armory - External";
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space)
 "oZb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45841,6 +45984,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"oZq" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/storage/box/zipties,
+/obj/item/storage/box/zipties{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oZT" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/machinery/light/small{
@@ -45851,6 +46012,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"paL" = (
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "pbt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -45871,13 +46045,38 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"pdT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+"pco" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"pdw" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "peb" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -45997,6 +46196,24 @@
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
+"phM" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "Security - EVA";
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "pil" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -46091,6 +46308,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"plE" = (
+/obj/machinery/computer/operating,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "pmd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -46145,13 +46381,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
-"pnK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "pnS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -46255,6 +46484,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"pqD" = (
+/obj/structure/target_stake,
+/obj/item/target/syndicate,
+/turf/open/floor/plating,
+/area/security/range)
 "pqP" = (
 /obj/machinery/light{
 	dir = 4
@@ -46273,20 +46507,25 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"pqZ" = (
-/obj/machinery/computer/bookmanagement,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "prm" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"prv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "prx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -46398,6 +46637,22 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/department/crew_quarters/bar)
+"pux" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "puH" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod One"
@@ -46624,6 +46879,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"pAS" = (
+/obj/structure/closet/secure_closet/evidence,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/warden)
 "pBk" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
@@ -46641,6 +46907,13 @@
 /obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
+"pBX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "pBY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -46656,6 +46929,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"pCq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "pDo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
@@ -46698,6 +46990,25 @@
 /obj/effect/turf_decal/atmos/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
+"pDB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "pDD" = (
 /obj/structure/sign/plaques/kiddie{
 	pixel_x = -32
@@ -46714,6 +47025,18 @@
 /obj/item/aiModule/reset,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"pEp" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "pEA" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -46723,6 +47046,30 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/science/lab)
+"pED" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/left,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"pEE" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/processing";
+	dir = 8;
+	name = "Labor Shuttle Dock APC";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"pEO" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "pFc" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced/shutters,
@@ -46952,6 +47299,22 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"pMD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "pMF" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
@@ -46962,6 +47325,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"pNb" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "pNl" = (
 /obj/machinery/light{
 	dir = 1
@@ -46993,18 +47368,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"pOs" = (
-/obj/machinery/computer/shuttle/labor{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "pOD" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -47134,6 +47497,10 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"pTI" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "pUl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47158,6 +47525,20 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/wood,
 /area/lawoffice)
+"pUZ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters{
+	id = "armory2";
+	name = "Armoury Shutter"
+	},
+/obj/machinery/button/door{
+	id = "armory2";
+	name = "Armory Shutters";
+	pixel_y = -26;
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "pVb" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
@@ -47200,6 +47581,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"pWl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "pWH" = (
 /obj/item/wrench,
 /obj/effect/turf_decal/stripes/line,
@@ -47243,26 +47641,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"pYI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"pYi" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "armory";
+	name = "Armoury Shutter"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/delivery,
+/obj/machinery/button/door{
+	id = "armory";
+	name = "Armory Shutters";
+	pixel_y = -26;
+	req_access_txt = "3"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "pZe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -47529,6 +47921,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"qjU" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/grass,
+/area/security/prison)
 "qkf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -47752,16 +48148,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qqz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "qqG" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -47787,8 +48173,7 @@
 	pixel_y = 27
 	},
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -31;
-	pixel_y = 33
+	pixel_y = -30
 	},
 /obj/machinery/button/door{
 	id = "AI Door";
@@ -47953,6 +48338,10 @@
 	dir = 5
 	},
 /area/science/research)
+"qtq" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "quy" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable{
@@ -48093,6 +48482,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"qyO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "qyP" = (
 /obj/item/radio/intercom{
 	pixel_y = -29
@@ -48130,6 +48529,22 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"qzM" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/interrogation{
+	dir = 1;
+	pixel_y = -30
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qAk" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -48151,6 +48566,10 @@
 /obj/item/stack/packageWrap,
 /turf/open/floor/plasteel/white/side,
 /area/science/explab)
+"qAH" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "qBr" = (
 /obj/item/stack/ducts/fifty,
 /obj/item/stack/ducts/fifty,
@@ -48181,6 +48600,13 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
+"qCE" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/item/lighter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "qDa" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable{
@@ -48330,6 +48756,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"qKK" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "qKP" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -48354,6 +48790,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"qMi" = (
+/obj/machinery/camera{
+	c_tag = "Labor Shuttle Dock North";
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"qNj" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "qNs" = (
 /obj/machinery/power/smes/engineering,
 /obj/effect/turf_decal/tile/neutral{
@@ -48448,6 +48917,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
+"qPi" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qPp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -48507,6 +48983,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qQv" = (
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 2";
+	name = "Cell 2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qQH" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
@@ -48556,6 +49052,11 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"qSE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/security/range)
 "qTh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -48565,6 +49066,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"qTq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qTC" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
@@ -48604,11 +49120,24 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"qVw" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qVC" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
+"qWc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "qWn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -48769,6 +49298,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"rbI" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	name = "Cell 2";
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rcD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -48833,25 +49374,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"rdT" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hos";
-	dir = 8;
-	name = "Head of Security's Office APC";
-	pixel_x = -24
+"reh" = (
+/obj/structure/bed/dogbed,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"reo" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "reu" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel"
@@ -48953,6 +49488,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
+"rhd" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
 "rhq" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -49036,16 +49578,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"rky" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "rlu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical{
@@ -49085,24 +49617,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"rmK" = (
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -27
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "rmX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"rnF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"rnM" = (
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/obj/item/taperecorder,
+/obj/item/folder/red,
+/obj/machinery/light_switch{
+	pixel_y = -23
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "rol" = (
 /obj/machinery/camera{
@@ -49301,6 +49843,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"rte" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "rti" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
@@ -49405,6 +49958,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"rvB" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/secure/weapon{
+	desc = "A secure clothing crate.";
+	name = "formal uniform crate";
+	req_access_txt = "3"
+	},
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/warden/formal,
+/obj/item/clothing/under/rank/security/head_of_security/formal,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navywarden,
+/obj/item/clothing/head/beret/sec/navyhos,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "rvK" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
@@ -49431,6 +50012,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"rwH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "rxu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -49489,6 +50077,21 @@
 /obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
+"rzr" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rzt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -49501,16 +50104,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rAt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"rAp" = (
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plating,
+/area/security/prison)
 "rAN" = (
 /obj/structure/table,
 /obj/item/kitchen/knife,
@@ -49536,32 +50135,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"rBA" = (
-/mob/living/simple_animal/hostile/retaliate/bat{
-	desc = "A fierce companion for any person of power, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine.";
-	emote_hear = list("chitters");
-	faction = list("spiders");
-	harm_intent_damage = 3;
-	health = 200;
-	icon_dead = "guard_dead";
-	icon_gib = "guard_dead";
-	icon_living = "guard";
-	icon_state = "guard";
-	maxHealth = 250;
-	max_co2 = 5;
-	max_tox = 2;
-	melee_damage_lower = 15;
-	melee_damage_upper = 20;
-	min_oxy = 5;
-	movement_type = 1;
-	name = "Sergeant Araneus";
-	real_name = "Sergeant Araneus";
-	response_help_continuous = "pets";
-	response_help_simple = "pet";
-	turns_per_move = 10
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "rBE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -49600,6 +50173,14 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"rCt" = (
+/obj/structure/falsewall/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
+"rDa" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/turf/open/floor/plating,
+/area/security/range)
 "rDh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -49706,13 +50287,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"rKh" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/firealarm{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "rKj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -49728,6 +50302,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"rKB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "rKP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -49750,33 +50331,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"rMf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/flasher{
-	id = "cell4";
-	pixel_x = 28
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"rMR" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+"rMr" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/security/brig)
 "rND" = (
 /obj/machinery/computer/upload/ai,
 /obj/machinery/airalarm{
@@ -49895,6 +50458,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"rRH" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/security/brig)
+"rSi" = (
+/obj/structure/bed,
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "rSx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49943,31 +50525,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"rVr" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/main";
-	dir = 4;
-	name = "Security Office APC";
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+"rTQ" = (
+/turf/open/floor/plating,
+/area/security/range)
+"rUp" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/computer/cargo/request{
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/security/main)
+/area/security/brig)
 "rVu" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/firealarm{
@@ -50004,6 +50578,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"rWM" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/wood,
+/area/maintenance/department/crew_quarters/bar)
 "rWU" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
@@ -50016,6 +50594,18 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
+"rXk" = (
+/obj/structure/table,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rXy" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=QM";
@@ -50045,13 +50635,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"rYW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "rZb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50088,6 +50671,16 @@
 	},
 /turf/open/floor/plating,
 /area/science/lab)
+"rZN" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "rZW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50100,6 +50693,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"sbn" = (
+/obj/structure/window/reinforced,
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/grass,
+/turf/open/floor/grass,
+/area/security/prison)
 "sbD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -50224,6 +50823,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"sfY" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/brig";
+	dir = 1;
+	name = "Brig APC";
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sgc" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -50257,14 +50880,6 @@
 	dir = 9
 	},
 /area/science/research)
-"sgU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/holopad/secure,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "shI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -50343,6 +50958,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"sjK" = (
+/obj/effect/turf_decal/bot,
+/mob/living/simple_animal/bot/secbot{
+	arrest_type = 1;
+	health = 45;
+	icon_state = "secbot1";
+	idcheck = 1;
+	name = "Sergeant-at-Armsky";
+	weaponscheck = 1
+	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "sjO" = (
 /obj/machinery/power/smes{
 	capacity = 9e+006;
@@ -50385,6 +51023,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"slE" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "slQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -50403,6 +51046,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"smT" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
+"smU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/security/brig)
 "snu" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -50469,6 +51134,21 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"spA" = (
+/obj/machinery/camera{
+	c_tag = "Brig Interrogation";
+	dir = 8;
+	network = list("interrogation")
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "spM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow,
@@ -50559,6 +51239,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"stn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/fore";
+	dir = 1;
+	name = "Fore Maintenance APC";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "stB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -50596,6 +51291,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"suJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "suU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -50622,6 +51333,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"svs" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"svV" = (
+/obj/item/radio/intercom{
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/security/range)
 "svZ" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/tile/blue,
@@ -50708,6 +51441,12 @@
 /obj/item/shovel/spade,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"sya" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "syj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -50757,6 +51496,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"szj" = (
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Brig Operations";
+	req_one_access_txt = "4; 1"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "szl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -50817,15 +51567,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"sAC" = (
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "sAH" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -50859,6 +51600,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
+"sCL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "sCZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -50958,6 +51703,22 @@
 	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
+"sFP" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "sGL" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -51057,6 +51818,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"sJP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel,
+/area/security/main)
 "sJX" = (
 /obj/machinery/door/airlock/virology{
 	name = "Break Room";
@@ -51219,34 +51995,24 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"sQw" = (
+"sQy" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"sQE" = (
-/obj/machinery/door/airlock/security{
-	name = "Brig";
-	req_access_txt = "63; 42"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/courtroom)
 "sQH" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
@@ -51261,6 +52027,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"sQS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "sRg" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab";
@@ -51370,6 +52140,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"sVS" = (
+/obj/item/clothing/gloves/color/rainbow,
+/obj/item/clothing/shoes/sneakers/rainbow,
+/obj/item/clothing/head/soft/rainbow,
+/obj/item/clothing/under/color/rainbow,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "sWt" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -51395,6 +52172,19 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"sXk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "sXC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -51407,23 +52197,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"sYt" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control";
-	req_access_txt = "3"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "sZw" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Vacant Office A";
@@ -51481,6 +52254,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tbd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "tbv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -51573,6 +52350,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"teF" = (
+/mob/living/simple_animal/hostile/retaliate/goose/vomit,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "teP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -51604,6 +52385,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"tfW" = (
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/security/main)
 "tgm" = (
 /obj/machinery/button/flasher{
 	id = "foflash";
@@ -51690,6 +52485,30 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"thd" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/closet/secure{
+	name = "nonlethal ammunition";
+	req_access = "list(3)"
+	},
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "thm" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
@@ -51799,18 +52618,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/genetics)
-"tjb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "tjg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52006,6 +52813,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"tpI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "tqd" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -52064,23 +52877,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"trb" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
+"tsg" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/range";
+	dir = 4;
+	name = "Firing Range APC";
+	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/security/courtroom)
+/area/security/range)
 "tsk" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line,
@@ -52097,6 +52903,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"tte" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
+/area/security/brig)
 "tti" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -52285,30 +53097,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"tzn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"tzP" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/warden)
 "tzX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52383,6 +53171,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"tBD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/processing)
+"tBY" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/hos,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "tCp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -52528,6 +53328,26 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"tGM" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "tGX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -52588,6 +53408,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"tIX" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tJn" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
@@ -52624,6 +53451,35 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"tJM" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
+"tKj" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/door_timer{
+	id = "Cell 1";
+	name = "Cell 1";
+	pixel_y = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Brig West";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tKG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -52680,10 +53536,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"tOx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "tOZ" = (
 /obj/effect/turf_decal/atmos/nitrous_oxide,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
+"tPm" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/navbeacon/wayfinding,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tPC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52721,6 +53600,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"tRf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tRr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -52763,6 +53651,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"tSJ" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "tSK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /obj/machinery/advanced_airlock_controller{
@@ -52771,6 +53663,39 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tSV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"tTi" = (
+/obj/item/radio/intercom{
+	pixel_y = 20
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"tTB" = (
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "tTN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -52823,22 +53748,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"tXZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
-"tYr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "tYu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -52930,20 +53839,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"uaM" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/carrot,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+"uby" = (
+/obj/machinery/keycard_auth{
+	pixel_x = 24;
+	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/structure/table/wood,
+/obj/machinery/photocopier/faxmachine{
+	department = "Head of Security"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "ubM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -53067,6 +53973,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ufw" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ufB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -53099,35 +54011,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"uhG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "uhN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"uhY" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Office";
-	req_access_txt = null;
-	req_one_access_txt = "1;4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+"uii" = (
+/obj/machinery/shower{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "uit" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -53177,18 +54090,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"ujq" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Equipment Room";
-	req_access_txt = "1"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "ujt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -53210,19 +54111,6 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
-"ujG" = (
-/obj/machinery/button/door{
-	id = "armory";
-	name = "Armory Shutters";
-	pixel_x = 26;
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "ulh" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
@@ -53278,33 +54166,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"umr" = (
-/obj/machinery/door/window/southleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Armory";
-	req_access_txt = "3"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "umA" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/fore/secondary";
@@ -53323,17 +54184,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"umI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+"ung" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/security/main)
+/area/security/brig)
 "unD" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
@@ -53368,6 +54228,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"uoE" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"uoO" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/l3closet/security,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "upA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -53457,6 +54332,29 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"urs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/cryopod{
+	pixel_y = 25
+	},
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"urL" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "usv" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -53565,6 +54463,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"uuR" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/turf/open/floor/plating,
+/area/security/prison)
 "uuX" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -53574,19 +54477,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"uvt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "uvv" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/cable{
@@ -53614,6 +54504,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"uvZ" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "uwk" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
@@ -53643,24 +54538,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"uxx" = (
-/obj/machinery/door/window/eastleft{
-	name = "armoury desk";
-	req_access_txt = "1"
-	},
-/obj/machinery/door/window/westleft{
-	name = "armoury desk";
-	req_access_txt = "3"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "uxG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -53668,6 +54545,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"uxJ" = (
+/obj/machinery/door/window/brigdoor/northleft{
+	name = "Brig Operations";
+	req_one_access_txt = "4; 1"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uyo" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -53675,6 +54563,21 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
+"uzm" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Infirmary";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
 "uzB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -53730,10 +54633,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"uAL" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "uAN" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"uBd" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uBG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -53749,6 +54667,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uCr" = (
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/item/reagent_containers/glass/bottle/charcoal,
+/obj/item/reagent_containers/syringe{
+	name = "steel point"
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "uDl" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -53788,16 +54734,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"uDN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "uDP" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"uDU" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "uEs" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -53823,6 +54776,19 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"uFl" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uFJ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
@@ -53847,6 +54813,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"uFV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/security/brig)
 "uGf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53901,6 +54873,13 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"uIY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "uIZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -53936,13 +54915,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"uKi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "uKk" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxillary Base Construction";
@@ -53983,6 +54955,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"uKU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "uLi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -54004,13 +54982,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/aft)
-"uLI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/warden)
 "uLW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54057,6 +55028,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"uMD" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/security/range)
 "uMX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Tool Storage Maintenance";
@@ -54250,6 +55225,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"uSg" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/bodybags,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "uSD" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -54335,6 +55332,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uUt" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/computer/warrant{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "uUV" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -54474,6 +55480,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"uXr" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uYC" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/signaler{
@@ -54551,11 +55564,27 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/engine/atmos)
-"vad" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
+"vao" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/brig)
+"vaz" = (
+/obj/structure/rack,
+/obj/item/instrument/banjo,
+/obj/item/instrument/harmonica,
+/obj/item/instrument/accordion,
+/obj/item/instrument/recorder,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "vaZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -54593,6 +55622,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"vcp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "vcB" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -54664,6 +55700,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"veX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/computer/shuttle/labor{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "vfd" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -54684,13 +55732,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vfs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "vfJ" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
 	dir = 1
@@ -54748,6 +55789,23 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
+"vgY" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Office";
+	req_access_txt = null;
+	req_one_access_txt = "1;4"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/main)
 "vhb" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
@@ -54896,6 +55954,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"vnx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vnz" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light_switch{
@@ -54904,13 +55971,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"vnJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vot" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -54976,6 +56036,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"vpr" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vpE" = (
 /obj/machinery/light{
 	dir = 8
@@ -55029,6 +56095,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vrD" = (
+/obj/vehicle/ridden/secway,
+/obj/item/key/security,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "vrN" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral{
@@ -55043,17 +56124,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
-"vrY" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/window/reinforced/shutters,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/prison)
 "vsk" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -55174,6 +56244,13 @@
 /obj/effect/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"vxE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "vxG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55282,6 +56359,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"vAn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/security/processing)
 "vAV" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -55291,21 +56374,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/science/research)
-"vAX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vBg" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
@@ -55447,13 +56515,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"vHi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "vHD" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
@@ -55514,34 +56575,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"vKx" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/navbeacon/wayfinding,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vKY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -55647,6 +56680,24 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"vPi" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vPn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -55854,6 +56905,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vUB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/range)
 "vVM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55939,6 +56996,11 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"vYd" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "vYe" = (
 /obj/machinery/light{
 	dir = 4
@@ -55948,6 +57010,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"vYl" = (
+/obj/structure/window/reinforced,
+/obj/item/cultivator,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/security/prison)
 "vYy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56108,6 +57176,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"wcK" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
 "wcT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -56122,6 +57198,10 @@
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
+"wdb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/warden)
 "wdq" = (
 /obj/machinery/camera{
 	c_tag = "Security Post - Medbay"
@@ -56151,25 +57231,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"wdT" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "wek" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -56309,6 +57370,12 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wid" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "wit" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56351,6 +57418,12 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"wlM" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wlU" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -56367,16 +57440,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"wnf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "wnm" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "8;12"
@@ -56415,10 +57478,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"wnM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+"wnS" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -56457,6 +57526,33 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"wpj" = (
+/obj/structure/bed,
+/obj/machinery/flasher{
+	id = "Cell 1";
+	pixel_x = -24;
+	pixel_y = -38
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -27;
+	pixel_y = -29;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/item/bedsheet/green,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wps" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -56542,6 +57638,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"wtu" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"wuc" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wud" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -56560,6 +57684,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"wul" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "wuF" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen cold room";
@@ -56600,6 +57728,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"wxU" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters{
+	id = "armory";
+	name = "Armoury Shutter"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"wyv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/security/main)
 "wyO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56679,21 +57819,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"wzV" = (
-/obj/machinery/camera{
-	c_tag = "Head of Security's Office";
-	dir = 4
-	},
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/structure/table/wood,
-/obj/machinery/newscaster/security_unit{
-	dir = 8;
-	pixel_x = -30
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
+"wAo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wAs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56721,6 +57850,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"wAJ" = (
+/obj/machinery/camera{
+	c_tag = "Security - Evidence Storage";
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/warden)
 "wAP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -56800,19 +57939,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"wCb" = (
-/obj/structure/closet/secure_closet/courtroom,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
-/obj/item/gavelhammer,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel,
-/area/security/courtroom)
 "wCh" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -56896,6 +58022,36 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wEF" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/chair/sofa{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
+"wFp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "wFK" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -56913,18 +58069,6 @@
 	},
 /turf/open/space,
 /area/solar/port/aft)
-"wGd" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/components/unary/vent_pump,
-/obj/machinery/advanced_airlock_controller{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "wGs" = (
 /obj/machinery/atmospherics/pipe/simple,
 /turf/closed/wall,
@@ -57012,13 +58156,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"wIr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
 "wIv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -57058,6 +58195,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"wJx" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/bombcloset/security,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wJL" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -57108,6 +58250,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"wLw" = (
+/obj/structure/closet/secure_closet/contraband/armory,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/effect/spawner/lootdrop/armory_contraband/metastation,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "wLW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -57117,25 +58275,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"wMv" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "wML" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -57165,6 +58304,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"wNj" = (
+/obj/machinery/door/window/brigdoor/westleft{
+	name = "Brig Operations";
+	req_one_access_txt = "4; 1"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wNk" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
@@ -57250,38 +58397,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"wPo" = (
-/obj/effect/turf_decal/tile/red{
+"wPY" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/camera{
+	c_tag = "Brig Control Room";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/power/apc{
+	areastring = "/area/security/warden";
+	name = "Brig Control APC";
+	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+/obj/machinery/button/door{
+	id = "Secure Gate";
+	name = "Cell Shutters";
+	pixel_x = 6;
+	pixel_y = -40
 	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"wPI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/button/door{
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	pixel_x = -6;
+	pixel_y = -40;
+	req_access_txt = "2"
 	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/structure/cable,
+/obj/machinery/light,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "wQn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -57321,6 +58464,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"wSa" = (
+/obj/machinery/door/window/brigdoor/westright{
+	name = "Brig Operations";
+	req_one_access_txt = "4; 1"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wSK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -57379,6 +58530,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"wUl" = (
+/obj/item/paper/fluff/jobs/security/beepsky_mom,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "wUs" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -57441,14 +58596,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/storage/tech)
-"wZe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "wZv" = (
 /obj/machinery/door/airlock/research{
 	name = "Experimentation Lab";
@@ -57475,6 +58622,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"xae" = (
+/obj/structure/table/wood,
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/clothing/shoes/sneakers/white,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "xal" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -57494,6 +58647,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"xaF" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Firing Range";
+	dir = 1;
+	network = list("ss13")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/security/range)
 "xaL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57632,6 +58800,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"xeK" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xeZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -57703,6 +58878,25 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xfZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Cell Interior Shutters";
+	name = "brig shutters"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
+"xgC" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/cigbutt/cigarbutt,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "xgG" = (
 /obj/effect/landmark/start/security_officer,
 /obj/structure/chair{
@@ -57713,13 +58907,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"xgS" = (
-/obj/machinery/computer/security/hos,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "xgT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/power/apc{
@@ -57749,6 +58936,22 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/bar)
+"xix" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "xiD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only,
@@ -57757,16 +58960,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"xiF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "xiL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57796,6 +58989,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"xjw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xjM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57865,6 +59067,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"xoj" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xon" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57886,12 +59093,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"xoT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "xoZ" = (
 /obj/machinery/door/airlock/command{
 	name = "Conference Room";
@@ -57944,6 +59145,12 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"xqH" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xqS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -57981,6 +59188,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"xrc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "xry" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58029,6 +59244,30 @@
 	dir = 9
 	},
 /area/science/research)
+"xsq" = (
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 1";
+	name = "Cell 1"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"xsv" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "xsw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -58178,6 +59417,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xxI" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xyf" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage";
@@ -58273,6 +59519,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing/chamber)
+"xBa" = (
+/obj/item/cigbutt/cigarbutt,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "xBf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58317,6 +59567,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"xCj" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "xCw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -58329,6 +59585,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"xEw" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "xEM" = (
 /obj/machinery/power/apc{
 	areastring = "/area/lawoffice";
@@ -58386,6 +59652,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"xFQ" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/carrot,
+/turf/open/floor/grass,
+/area/security/prison)
 "xFS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -58406,6 +59677,18 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"xGU" = (
+/obj/machinery/door/airlock/security{
+	name = "Shooting Range";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/range)
 "xGZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -58415,6 +59698,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"xHb" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"xHf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall,
+/area/security/brig)
 "xHi" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "maint3"
@@ -58573,6 +59872,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"xIY" = (
+/mob/living/simple_animal/mouse/brown/Tom,
+/turf/open/floor/grass,
+/area/security/prison)
 "xJl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -58605,19 +59908,6 @@
 /obj/machinery/nanite_programmer,
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
-"xJQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "xKf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -58653,6 +59943,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"xLU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xMd" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -58683,25 +59983,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"xNu" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "xNz" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/line{
@@ -58771,6 +60052,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"xRB" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "xRG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58841,6 +60134,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"xUv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/rack,
+/obj/item/storage/box/prisoner,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "xVk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58867,6 +60169,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"xVN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
+"xVO" = (
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xWy" = (
 /obj/machinery/door/airlock/external{
 	name = "Common Mining Shuttle Bay"
@@ -58883,6 +60197,51 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"xXx" = (
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/hos";
+	dir = 8;
+	name = "Head of Security's Office APC";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/bed/dogbed{
+	name = "pet bed"
+	},
+/mob/living/simple_animal/hostile/retaliate/bat{
+	desc = "A fierce companion for any person of power, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine.";
+	emote_hear = list("chitters");
+	faction = list("spiders");
+	harm_intent_damage = 3;
+	health = 200;
+	icon_dead = "guard_dead";
+	icon_gib = "guard_dead";
+	icon_living = "guard";
+	icon_state = "guard";
+	maxHealth = 250;
+	max_co2 = 5;
+	max_tox = 2;
+	melee_damage_lower = 15;
+	melee_damage_upper = 20;
+	min_oxy = 5;
+	movement_type = 1;
+	name = "Sergeant Araneus";
+	real_name = "Sergeant Araneus";
+	response_help_continuous = "pets";
+	response_help_simple = "pet";
+	turns_per_move = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "xXK" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -58893,25 +60252,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"xXX" = (
-/obj/machinery/door/airlock/security{
-	name = "Labor Shuttle";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "xYf" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59025,6 +60365,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"ybo" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ybA" = (
 /obj/machinery/status_display/ai{
 	pixel_x = -32
@@ -59040,6 +60395,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"ybC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 30
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "ybI" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -59075,16 +60440,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
-"ydV" = (
-/obj/effect/landmark/start/security_officer,
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "yeu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -59117,6 +60472,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"yfg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"yfk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "yfn" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
@@ -59129,6 +60503,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"ygA" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "ygI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -59213,26 +60593,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"yjz" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 3";
-	name = "Cell 3"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ykb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59250,21 +60610,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"ykv" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "ykJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -59277,6 +60622,25 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"ykT" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"ykU" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "yle" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -59305,6 +60669,18 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"yml" = (
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/warden)
 
 (1,1,1) = {"
 aaa
@@ -75848,8 +77224,8 @@ nUj
 amz
 xCg
 anH
+amC
 aok
-anJ
 anJ
 aFJ
 arK
@@ -76105,8 +77481,8 @@ alR
 alR
 alR
 alR
-aom
 amC
+aom
 apP
 amC
 arN
@@ -76358,12 +77734,12 @@ aaf
 aaf
 aaa
 aaa
+aaa
 alU
 alF
 anj
 anJ
-anl
-aoU
+rSi
 alU
 amC
 arM
@@ -76615,11 +77991,11 @@ aaa
 aaf
 aaf
 aaf
+gXs
 alU
 alF
 anl
 amC
-alU
 alU
 alU
 amC
@@ -76872,12 +78248,12 @@ aaf
 aaf
 aaa
 aaa
+aaa
 alU
 alU
 vTm
 alU
 alU
-aoV
 alU
 amC
 amC
@@ -77129,13 +78505,13 @@ aaa
 aaS
 aaa
 aaa
+aaa
 alU
 amD
 anm
 amC
-qVn
-aaa
-qVn
+amC
+sCL
 amC
 alU
 asO
@@ -77386,13 +78762,13 @@ aaa
 aaS
 aaf
 aaf
+gXs
 alU
 amC
 amC
 amC
-qVn
-aaf
-qVn
+amC
+sCL
 amC
 alU
 alU
@@ -77643,13 +79019,13 @@ aaS
 aaS
 aaa
 aaa
+aaa
 alU
 amE
 ann
 amC
+amC
 alU
-aoV
-qVn
 amC
 alU
 arN
@@ -77900,12 +79276,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
 alU
 alU
 alU
 vTm
 alU
-aoV
 alU
 amC
 amC
@@ -78157,12 +79533,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
 alU
 amF
 alU
 amC
 alU
-aaf
 alU
 alU
 alU
@@ -78414,16 +79790,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
 alU
 alU
 alU
 amC
 alU
-aaf
 aaH
-alU
-arO
-alU
+qVn
+sVS
+tSJ
 amC
 avc
 atO
@@ -78673,13 +80049,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
 qVn
 anK
 qVn
-aaH
-atR
+aaf
 alU
-alU
+qVn
 alU
 atW
 atW
@@ -78930,12 +80306,12 @@ aaa
 aaa
 aaa
 aaa
-alU
+aaa
+qVn
 amC
-alU
-aaH
-aaf
-aaf
+qVn
+gCF
+gCF
 aaH
 alU
 qVn
@@ -79184,18 +80560,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
+sEJ
 aaa
 aaa
 qVn
-aKY
 qVn
-asC
-aaf
-aaH
-aaf
+amC
+alU
+alU
+alU
+aaa
 aoV
-aoV
+aae
 aaf
 uHS
 jdG
@@ -79441,20 +80817,20 @@ aaa
 aaa
 aaa
 aaa
-aae
 aaa
-aaf
+aaa
+aaa
 qVn
+jfY
 amC
-qVn
-asC
-aaH
-aaf
-aoV
-aaa
-aoV
-aoV
-uHS
+aon
+aoW
+arP
+riT
+riT
+riT
+riT
+avZ
 xZT
 mEB
 aaf
@@ -79698,20 +81074,20 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 qVn
-qVn
-alU
-alU
-vTm
-alU
-alU
-alU
-aaH
-aaf
-aoV
-aaf
-aaf
-uHS
+amC
+amC
+amC
+amC
+oXm
+aqR
+aGh
+aqR
+aqR
+awb
 xZT
 mEB
 aaa
@@ -79955,19 +81331,19 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 qVn
-alV
-amG
-ano
-amC
-aon
-aoW
-alU
-riT
-riT
-riT
-riT
-riT
+xgC
+anL
+aoo
+aoX
+arP
+arP
+arP
+arP
+arP
 avZ
 tbv
 rIm
@@ -80212,20 +81588,20 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 qVn
-aKY
-amC
-anp
-amC
-amC
-amC
-vTm
+qVn
+alU
+alU
+alU
+arP
 aqR
-aqR
-aGh
-aqR
-aqR
-awb
+vaz
+mZy
+xCj
+avZ
 xZT
 mEB
 aaa
@@ -80469,19 +81845,19 @@ aaa
 aaa
 aaa
 aaa
-qVn
-alW
-amH
-ano
-anL
-aoo
-aoX
-alU
-riT
-riT
-riT
-riT
-riT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+arP
+reh
+teF
+tbd
+qAH
+xBa
 awa
 sdK
 cvH
@@ -80726,20 +82102,20 @@ aaa
 aaa
 aaa
 aaa
-qVn
-qVn
-alU
-alU
-qVn
-alU
-alU
-alU
 aaa
 aaa
 aaa
 aaa
-aag
-uHS
+aaa
+aaa
+aaa
+riT
+wid
+tbd
+aqR
+aqR
+aqR
+iuB
 xZT
 mEB
 aaa
@@ -80990,13 +82366,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aag
-uHS
+riT
+aqR
+aqR
+iBo
+xae
+iBo
+avZ
 xZT
 mEB
 aaf
@@ -81247,13 +82623,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aag
-uHS
+riT
+wid
+tbd
+arP
+arP
+arP
+avZ
 jdG
 oqU
 aaa
@@ -81318,7 +82694,7 @@ bCq
 bCq
 bRz
 wcZ
-ffT
+rWM
 rss
 utd
 icl
@@ -81488,7 +82864,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aae
 aaa
 aaa
@@ -81502,15 +82877,16 @@ aaa
 aaa
 aaa
 aaa
+anO
 aaa
 aaa
-aaa
-aaa
-aaa
-aaf
 arP
-avd
-avZ
+aqR
+aqR
+arP
+asQ
+aqR
+awb
 qTC
 ayE
 ayE
@@ -81753,21 +83129,21 @@ aaa
 aaa
 aaa
 aaa
+dGM
+aln
+dGM
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+dGM
+anN
+dGM
+uAL
 arP
-wGd
-jwP
+fzM
+cQn
+arP
+asP
+xsv
+awa
 jfT
 izU
 izU
@@ -81997,33 +83373,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
-adB
-aaa
+gJH
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dIC
+dIC
+dIC
+rDa
+dIC
+dIC
+gXs
+gXs
+gXs
+juy
+nfF
+xLb
+uAL
+juy
+grQ
+xLb
 arP
 arP
 arP
-fju
+arP
+arP
+arP
+arP
 avZ
 drZ
 ayG
@@ -82254,34 +83630,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
 abc
 abc
 abc
 tAq
 abc
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-anO
-aaa
-aaa
-aaa
-aaa
+dVN
+enD
+eLc
+grc
+dIC
+dGM
+dGM
+aiV
+nMS
+cxJ
+rra
+amK
+faJ
+cxP
+rra
 arP
-asQ
-aqR
-aqR
-avZ
+hjN
+tbd
+ufw
+eaj
+dKJ
+arP
+lls
 drZ
 ayG
 azK
@@ -82511,33 +83887,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
 abc
 aea
 aeH
 aft
 abc
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-dGM
-aln
-dGM
-aaa
-dGM
-anN
-dGM
-aaa
-aaa
-aaa
+njV
+vUB
+pqD
+uMD
+dIC
+ajs
+alq
+klJ
+xUv
+akI
+veX
+aiT
+eWq
+akI
+iFv
 arP
-asP
-aqR
-aqR
+hWv
+tbd
+tbd
+tbd
+tbd
+mvh
 awb
 drZ
 ayG
@@ -82760,10 +84136,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+aaH
 abc
 abu
 abu
@@ -82775,27 +84150,28 @@ aeJ
 afw
 abc
 abc
-aaf
-aaa
-aaf
-aaf
-aaf
-aaf
-juy
-nfF
-xLb
-aaa
-juy
-grQ
-xLb
-aaf
-aaf
-aaf
+vUB
+rTQ
+uMD
+iZg
+ajr
+jny
+tBD
+hjV
+dRX
+kyE
+jhY
+fUX
+yfk
+lfg
 arP
+jkG
+tbd
+tbd
+tbd
+tbd
 arP
-arP
-arP
-avZ
+awb
 drZ
 ayG
 kEy
@@ -83016,11 +84392,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+aai
+aai
+aai
 abb
 abt
 aca
@@ -83032,27 +84407,28 @@ aeI
 afv
 ane
 abc
-aaf
-aaa
-aaa
-aiT
-aiT
-aiV
-nMS
-cxJ
-rra
-amK
-faJ
-cxP
-gQa
-aiV
-aiT
-aiT
+vUB
+rTQ
+uMD
+dIC
+tTi
+oql
+okj
+rKB
+mZk
+qMi
+coh
+pco
+ipk
+uDU
 arP
-asR
-aqR
 arP
-awc
+arP
+arP
+qCE
+krX
+arP
+awb
 drZ
 ayG
 vrN
@@ -83274,10 +84650,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aai
+aay
+rAp
 abe
 abw
 acc
@@ -83289,28 +84664,29 @@ aeL
 afy
 agh
 abc
-aaf
-aaa
-aaf
-aiT
-ajs
-haI
-eyv
-akI
-pOs
-aiT
-eWq
-akI
-kRU
-aiT
-apR
-cCh
+lND
+ltX
+fmV
+fuM
+vAn
+gLw
+aiX
+aiX
+aiX
+aiX
+aiX
+pMD
+alq
+xEw
 arP
-asT
-aqR
-mvh
-awb
-drZ
+wUl
+eAS
+arP
+arP
+arP
+arP
+stn
+gmH
 ayG
 azN
 aBe
@@ -83530,11 +84906,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+aai
+uuR
+aay
 abd
 abv
 acb
@@ -83546,28 +84921,29 @@ xiL
 bxK
 agg
 abc
-aaf
-aaa
-aaa
-dGM
-ajr
-aka
-mIi
-alq
-hqt
-aiU
-wPo
-alq
-lBh
-apb
-alp
-aqS
+hnb
+crD
+xaF
+qSE
+suJ
+iEn
+agj
+eNq
+hXw
+hXw
+aiX
+qNj
+msQ
+hXn
 arP
-asS
 aqR
+dxS
 arP
-bqF
-cSR
+pTI
+fqY
+aqR
+awb
+drZ
 ayG
 ayG
 ayG
@@ -83786,12 +85162,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaf
-aaH
 aai
 aai
+rCt
 abg
 aby
 aby
@@ -83802,27 +85177,28 @@ aeg
 pKy
 afA
 afA
-afA
-aaf
-aaa
-aaa
-dGM
-aju
-wnM
-wnf
-uKi
-pnK
-kOr
-hpx
-vHi
-kpa
-aiT
-aiT
-aiT
+abc
+svV
+oMk
+oMk
+xGU
+csV
+qzM
+agj
+edW
+fXT
+rnM
+aiX
+wnS
+alq
+iim
+arP
+bIF
 arP
 arP
-arP
-arP
+uvZ
+aqR
+aqR
 tgP
 sfS
 aqR
@@ -84041,41 +85417,41 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaf
 aaf
 aai
 aai
-aai
-aaU
 abf
-abx
+nNb
+cFw
+oGB
 acd
 acC
 ada
 adF
-aef
-tzn
-afz
-aai
-aai
-aai
-aai
-aai
-aai
-ajt
-mBJ
-edC
-alr
-vfs
-amL
-jPY
-nXR
-oPd
+jrB
+pux
+gMv
+hPA
+otP
+rZN
+tsg
+nVq
+fuM
+ykU
+tRf
+mpy
+eNq
+wlM
+wlM
+aiX
+awx
+iFu
+xix
 mpu
 svf
-ePl
+pEE
 svf
 svf
 svf
@@ -84296,7 +85672,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
 aah
 aai
@@ -84304,7 +85679,7 @@ aai
 aai
 aai
 aaI
-pqZ
+aat
 aat
 aat
 aat
@@ -84315,17 +85690,18 @@ cEQ
 aei
 edD
 afJ
-acd
-agL
-agK
-agK
-aiB
-aai
-ajw
-xXX
-aiX
-aiX
-aiX
+fuM
+fuM
+fuM
+fuM
+fuM
+fuM
+prv
+uoE
+agj
+eNq
+spA
+odQ
 aiX
 aiV
 gqv
@@ -84553,14 +85929,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
 aaf
 aai
-aan
-aaw
-aaB
-aat
+ikV
+uKU
+eqR
+lgm
 aaJ
 aat
 abh
@@ -84572,19 +85947,20 @@ adG
 aeh
 edD
 afI
-bQT
-agH
-ags
-ags
-aho
-acd
-ajv
-aDU
+jfb
+uCr
+uSg
+oMS
+fvj
+oCM
+ogI
+rUp
 agj
-afL
-aez
-ahU
+agj
+agj
+agj
 aiX
+iWn
 anz
 aov
 aph
@@ -84810,14 +86186,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
 aaa
-vrY
-uaM
-aay
-aaD
-aat
+wtu
+xFQ
+qjU
+sbn
+oyN
 aat
 aat
 aat
@@ -84827,21 +86202,22 @@ acd
 acd
 acd
 aek
-dXp
-afI
-acd
-agI
-ahq
-ahV
-aho
-acd
-gkJ
-jFQ
-daD
-ajc
-afM
-afN
-aiX
+xLU
+dwj
+kQF
+rhd
+jWs
+nKT
+xVN
+uzm
+dKO
+hMy
+ktD
+rMr
+wAo
+wpj
+mEZ
+npE
 anz
 aov
 ihe
@@ -85067,16 +86443,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
 aaf
-aai
-kti
-aax
-aaC
+tpI
+gNA
+xIY
+nFk
+ktU
 aat
-aat
-adO
+gFh
 aat
 abz
 acd
@@ -85086,19 +86461,20 @@ adF
 aej
 dXp
 afD
-acd
-agJ
-ahp
-ahp
-aiC
-adF
-pYI
-akg
-agj
-adL
-ahr
-aih
-aiX
+aQJ
+esE
+lrs
+wcK
+smT
+cDk
+uBd
+fva
+uXr
+xsq
+afM
+xxI
+iPB
+npE
 anz
 aov
 aph
@@ -85324,16 +86700,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
 aaa
-vrY
-jnZ
-aay
-aaF
+mWG
+nDR
+iHz
+vYl
 aat
-aaO
-aaW
+aat
+dzI
 aat
 abB
 xIJ
@@ -85343,20 +86718,21 @@ nCN
 aem
 edD
 afG
-acd
-agK
-agK
-ail
-aiE
-lGm
-ePt
-akp
-agj
-agj
-agj
-aiX
-aiX
-anQ
+uIY
+plE
+jDy
+hON
+uii
+oCM
+myk
+xjw
+iRe
+smU
+dhY
+bNP
+cdw
+npE
+anz
 aov
 oGU
 are
@@ -85581,17 +86957,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
 aaf
-aai
-hww
-aay
-aaE
-nmq
-aaN
-aaV
+tpI
+fNN
+nqI
+urL
 aat
+ieP
+eYY
+fVr
 aat
 acd
 abL
@@ -85606,13 +86981,14 @@ agj
 agj
 agj
 agj
-bJd
-akm
-tXZ
-aly
-amf
-mEZ
-anw
+sfY
+vnx
+tKj
+xHf
+xfZ
+xfZ
+tte
+anz
 anz
 aov
 mGQ
@@ -85838,17 +87214,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
 aaa
-vrY
-qqz
-aay
+mWG
 aat
 aat
-aaJ
 aat
 aat
+pED
+vpr
+eJw
 abD
 acd
 acd
@@ -85858,18 +87233,19 @@ aen
 edD
 afH
 agj
-agM
-hXI
-ahW
-aiD
+fci
+afM
+rXk
+pEO
 agj
-wPI
-fzb
-jNu
-uhG
-uhG
-wMv
-anw
+fmG
+jDt
+dIW
+kds
+wAo
+nXZ
+aGH
+npE
 anz
 aox
 aph
@@ -86095,16 +87471,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
 aaf
-aai
-sAC
-aaz
+tpI
+tIX
 aat
 aat
 aat
 aat
+dXY
 aat
 abC
 acd
@@ -86115,18 +87490,19 @@ aeo
 edD
 afH
 agj
-agN
-jwN
-aht
-aid
-agj
-iSk
-akk
-wZe
-alw
-amg
-mgg
-anw
+nvk
+afM
+afM
+afM
+uxJ
+dWI
+ovQ
+xeK
+qQv
+afM
+qPi
+idf
+npE
 anR
 aow
 qHT
@@ -86352,16 +87728,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
 aaa
-vrY
-fcD
+jfI
 ogG
 ogG
-ykv
-rMR
-djv
+ogG
+nhI
+liJ
+mVY
 ogG
 iNj
 dhe
@@ -86372,18 +87747,19 @@ sum
 kEO
 afH
 agj
-ahs
-ahP
-ahP
-aiF
-agj
-hUs
-ajG
-agj
-agj
-agj
-aiX
-anx
+cxc
+xqH
+afM
+afM
+szj
+dWI
+hBR
+iRe
+mGl
+dhY
+bJn
+cdw
+npE
 anz
 aov
 apd
@@ -86609,16 +87985,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
 aaf
 aai
-aau
-aaA
+urs
+lON
 aaG
-aaK
-aaP
-aaX
+cCR
+iOU
+iXM
 aat
 aat
 acd
@@ -86629,18 +88004,19 @@ aeq
 wAs
 acd
 agj
-ahm
-ahD
-aiw
-aiO
 agj
-jKc
-akm
-tXZ
-aly
-amh
-mEZ
-anw
+xVO
+wSa
+wNj
+hWp
+sQy
+ovQ
+rbI
+xHf
+xfZ
+xfZ
+tte
+anz
 anz
 aov
 apd
@@ -86866,7 +88242,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
 aaa
 aai
@@ -86886,18 +88261,19 @@ ghd
 teE
 hRn
 caB
+lpa
 qvH
 qvH
 qvH
-qvH
-oim
-kHx
-fzb
-fQc
-uhG
-uhG
-wdT
-anw
+mYJ
+dsh
+jDt
+bdT
+kds
+wAo
+luI
+aGH
+npE
 anz
 aov
 sFN
@@ -87127,7 +88503,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaf
 aaa
@@ -87136,25 +88511,26 @@ aai
 abi
 abF
 lBH
-acK
+jyB
 adf
 acd
 rjk
 afB
 hAT
 pqW
+oCk
 agO
-agO
-agO
+dtI
 agO
 aiy
-dQk
-ajF
-wZe
-alw
-ami
-mgg
-anw
+fgF
+qVw
+xeK
+kxr
+afM
+ojv
+iPB
+npE
 anz
 aov
 jQn
@@ -87379,7 +88755,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaf
 aaf
@@ -87398,20 +88773,21 @@ aaZ
 aaZ
 aaZ
 aaZ
-aaZ
-agn
-uLI
-agn
-uLI
-agn
-ajc
-hUs
-ako
-agj
-agj
-agj
 aiX
-any
+aiX
+duI
+oCM
+aiX
+pBX
+oZq
+ezx
+hBR
+iRe
+rRH
+hiW
+moP
+cdw
+npE
 anz
 aov
 apd
@@ -87642,33 +89018,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaa
 aaf
 aaf
 aaT
 aaf
+klS
 aaZ
-abm
-cpg
-acv
-adi
-adi
-aaZ
-omQ
-nPy
-eqd
-eke
-tzP
-aiH
-ojX
-akm
-tXZ
-aly
-amj
-mEZ
-anw
+sFP
+jOb
+icA
+kyd
+phM
+wuc
+pdw
+dsK
+xrc
+uoO
+ajc
+iyN
+ovQ
+bKv
+agj
+xfZ
+ofo
+tte
+pEp
 anz
 aov
 apd
@@ -87899,33 +89275,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaa
 aaf
 aaf
 aaT
-aaa
+gXs
+rVN
 aaZ
-abH
-acl
-ajC
-acL
-adi
-aaZ
-agp
-agt
-gef
-ahS
-dHW
+cMM
+ioC
+krN
+vxE
+vYd
+vYd
+hht
+xoj
+uIY
+wJx
 ajc
-sQw
-fzb
-yjz
-eoH
-uhG
-wMv
-anw
+iyN
+ovQ
+xeK
+ird
+yfg
+coa
+tPm
+sXk
 anz
 aov
 xyt
@@ -88156,33 +89532,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaa
 aaf
 aaf
-abY
-aaa
+aaS
+gXs
+rVN
 aaZ
-dTj
-ack
-adk
-adK
-cqG
-nAr
-ago
-agS
-gef
-ahR
-gzp
-ajc
-hUs
-akk
-wZe
-alw
-amk
-mgg
-anw
+cLU
+wFp
+hQz
+aaZ
+aaZ
+rwH
+nYz
+aaZ
+aaZ
+aaZ
+etZ
+iyN
+ovQ
+xeK
+oCM
+byq
+xeK
+aQJ
+sXk
 anS
 aoy
 vcm
@@ -88413,33 +89789,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaa
 aaf
 aaf
 aaT
-aaa
+gXs
+rVN
 aaZ
-abJ
-ack
-acM
-adQ
-cwM
-mpn
-agr
-agU
-nKI
-ahX
-uLI
-ajc
-hUs
-akq
-agj
-agj
-agj
-aiX
-anx
+vrD
+lFl
+sya
+kFW
+ghk
+ovF
+thd
+hBv
+eUy
+tOx
+oEo
+fgF
+gUb
+ung
+ird
+nVe
+svs
+vPi
+sXk
 anz
 aoz
 upH
@@ -88669,33 +90045,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaf
 aaa
 aaf
 aaf
 aaT
-aaa
+gXs
+rVN
 aaZ
-abI
-ack
-coS
-aet
-cxA
-mbz
-agt
-agt
-dAi
-aie
-mxY
-ajc
-hUs
-akp
-akU
-alz
-aml
-amT
+kCD
+lGw
+mUW
+opC
+oDJ
+cFJ
+mAP
+mAP
+ykT
+iCG
+vao
+iyN
+uXr
+lEY
+agn
+btP
+fMk
+aak
 anw
 anz
 aoz
@@ -88927,35 +90303,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaa
 aaf
 aaf
-abY
-aaa
+aaS
+gXs
+rVN
 aaZ
-abQ
-ack
-adj
-pdT
-cxe
-umr
-eBc
-sgU
-lPS
-mgP
-sYt
-ajc
-sQw
-mMV
-vad
-alB
-amn
-amV
-anw
+wLw
+lGw
+mUW
+ogA
+sjK
+ozo
+ozo
+ivB
+hFZ
+cml
+grq
+fgF
+lau
+drc
+meY
+dZW
+lbG
+gOt
+npE
 anz
-aoz
+bAe
 aod
 qkf
 oTZ
@@ -89184,35 +90560,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaa
 aaf
 aaf
-abY
-aaa
-aaZ
-abN
-ack
-bkA
-xoT
-aes
-wIr
-amN
+adR
+hsQ
+adR
+adR
+adR
+ybo
+tSV
+qWc
+pNb
+nIX
+lFX
+lFX
+eVv
+okC
+pDB
+uFl
+afM
+lmu
 agt
-lDW
-aHp
-dHW
-ajc
-hUs
-akp
-agj
-alA
-amm
-lnL
-anw
+fej
+fmq
+fwg
+npE
 anT
-aoA
+jXr
 apn
 lzH
 arf
@@ -89441,35 +90817,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaa
 aaf
 aaf
-aaT
-aaf
-aaZ
-aci
-mLD
-cNH
-ujG
-aes
-alt
-agu
-agX
-lDW
-aij
-agn
-rnF
-nzl
-akr
-ldt
-jOg
-alC
-vKx
-anw
+adR
+rvB
+reo
+iec
+adR
+rte
+gLN
+lNC
+aii
+gLN
+gLN
+dcE
+gTe
+tOx
+rzr
+qTq
+jOV
+agr
+agp
+msJ
+cga
+ceX
+npE
 anz
-rKh
+ljv
 aod
 lzH
 arf
@@ -89697,36 +91073,36 @@ aaa
 aaa
 aaa
 aaa
+aaf
+aaf
+aaf
+aaf
 aaa
-aaf
-aaf
-aaf
-aaf
-oYB
 adR
-hsQ
+dGx
+dGx
+dGx
+adR
+wxU
+pYi
+aaZ
+aaZ
+glD
+pUZ
 aaZ
 aaZ
 aaZ
-uxx
-oXs
-aaZ
-aaZ
+jTR
+jNj
+njY
+kDR
+kbK
+kTn
+wPY
 agn
-agW
-lbL
-aii
-agn
-ajd
-sQw
-vAX
-tYr
-eqG
-maj
-aWI
+anA
 anz
-anz
-aoz
+bAe
 aod
 lzH
 arf
@@ -89956,34 +91332,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaf
 aaa
-abp
-abP
-aco
-acO
-abl
+adR
+abO
+abO
+abO
+ezU
 abO
 abO
 afc
 afQ
-agw
-agY
-oIt
-hEp
+hnZ
+kMr
+lBg
+sJP
 adR
-aiQ
-hUs
-akt
-xNu
-iGX
-amo
-dFW
+glt
+gMS
+ofq
+jZT
+fRo
+cjm
+olJ
+agn
 anA
 anz
-aoD
+fOk
 aod
 lzH
 arf
@@ -90214,7 +91590,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaa
 hsQ
@@ -90228,19 +91603,20 @@ afb
 abo
 afg
 ahb
-len
-dDx
-uhY
-xJQ
-fxO
-aks
-agj
-agj
-agj
-aiX
-nsK
+lbs
+mJT
+vgY
+jnD
+juE
+gyR
+agn
+mKd
+paL
+agn
+agn
+anA
 anz
-aoz
+nwk
 aod
 lzH
 arf
@@ -90471,33 +91847,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaa
-abp
-abO
-acq
-acq
-acq
-acq
-aew
-afe
-ujq
+adR
+hPv
+heY
+heY
+heY
+heY
+mDs
+qyO
+fQD
 agy
 aha
-dWN
-aia
-aiP
-aiR
-vnJ
-akl
-jfb
-edn
-edn
-aiX
-anA
+jpy
+rmK
+adR
+gfa
+aYy
+fib
+yml
+bee
+wdb
+wAJ
+agn
+ieQ
 anz
-aoC
+slE
 apo
 oqf
 jaL
@@ -90726,35 +92102,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaf
 aaf
 aaf
 hsQ
-abO
-acp
-acP
-acP
-acP
-aev
-afd
+axV
+sQS
+nbC
+nbC
+nbC
+ybC
+kmk
 afR
 agx
 agZ
 nwW
-aim
+tTB
 adR
-ajc
-jNo
-drT
-hcm
-akz
-amq
-aiX
-anA
+nqs
+xHb
+mcg
+mLC
+oHq
+pAS
+dIX
+agn
+uUt
 anz
-aoF
+hct
 aod
 wyO
 aun
@@ -90986,32 +92362,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
-abp
-abR
-abP
-abP
-abP
-abP
-abp
-abp
-abp
+adR
+ouq
+bhp
+gML
+gML
+gML
+adR
+adR
+adR
 jsd
 afU
 irK
-aip
+wEF
 adR
-rAt
-ajN
-akx
-wZe
-rMf
-iTt
-aiX
-kdH
-ajn
-gjb
+uFV
+ffn
+dKW
+wHs
+wHs
+wHs
+wHs
+wHs
+anC
+bso
+anC
 cSA
 lzH
 arf
@@ -91239,36 +92615,36 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaf
 aaf
 aaf
 aaf
-abq
-abq
-abq
-mxf
-nas
-abq
-abq
+jqk
+jqk
+jqk
+pWl
+cCF
+jqk
+jqk
 aff
 afT
 agz
 ahb
-irK
-clI
-abp
-wHs
-sQE
-jjs
-wHs
-wHs
-wHs
-wHs
-anC
-bso
-anC
+mqg
+jsq
+wyv
+ewG
+wul
+akw
+alb
+alG
+amr
+amY
+amY
+ajp
+ajp
+aBZ
 cSA
 lzH
 arf
@@ -91500,31 +92876,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
-abq
-mgJ
-wzV
-acR
-rYW
-rdT
-xiF
+jqk
+ovX
+lhE
+tJM
+vcp
+xXx
+nlJ
 afh
 afV
 agB
 ahd
 nwW
-clS
+xRB
 abp
-wCb
-ajM
-akw
-alb
-alG
-amr
-amY
-amY
-ajp
+ajj
+ajP
+aky
+alc
+alI
+ams
+amZ
+amZ
+cPm
+bTJ
 aoH
 cSA
 lzH
@@ -91753,35 +93129,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaf
 aaf
 aaf
 aaf
 tAo
-abS
+qtq
 acr
 acQ
 adn
-uDN
-abq
+cvh
+jqk
 afg
 afU
 afU
 ahc
 lXy
-aiq
+lxq
 abp
-ajj
-ajP
-aky
-alc
-alI
-ams
-amZ
-amZ
-anV
+aji
+ajO
+akw
+ajn
+alH
+amr
+amY
+amY
+ajp
+dTj
 ajo
 cSA
 lzH
@@ -92014,30 +93390,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 qvL
-xgS
+lMM
 itZ
 muW
 miF
-uvt
-fBS
+luM
+nKu
 vHh
 wBI
 tqN
 oGP
 dow
-ait
+tfW
 abp
-aji
-ajO
+ajl
+ajR
 akw
-ajn
-alH
-amr
-amY
-amY
+ald
+alJ
+gMx
+ajp
+ajp
+ajp
 anY
 ajo
 apq
@@ -92267,19 +93643,18 @@ aaa
 aaa
 aaa
 aag
-aaf
-aaf
+sNJ
 aaf
 aaf
 aaf
 aaf
 lim
-abU
+hgd
 act
-rBA
 acu
-rky
-abq
+acu
+owJ
+jqk
 afi
 afW
 afW
@@ -92287,13 +93662,14 @@ ahe
 irK
 ais
 abp
-ajl
-ajR
+ajk
+ajQ
 akw
-ald
-alJ
-gMx
-ajp
+ajn
+alH
+amr
+amY
+amY
 ajp
 anX
 ajo
@@ -92303,7 +93679,7 @@ arf
 ask
 atm
 arf
-avl
+dRD
 awq
 axO
 aza
@@ -92528,31 +93904,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
-abq
-abW
-abk
-acj
-acn
-okd
-hrb
+jqk
+jww
+uby
+tBY
+mgO
+iJp
+nQY
 afk
 afZ
-agE
-ahh
-tjb
-aiv
+iVk
+fQZ
+kAi
+coA
 abp
-ajk
-ajQ
-akw
-ajn
-alH
-amr
-amY
-amY
-ajp
+aiY
+ajE
+ajH
+akn
+ale
+alD
+ana
+ana
+bKP
+gNu
 ajo
 aps
 mVe
@@ -92786,30 +94162,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-abq
-abq
-abq
-abq
-abq
-abq
-abq
+jqk
+jqk
+jqk
+jqk
+jqk
+jqk
+jqk
 nHY
 xgG
-ydV
+xgG
 swm
 tOl
-umI
+cqA
 abp
-aiY
-ajE
-ajH
-akn
-ale
-alD
-ana
-ana
-gNu
+ajm
+tGM
+ajn
+aXb
+akA
+amr
+amY
+amY
+ajp
+ajp
 ajo
 umA
 tZh
@@ -93045,27 +94421,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaa
 aaf
 hsQ
-aeB
+glu
 gct
 agb
 agG
 ahi
-rVr
-jyM
+cMr
+pCq
 abp
-ajm
-ajS
+ajp
+frV
 ajn
-trb
-akA
+ygA
+ajn
 amr
-amY
-amY
+ajp
+ajp
+ajp
 ajp
 ajo
 apt
@@ -93295,7 +94671,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaf
 aag
@@ -93315,6 +94690,7 @@ ahj
 abp
 rdm
 abp
+ajo
 ajo
 ajo
 ajo
@@ -93559,7 +94935,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 acw
 abp
 abp
@@ -93568,9 +94943,10 @@ abp
 uIZ
 abp
 adR
-ahl
+cAY
 ahO
 tHF
+ahT
 ahT
 ahT
 ahT
@@ -93815,7 +95191,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aag
 acU
@@ -93828,6 +95203,7 @@ abp
 ahk
 aoJ
 msL
+qKK
 yln
 yln
 yln
@@ -94073,7 +95449,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
 abp
 abp
@@ -94082,6 +95457,7 @@ abp
 afo
 abp
 abp
+ahn
 ahn
 ahn
 eGt
@@ -94323,7 +95699,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaf
 aag
@@ -94339,6 +95714,7 @@ aaa
 afp
 aaa
 abp
+aaa
 aaa
 aaa
 aaa
@@ -94587,7 +95963,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaa
 aaa
@@ -94596,6 +95971,7 @@ aaa
 aaa
 aaa
 adR
+aaa
 aaa
 aaa
 aaa
@@ -94847,12 +96223,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 gXs
 aaa
 aaa
 aaa
 gXs
+aaa
 aaa
 aaa
 aaa
@@ -95104,12 +96480,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 gXs
 aaa
 aaa
 aaa
 gXs
+aaa
 aaa
 aaa
 aaa
@@ -95361,12 +96737,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 xZR
 aaa
 aqG
 aaa
 cZc
+aaa
 aaa
 aaa
 aaa
@@ -95618,12 +96994,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 mIv
 ndA
 aaa
 ndA
 wop
+aaa
 aaa
 aaa
 aaa
@@ -95870,7 +97246,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 sEJ
 aaa
 aaa
@@ -95881,6 +97256,7 @@ aag
 gXs
 rVN
 rVN
+aaa
 aaa
 aaa
 aaa
@@ -96133,10 +97509,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
 gXs
 aaa
 gXs
+aaa
 aaa
 aaa
 aaa
@@ -96390,10 +97766,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
 oGu
 aaa
 oGu
+aaa
 aaa
 aaa
 aaa
@@ -104143,7 +105519,7 @@ aFw
 aPg
 aQr
 aFu
-aTb
+dod
 vtb
 aVR
 aYW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR redesigns Box's Brig to be more similar to Citadel's Brig. 

Changes include the following. 

Permabrig - Adds some grass to the garden, some comfy chairs, a couch, a mirror to the bathroom, and the option to Cryo on long rounds.

![image](https://user-images.githubusercontent.com/6519623/103159808-e9073a00-479b-11eb-8e96-191406b67544.png)

Adds a firing range near the Gulag shuttle. 

Redesigned the Brig infirmary, with operating equipment included. 

![image](https://user-images.githubusercontent.com/6519623/103159826-0b995300-479c-11eb-937c-53d7e63bb131.png)

Warden's brig control is now additionally the front desk for the Brig, further cementing their role to not leave the damn brig. 

![image](https://user-images.githubusercontent.com/6519623/103159857-6e8aea00-479c-11eb-8625-8a97babdd1b4.png)

Armory was separated from brig control, but easily accessible for the Warden or related access, including the option to open some shutters for when the team needs to gear up. EVA equipment was separated into its own room nearby.

![image](https://user-images.githubusercontent.com/6519623/103159868-87939b00-479c-11eb-9d84-3de9086aeeb9.png)

HoS office has been reinforced, including some shutters for all the windows as well as replacing the simple walls with R-Walls. Why was his office not reinforced in the first place? 

![image](https://user-images.githubusercontent.com/6519623/103159878-92e6c680-479c-11eb-9a2c-876eda4dc3b0.png)

Security office has a couch, microwave, and some DONK. Techfab and computer consoles were moved to Brig central, with the same security access required to access.

![image](https://user-images.githubusercontent.com/6519623/103159885-a134e280-479c-11eb-9859-b75b22538328.png)

Fore / Port Bow maintenance has been modified to accommodate the moving of the Gulag shuttle. The small chemical storage closet by Beepsky's room has been expanded a bit to encourage ghetto chems a bit. A new room has been added next to it, where Birdboat now resides with his own pet bed and some general maint loot. 

![image](https://user-images.githubusercontent.com/6519623/103159887-b0b42b80-479c-11eb-9e96-8b2ff87918e1.png)

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/6519623/103159645-e4418680-4799-11eb-9f56-e8d073160efa.png)


## Changelog
:cl:
add: Permabrig on Boxstation is a bit more cozy for your stay.
balance: Boxstation's Brig and parts of the Fort / Port Bow maintenance has been redesigned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
