### PR TITLE
Re-Adds Plant DNA circuitboard to the Service techfab

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -226,6 +226,14 @@
 	category = list ("Hydroponics Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
+/datum/design/board/plantgenes
+	name = "Machine Design (Plant DNA Manipulator)"
+	desc = "The circuit board for a plant DNA manipulator."
+	id = "plantgenes"
+	build_path = /obj/item/circuitboard/machine/plantgenes
+	category = list ("Hydroponics Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+
 /datum/design/board/destructive_analyzer
 	name = "Machine Design (Destructive Analyzer Board)"
 	desc = "The circuit board for a destructive analyzer."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Re-adds something that got removed from a TG Merge probably.

## Why It's Good For The Game

Fix

## Changelog
:cl:
fix: Botanists can now once again print Plant DNA Manipulator boards from the service techfab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
