### PR TITLE
Changing Poster Fix

### DIFF
--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -114,6 +114,11 @@
 	R.add_fingerprint(user)
 	qdel(src)
 
+// WaspStation Start - Changing Posters Fix
+/obj/structure/sign/poster/wrench_act(mob/living/user, obj/item/wrench/I)
+	return
+// WaspStation End
+
 /obj/structure/sign/poster/proc/roll_and_drop(loc)
 	pixel_x = 0
 	pixel_y = 0


### PR DESCRIPTION
## About The Pull Request

Posters would turn invisible when removed via wrench, and change which poster they were when re-applied to a wall.  To prevent this, posters can no longer be removed with a wrench (wirecutters still work).  I did this by overriding wrench_act for posters to immediately return.

## Why It's Good For The Game

Bugfix: Issue #658 

## Changelog
:cl:
fix: Posters no longer change when removed
/:cl:
