### PR TITLE
Remove Jukebox Access Requirement

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -5,7 +5,7 @@
 	icon_state = "jukebox"
 	verb_say = "states"
 	density = TRUE
-	req_one_access = list(ACCESS_BAR, ACCESS_KITCHEN, ACCESS_HYDROPONICS, ACCESS_ENGINE, ACCESS_CARGO, ACCESS_THEATRE) //Wasp Edit Cit #7905
+	// WaspStation Edit - Removed Jukebox Access Requirements
 	var/active = FALSE
 	var/list/rangers = list()
 	var/stop = 0


### PR DESCRIPTION
## About The Pull Request

Removed the access requirement from the jukebox.  This was done by removing the req_one_access variable.

## Why It's Good For The Game

The jobs currently allowed to access the jukebox seem very arbitrary; this will allow anyone to use it.  This was spurred on by the Entertainer alt title having assistant-level access, thus not being able to use the jukebox.

Current roles with jukebox access:
![image](https://user-images.githubusercontent.com/7697956/103317569-257fa380-49f1-11eb-8200-25b9e5a32ce2.png)

## Changelog
:cl:
tweak: Everyone can access the jukebox
/:cl:
