### PR TITLE
Merges facial hair color with head hair color

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -79,7 +79,7 @@
 
 #define DNA_UNI_IDENTITY_BLOCKS		7
 #define DNA_HAIR_COLOR_BLOCK		1
-#define DNA_FACIAL_HAIR_COLOR_BLOCK	2
+//Wasp edit, merged hair color
 #define DNA_SKIN_TONE_BLOCK			3
 #define DNA_EYE_COLOR_BLOCK			4
 #define DNA_GENDER_BLOCK			5

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -116,7 +116,7 @@
 #define RANDOM_EXOWEAR_STYLE "random_jumpsuit_style"
 #define RANDOM_HAIRSTYLE "random_hairstyle"
 #define RANDOM_HAIR_COLOR "random_hair_color"
-#define RANDOM_FACIAL_HAIR_COLOR "random_facial_hair_color"
+//Wasp edit, merged hair color
 #define RANDOM_FACIAL_HAIRSTYLE "random_facial_hairstyle"
 #define RANDOM_SKIN_TONE "random_skin_tone"
 #define RANDOM_EYE_COLOR "random_eye_color"

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -114,7 +114,7 @@
 		if(!GLOB.facial_hairstyles_list.len)
 			init_sprite_accessory_subtypes(/datum/sprite_accessory/facial_hair, GLOB.facial_hairstyles_list, GLOB.facial_hairstyles_male_list, GLOB.facial_hairstyles_female_list)
 		L[DNA_FACIAL_HAIRSTYLE_BLOCK] = construct_block(GLOB.facial_hairstyles_list.Find(H.facial_hairstyle), GLOB.facial_hairstyles_list.len)
-		L[DNA_FACIAL_HAIR_COLOR_BLOCK] = sanitize_hexcolor(H.facial_hair_color)
+		//Wasp edit, merged hair color
 		L[DNA_SKIN_TONE_BLOCK] = construct_block(GLOB.skin_tones.Find(H.skin_tone), GLOB.skin_tones.len)
 		L[DNA_EYE_COLOR_BLOCK] = sanitize_hexcolor(H.eye_color)
 
@@ -188,8 +188,7 @@
 	switch(blocknumber)
 		if(DNA_HAIR_COLOR_BLOCK)
 			setblock(uni_identity, blocknumber, sanitize_hexcolor(H.hair_color))
-		if(DNA_FACIAL_HAIR_COLOR_BLOCK)
-			setblock(uni_identity, blocknumber, sanitize_hexcolor(H.facial_hair_color))
+		//Wasp edit, merged hair color
 		if(DNA_SKIN_TONE_BLOCK)
 			setblock(uni_identity, blocknumber, construct_block(GLOB.skin_tones.Find(H.skin_tone), GLOB.skin_tones.len))
 		if(DNA_EYE_COLOR_BLOCK)
@@ -403,7 +402,7 @@
 	..()
 	var/structure = dna.uni_identity
 	hair_color = sanitize_hexcolor(getblock(structure, DNA_HAIR_COLOR_BLOCK))
-	facial_hair_color = sanitize_hexcolor(getblock(structure, DNA_FACIAL_HAIR_COLOR_BLOCK))
+	//Wasp edit, merged hair color
 	skin_tone = GLOB.skin_tones[deconstruct_block(getblock(structure, DNA_SKIN_TONE_BLOCK), GLOB.skin_tones.len)]
 	eye_color = sanitize_hexcolor(getblock(structure, DNA_EYE_COLOR_BLOCK))
 	facial_hairstyle = GLOB.facial_hairstyles_list[deconstruct_block(getblock(structure, DNA_FACIAL_HAIRSTYLE_BLOCK), GLOB.facial_hairstyles_list.len)]

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -225,11 +225,7 @@
 				if(new_hair_color)
 					H.hair_color = sanitize_hexcolor(new_hair_color)
 					H.dna.update_ui_block(DNA_HAIR_COLOR_BLOCK)
-				if(H.gender == "male")
-					var/new_face_color = input(H, "Choose your facial hair color", "Hair Color","#"+H.facial_hair_color) as color|null
-					if(new_face_color)
-						H.facial_hair_color = sanitize_hexcolor(new_face_color)
-						H.dna.update_ui_block(DNA_FACIAL_HAIR_COLOR_BLOCK)
+				//Wasp edit, merged hair color
 				H.update_hair()
 
 		if(BODY_ZONE_PRECISE_EYES)

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -19,8 +19,8 @@
 	H.skin_tone = random_skin_tone()
 	H.hairstyle = random_hairstyle(H.gender)
 	H.facial_hairstyle = random_facial_hairstyle(H.gender)
-	H.hair_color = random_short_color_natural()
-	H.facial_hair_color = H.hair_color
+	H.hair_color = random_short_color_natural()	//Wasp edit, natural-ish hair colors
+	//Wasp edit, merged hair color
 	H.eye_color = random_eye_color()
 	H.dna.blood_type = random_blood_type()
 

--- a/code/modules/antagonists/fugitive/fugitive_outfits.dm
+++ b/code/modules/antagonists/fugitive/fugitive_outfits.dm
@@ -36,7 +36,7 @@
 	H.hairstyle = "Business Hair 3"
 	H.facial_hairstyle = "Shaved"
 	H.hair_color = "000"
-	H.facial_hair_color = H.hair_color
+	//Wasp edit, merged hair color
 	H.update_body()
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/knock(null))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -77,13 +77,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/hairstyle = "Bald"				//Hair type
 	var/hair_color = "000"				//Hair color
 	var/facial_hairstyle = "Shaved"	//Face hair type
-	var/facial_hair_color = "000"		//Facial hair color
+	//Wasp edit, merged hair color
 	var/skin_tone = "caucasian1"		//Skin color
 	var/eye_color = "000"				//Eye color
 	var/datum/species/pref_species = new /datum/species/human()	//Mutant race
 	var/species_looking_at = "human" //used as a helper to keep track of in the species select thingy
 	var/list/features = list("mcolor" = "FFF", "ethcolor" = "9c3030", "tail_lizard" = "Smooth", "tail_human" = "None", "snout" = "Round", "horns" = "None", "ears" = "None", "wings" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None", "legs" = "Normal Legs", "moth_wings" = "Plain", "moth_fluff" = "Plain", "moth_markings" = "None", "spider_legs" = "Plain", "spider_spinneret" = "Plain", "spider_mandibles" = "Plain", "squid_face" = "Squidward", "ipc_screen" = "Blue", "ipc_antenna" = "None", "ipc_chassis" = "Morpheus Cyberkinetics(Greyscale)", "flavor_text" = "")
-	var/list/randomise = list(RANDOM_UNDERWEAR = TRUE, RANDOM_UNDERWEAR_COLOR = TRUE, RANDOM_UNDERSHIRT = TRUE, RANDOM_SOCKS = TRUE, RANDOM_BACKPACK = TRUE, RANDOM_JUMPSUIT_STYLE = TRUE, RANDOM_EXOWEAR_STYLE = TRUE, RANDOM_HAIRSTYLE = TRUE, RANDOM_HAIR_COLOR = TRUE, RANDOM_FACIAL_HAIRSTYLE = TRUE, RANDOM_FACIAL_HAIR_COLOR = TRUE, RANDOM_SKIN_TONE = TRUE, RANDOM_EYE_COLOR = TRUE)
+	var/list/randomise = list(RANDOM_UNDERWEAR = TRUE, RANDOM_UNDERWEAR_COLOR = TRUE, RANDOM_UNDERSHIRT = TRUE, RANDOM_SOCKS = TRUE, RANDOM_BACKPACK = TRUE, RANDOM_JUMPSUIT_STYLE = TRUE, RANDOM_EXOWEAR_STYLE = TRUE, RANDOM_HAIRSTYLE = TRUE, RANDOM_HAIR_COLOR = TRUE, RANDOM_FACIAL_HAIRSTYLE = TRUE, RANDOM_SKIN_TONE = TRUE, RANDOM_EYE_COLOR = TRUE)	//Wasp edit, merged hair color
 	var/list/friendlyGenders = list("Male" = "male", "Female" = "female", "Other" = "plural")
 	var/phobia = "spiders"
 	var/list/alt_titles_preferences = list()
@@ -400,9 +400,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				dat += "<a href='?_src_=prefs;preference=previous_facehairstyle;task=input'>&lt;</a> <a href='?_src_=prefs;preference=next_facehairstyle;task=input'>&gt;</a>"
 				dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_FACIAL_HAIRSTYLE]'>[(randomise[RANDOM_FACIAL_HAIRSTYLE]) ? "Lock" : "Unlock"]</A>"
 
-				dat += "<br><span style='border: 1px solid #161616; background-color: #[facial_hair_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=facial;task=input'>Change</a>"
-				dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_FACIAL_HAIR_COLOR]'>[(randomise[RANDOM_FACIAL_HAIR_COLOR]) ? "Lock" : "Unlock"]</A>"
-				dat += "<br></td>"
+				//Wasp edit, merged hair color
 
 			//Mutant stuff
 			var/mutant_category = 0
@@ -1497,8 +1495,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					hair_color = random_short_color()
 				if("hairstyle")
 					hairstyle = random_hairstyle(gender)
-				if("facial")
-					facial_hair_color = random_short_color()
+				//Wasp edit, merged hair color
 				if("facial_hairstyle")
 					facial_hairstyle = random_facial_hairstyle(gender)
 				if("underwear")
@@ -1630,10 +1627,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					else
 						hairstyle = previous_list_item(hairstyle, GLOB.hairstyles_list)
 
-				if("facial")
-					var/new_facial = input(user, "Choose your character's facial-hair colour:", "Character Preference","#"+facial_hair_color) as color|null
-					if(new_facial)
-						facial_hair_color = sanitize_hexcolor(new_facial)
+				//Wasp edit, merged hair color
 
 				if("facial_hairstyle")
 					var/new_facial_hairstyle
@@ -2240,7 +2234,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			organ_eyes.eye_color = eye_color
 		organ_eyes.old_eye_color = eye_color
 	character.hair_color = hair_color
-	character.facial_hair_color = facial_hair_color
+	//Wasp edit, merged hair color
 
 	character.skin_tone = skin_tone
 	character.hairstyle = hairstyle

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -352,7 +352,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	READ_FILE(S["gender"], gender)
 	READ_FILE(S["age"], age)
 	READ_FILE(S["hair_color"], hair_color)
-	READ_FILE(S["facial_hair_color"], facial_hair_color)
+	//Wasp edit, merged hair color
 	READ_FILE(S["eye_color"], eye_color)
 	READ_FILE(S["skin_tone"], skin_tone)
 	READ_FILE(S["hairstyle_name"], hairstyle)
@@ -475,7 +475,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	socks			= sanitize_inlist(socks, GLOB.socks_list)
 	age				= sanitize_integer(age, AGE_MIN, AGE_MAX, initial(age))
 	hair_color			= sanitize_hexcolor(hair_color, 3, 0)
-	facial_hair_color			= sanitize_hexcolor(facial_hair_color, 3, 0)
+	//Wasp edit, merged hair color
 	underwear_color			= sanitize_hexcolor(underwear_color, 3, 0)
 	eye_color		= sanitize_hexcolor(eye_color, 3, 0)
 	skin_tone		= sanitize_inlist(skin_tone, GLOB.skin_tones)
@@ -531,7 +531,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["gender"]			, gender)
 	WRITE_FILE(S["age"]			, age)
 	WRITE_FILE(S["hair_color"]			, hair_color)
-	WRITE_FILE(S["facial_hair_color"]			, facial_hair_color)
+	//Wasp edit, merged hair color
 	WRITE_FILE(S["eye_color"]			, eye_color)
 	WRITE_FILE(S["skin_tone"]			, skin_tone)
 	WRITE_FILE(S["hairstyle_name"]			, hairstyle)

--- a/code/modules/clothing/outfits/event.dm
+++ b/code/modules/clothing/outfits/event.dm
@@ -22,5 +22,5 @@
 	H.hairstyle = "Long Hair 3"
 	H.facial_hairstyle = "Beard (Full)"
 	H.hair_color = "FFF"
-	H.facial_hair_color = "FFF"
+	//Wasp edit, merged hair color
 	H.update_hair()

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -31,8 +31,7 @@
 		facial_hairstyle = random_facial_hairstyle(gender)
 	if(randomise[RANDOM_HAIR_COLOR])
 		hair_color = random_short_color()
-	if(randomise[RANDOM_FACIAL_HAIR_COLOR])
-		facial_hair_color = random_short_color()
+	//Wasp edit, merged hair color
 	if(randomise[RANDOM_SKIN_TONE])
 		skin_tone = random_skin_tone()
 	if(randomise[RANDOM_EYE_COLOR])

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -46,7 +46,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/hair_color
 	var/mutable_appearance/hair_overlay
 	var/facial_hairstyle
-	var/facial_hair_color
+	//Wasp edit, merged hair color
 	var/mutable_appearance/facial_hair_overlay
 
 	var/updatedir = 1						//Do we have to update our dir as the ghost moves around?
@@ -112,7 +112,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 				hair_color = brighten_color(body_human.hair_color)
 			if(FACEHAIR in body_human.dna.species.species_traits)
 				facial_hairstyle = body_human.facial_hairstyle
-				facial_hair_color = brighten_color(body_human.facial_hair_color)
+				//Wasp edit, merged hair color
 
 	update_icon()
 
@@ -219,8 +219,8 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 			S = GLOB.facial_hairstyles_list[facial_hairstyle]
 			if(S)
 				facial_hair_overlay = mutable_appearance(S.icon, "[S.icon_state]", -HAIR_LAYER)
-				if(facial_hair_color)
-					facial_hair_overlay.color = "#" + facial_hair_color
+				if(hair_color)
+					facial_hair_overlay.color = "#" + hair_color
 				facial_hair_overlay.alpha = 200
 				add_overlay(facial_hair_overlay)
 		if(hairstyle)
@@ -793,7 +793,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		hair_color = brighten_color(client.prefs.hair_color)
 	if(FACEHAIR in client.prefs.pref_species.species_traits)
 		facial_hairstyle = client.prefs.facial_hairstyle
-		facial_hair_color = brighten_color(client.prefs.facial_hair_color)
+		//Wasp edit, merged hair color
 
 	update_icon()
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -16,8 +16,7 @@
 	var/hair_color = "000"
 	var/hairstyle = "Bald"
 
-	//Facial hair colour and style
-	var/facial_hair_color = "000"
+	//Facial hair style | //Wasp edit, merged hair color
 	var/facial_hairstyle = "Shaved"
 
 	//Eye colour

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -531,7 +531,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					else
 						facial_overlay.color = "#" + hair_color
 				else
-					facial_overlay.color = "#" + H.facial_hair_color
+					facial_overlay.color = "#" + H.hair_color
 			else
 				facial_overlay.color = forced_colour
 
@@ -904,7 +904,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 							else
 								accessory_overlay.color = "#[H.hair_color]"
 						if(FACEHAIR)
-							accessory_overlay.color = "#[H.facial_hair_color]"
+							accessory_overlay.color = "#[H.hair_color]"
 						if(EYECOLOR)
 							accessory_overlay.color = "#[H.eye_color]"
 				else

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/ghost.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/ghost.dm
@@ -38,7 +38,7 @@
 	var/ghost_hair_color
 	var/mutable_appearance/ghost_hair
 	var/ghost_facial_hairstyle
-	var/ghost_facial_hair_color
+	//Wasp edit, merged hair color
 	var/mutable_appearance/ghost_facial_hair
 	var/random = TRUE //if you want random names for ghosts or not
 
@@ -62,5 +62,5 @@
 	if(ghost_facial_hairstyle != null)
 		ghost_facial_hair = mutable_appearance('icons/mob/human_face.dmi', "facial_[ghost_facial_hairstyle]", -HAIR_LAYER)
 		ghost_facial_hair.alpha = 200
-		ghost_facial_hair.color = ghost_facial_hair_color
+		//Wasp edit, merged hair color
 		add_overlay(ghost_facial_hair)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2088,7 +2088,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			var/mob/living/carbon/human/N = M
 			N.age += 1
 			if(N.age > 70)
-				N.facial_hair_color = "ccc"
+				//Wasp edit, merged hair color
 				N.hair_color = "ccc"
 				N.update_hair()
 				if(N.age > 100)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1197,7 +1197,7 @@
 	if(M && ishuman(M) && reac_volume >= 0.5)
 		var/mob/living/carbon/human/H = M
 		H.hair_color = "C2F"
-		H.facial_hair_color = "C2F"
+		//Wasp edit, merged hair color
 		H.update_hair()
 
 /datum/reagent/medicine/regen_jelly/on_mob_life(mob/living/carbon/M)
@@ -1579,7 +1579,7 @@
 		if(M && ishuman(M) && reac_volume >= 0.5)
 			var/mob/living/carbon/human/H = M
 			H.hair_color = "92f"
-			H.facial_hair_color = "92f"
+			//Wasp edit, merged hair color
 			H.update_hair()
 
 /datum/reagent/medicine/polypyr/overdose_process(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -442,7 +442,7 @@
 		if(!HAS_TRAIT(N, TRAIT_BALD))
 			N.hairstyle = "Spiky"
 		N.facial_hairstyle = "Shaved"
-		N.facial_hair_color = "000"
+		//Wasp edit, merged hair color
 		N.hair_color = "000"
 		if(!(HAIR in N.dna.species.species_traits)) //No hair? No problem!
 			N.dna.species.species_traits += HAIR
@@ -1690,7 +1690,7 @@
 		if(M && ishuman(M))
 			var/mob/living/carbon/human/H = M
 			H.hair_color = pick(potential_colors)
-			H.facial_hair_color = pick(potential_colors)
+			//Wasp edit, merged hair color
 			H.update_hair()
 
 /datum/reagent/barbers_aid

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -319,7 +319,7 @@
 	// These are stored before calling super. This is so that if the head is from a different body, it persists its appearance.
 	var/hair_color = src.hair_color
 	var/hairstyle = src.hairstyle
-	var/facial_hair_color = src.facial_hair_color
+	//Wasp edit, merged hair color
 	var/facial_hairstyle = src.facial_hairstyle
 	var/lip_style = src.lip_style
 	var/lip_color = src.lip_color
@@ -349,7 +349,7 @@
 		var/mob/living/carbon/human/H = C
 		H.hair_color = hair_color
 		H.hairstyle = hairstyle
-		H.facial_hair_color = facial_hair_color
+		//Wasp edit, merged hair color
 		H.facial_hairstyle = facial_hairstyle
 		H.lip_style = lip_style
 		H.lip_color = lip_color

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -28,7 +28,7 @@
 	var/hairstyle = "Bald"
 	var/hair_alpha = 255
 	//Facial hair colour and style
-	var/facial_hair_color = "000"
+	//Wasp edit, merged hair color
 	var/facial_hairstyle = "Shaved"
 	//Eye Colouring
 
@@ -146,19 +146,10 @@
 		//Facial hair
 		if(H.facial_hairstyle && (FACEHAIR in S.species_traits))
 			facial_hairstyle = H.facial_hairstyle
-			if(S.hair_color)
-				if(S.hair_color == "mutcolor")
-					facial_hair_color = H.dna.features["mcolor"]
-				else if(hair_color == "fixedmutcolor")
-					facial_hair_color = "#[S.fixed_mut_color]"
-				else
-					facial_hair_color = S.hair_color
-			else
-				facial_hair_color = H.facial_hair_color
+			//Wasp edit, merged hair color
 			hair_alpha = S.hair_alpha
 		else
 			facial_hairstyle = "Shaved"
-			facial_hair_color = "000"
 			hair_alpha = 255
 		//Hair
 		if(H.hairstyle && (HAIR in S.species_traits))
@@ -207,7 +198,7 @@
 				var/datum/sprite_accessory/S = GLOB.facial_hairstyles_list[facial_hairstyle]
 				if(S)
 					var/image/facial_overlay = image(S.icon, "[S.icon_state]", -HAIR_LAYER, SOUTH)
-					facial_overlay.color = "#" + facial_hair_color
+					facial_overlay.color = "#" + hair_color
 					facial_overlay.alpha = hair_alpha
 					. += facial_overlay
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This Pr is your standard var deletion PR, any cod ethat initialized or wrote to facial_hair_color, gone.
Any code that read from facial_hair_color, the refrence was replaced with hair_color
I may have been a bit aggressive with the margularization...
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is mainly for further QoL for random mob players (such as charlie station inhabitants) and etc. People who do not have any choice on the colors assigned. While at the same time a couple ms a tick are being saved in hair rendering.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: You can no longer customize your facial hair color
tweak: Your facial hair color is now directly connected with your hair color
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
