### PR TITLE
Map Maintenance Again

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5735,21 +5735,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"avl" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "avm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6840,12 +6825,6 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "aAQ" = (
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
-"aAS" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aAT" = (
@@ -8359,15 +8338,6 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"aHg" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel Office"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/chapel/office)
 "aHi" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/window/reinforced{
@@ -8940,20 +8910,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aJg" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aJh" = (
 /turf/open/floor/plasteel,
 /area/gateway)
@@ -9421,15 +9377,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"aKW" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "aKX" = (
 /obj/machinery/door/window/eastright{
 	name = "Hydroponics Delivery";
@@ -11272,13 +11219,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aSl" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/plating,
-/area/storage/emergency/port)
 "aSm" = (
 /turf/open/floor/plating,
 /area/storage/emergency/port)
@@ -11557,12 +11497,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"aTb" = (
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/turf/open/floor/wood,
-/area/library)
 "aTc" = (
 /obj/machinery/door/window/northright{
 	dir = 8;
@@ -12173,6 +12107,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"aVf" = (
+/obj/structure/closet/secure_closet/medical1,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "aVr" = (
 /obj/machinery/camera{
 	c_tag = "Bridge East";
@@ -12247,14 +12192,6 @@
 /area/crew_quarters/kitchen)
 "aVF" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"aVH" = (
-/obj/machinery/processor,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aVI" = (
@@ -13384,11 +13321,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"baA" = (
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/chapel/main)
 "baB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -14382,35 +14314,6 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/sorting)
-"beW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/obj/structure/table/reinforced,
-/obj/item/stack/wrapping_paper{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/stack/packageWrap{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "beY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -14822,14 +14725,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"bgF" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/pharmacy)
 "bgG" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway West";
@@ -15880,13 +15775,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"bkC" = (
-/obj/effect/decal/cleanable/oil,
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "bkE" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/r_wall,
@@ -16278,15 +16166,6 @@
 	},
 /obj/structure/dresser,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"bmB" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -16764,35 +16643,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bou" = (
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
-"bov" = (
-/obj/structure/table,
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/crowbar,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/item/radio/headset/headset_sci{
-	pixel_x = -3
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "box" = (
@@ -17646,6 +17496,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"bsv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	dir = 8;
+	name = "Atmos RC";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bsz" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -19039,19 +18900,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"bzd" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/pen,
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bze" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -19355,17 +19203,22 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
-"bAp" = (
-/obj/structure/closet/secure_closet/medical1,
-/obj/machinery/light{
-	dir = 8
+"bAn" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/storage/tools)
 "bAr" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
@@ -20185,19 +20038,6 @@
 "bDc" = (
 /turf/closed/wall,
 /area/science/storage)
-"bDf" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/science/storage)
 "bDg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -20685,19 +20525,6 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/medical/sleeper)
-"bFA" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
-	},
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bFB" = (
 /obj/structure/closet/secure_closet/medical2,
@@ -22081,8 +21908,8 @@
 /area/science/test_area)
 "bLq" = (
 /turf/closed/indestructible/riveted{
-	name = "hyper-reinforced wall";
-	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease"
+	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
+	name = "hyper-reinforced wall"
 	},
 /area/science/test_area)
 "bLr" = (
@@ -24156,28 +23983,6 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
-"bWf" = (
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/color/latex,
-/obj/machinery/requests_console{
-	department = "Virology";
-	name = "Virology Requests Console";
-	pixel_y = -32
-	},
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/hud/health,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/clothing/glasses/science,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bWg" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -25851,14 +25656,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"cfZ" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "cgd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27807,6 +27604,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"cAM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/department/electrical)
 "cAQ" = (
 /obj/structure/chair,
 /turf/open/floor/plating,
@@ -29493,6 +29301,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"drI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/teleporter)
 "drT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -29676,6 +29494,35 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
+"dxf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/wrapping_paper{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/stack/packageWrap{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "dxy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -31080,6 +30927,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ezb" = (
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "ezf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -31452,6 +31307,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"eQG" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -30
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "eRz" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -31572,16 +31436,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"eVL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "eWq" = (
 /obj/machinery/gulag_item_reclaimer{
 	pixel_y = 24
@@ -31615,6 +31469,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"eXK" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eXX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -31929,6 +31798,14 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"fkg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fkm" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
@@ -32453,18 +32330,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"fBs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/table/wood,
-/obj/item/hand_labeler{
-	pixel_x = 5
-	},
-/obj/item/storage/box/evidence,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
 "fBS" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Head of Security";
@@ -33445,6 +33310,40 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"got" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Common Channel";
+	pixel_x = -27;
+	pixel_y = -3
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_x = 29;
+	pixel_y = -4
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_x = 1;
+	pixel_y = 27
+	},
+/obj/machinery/button/door{
+	id = "AI Door";
+	name = "AI Chamber Blast Door";
+	pixel_x = 28;
+	pixel_y = 28;
+	req_access_txt = "16"
+	},
+/obj/effect/landmark/start/ai,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "goV" = (
 /obj/machinery/camera{
 	c_tag = "Toxins Launch Room Access";
@@ -33649,6 +33548,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"gwG" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/pharmacy)
 "gwP" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -33862,6 +33770,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"gBQ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel,
+/area/science/storage)
 "gBS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -34719,6 +34641,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hkd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "hkj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -36064,19 +35995,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"inM" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel/white,
-/area/science/nanite)
 "ipA" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
@@ -36196,6 +36114,19 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
+"itD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table/wood,
+/obj/item/hand_labeler{
+	pixel_x = 5
+	},
+/obj/item/storage/box/evidence,
+/obj/machinery/newscaster/security_unit{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "itG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -37468,22 +37399,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jwv" = (
-/obj/machinery/camera{
-	c_tag = "Toxins Lab East";
-	dir = 8;
-	network = list("ss13","rd");
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "jwN" = (
 /obj/effect/landmark/start/brig_phys,
 /turf/open/floor/plasteel/white,
@@ -37764,6 +37679,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jIF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "jIG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -38316,6 +38240,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"kaa" = (
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/clothing/glasses/science,
+/obj/machinery/requests_console{
+	department = "Virology";
+	dir = 8;
+	name = "Virology Requests Console";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "kbr" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38826,6 +38773,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"kvF" = (
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/pen,
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	dir = 1;
+	name = "Medbay RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "kvI" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -40271,6 +40232,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"lAm" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "lAw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -40672,6 +40643,16 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"lQi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/science/nanite)
 "lQv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -41292,6 +41273,36 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"mhl" = (
+/obj/structure/table,
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/crowbar,
+/obj/item/radio/headset/headset_sci{
+	pixel_x = -3
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "mhR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -41813,16 +41824,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"mBY" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/department/electrical)
 "mCv" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel,
@@ -42190,14 +42191,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"mKO" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "mLh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -43433,6 +43426,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"nvL" = (
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/radio/headset/headset_med,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/pharmacy)
 "nvU" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -43639,6 +43641,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"nAU" = (
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/wood,
+/area/library)
 "nBp" = (
 /obj/machinery/door/window{
 	name = "Gateway Chamber";
@@ -43861,6 +43870,20 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"nHL" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	dir = 4;
+	name = "Medbay RC";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "nHY" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/red{
@@ -44091,16 +44114,6 @@
 	},
 /turf/closed/wall,
 /area/science/lab)
-"nQk" = (
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "nQy" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/exit";
@@ -44118,20 +44131,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit)
-"nQI" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/radio/headset/headset_med,
-/turf/open/floor/plasteel/white,
-/area/medical/pharmacy)
-"nQK" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "nRf" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -44177,21 +44176,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"nTU" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/emergency,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel,
-/area/storage/tools)
 "nUe" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -44283,20 +44267,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"nZF" = (
-/obj/item/kirbyplants/random,
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science Requests Console";
-	pixel_y = -32;
-	receive_ore_updates = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/nanite)
 "nZT" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -45431,6 +45401,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"oLG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "oLJ" = (
 /obj/machinery/camera{
 	c_tag = "Research and Development";
@@ -46616,6 +46597,16 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
+"pAs" = (
+/obj/machinery/camera{
+	c_tag = "Chapel Office"
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/grimy,
+/area/chapel/office)
 "pAR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -46951,6 +46942,14 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"pMC" = (
+/obj/machinery/processor,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "pMF" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
@@ -47761,44 +47760,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"qqG" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Common Channel";
-	pixel_x = -27;
-	pixel_y = -3
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel";
-	pixel_x = 29;
-	pixel_y = -4
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_x = 1;
-	pixel_y = 27
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -31;
-	pixel_y = 33
-	},
-/obj/machinery/button/door{
-	id = "AI Door";
-	name = "AI Chamber Blast Door";
-	pixel_x = 28;
-	pixel_y = 28;
-	req_access_txt = "16"
-	},
-/obj/effect/landmark/start/ai,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "qqH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -48667,6 +48628,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
+"qXO" = (
+/obj/machinery/camera{
+	c_tag = "Toxins Lab East";
+	dir = 8;
+	network = list("ss13","rd");
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "qXS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49666,6 +49644,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"rGc" = (
+/obj/item/storage/box/lights/mixed,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plating,
+/area/storage/emergency/port)
 "rGg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -50327,6 +50313,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"siM" = (
+/obj/item/kirbyplants/random,
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	dir = 4;
+	name = "Science Requests Console";
+	pixel_x = 32;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/nanite)
 "sjI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -50463,6 +50464,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"spd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "spf" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -50520,6 +50537,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"srH" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "srU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/spawner/structure/window/reinforced/shutters,
@@ -51517,12 +51541,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"tdo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/nanite)
 "tdZ" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/five,
@@ -55947,6 +55965,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"vYo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain)
 "vYy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57849,6 +57877,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"xnN" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/white,
+/area/science/nanite)
 "xoc" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -57970,16 +58009,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"xra" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "xry" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58713,15 +58742,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"xOg" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/teleporter)
 "xOQ" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -73559,7 +73579,7 @@ aNf
 aNf
 aLA
 aQD
-xra
+hkd
 czK
 aUQ
 aUW
@@ -73830,7 +73850,7 @@ beT
 bdQ
 beZ
 bje
-bkC
+ezb
 cAJ
 beO
 aaa
@@ -75345,7 +75365,7 @@ aaf
 atO
 eLZ
 azF
-aAS
+srH
 aFP
 aAQ
 aAQ
@@ -81012,7 +81032,7 @@ iHL
 uRo
 tsw
 aPK
-aSl
+rGc
 aTH
 aPK
 xHr
@@ -81550,7 +81570,7 @@ bjv
 btv
 tia
 bxz
-eVL
+oLG
 uXa
 byy
 bBa
@@ -83324,7 +83344,7 @@ fRs
 iHL
 aOz
 aPQ
-nTU
+bAn
 aTL
 aTP
 tav
@@ -83336,7 +83356,7 @@ nXi
 bcV
 bcV
 bfn
-beW
+dxf
 bfR
 bKF
 bNH
@@ -86129,7 +86149,7 @@ anw
 anR
 aow
 qHT
-fBs
+itD
 dyN
 wUs
 qHT
@@ -87958,7 +87978,7 @@ aWT
 dWX
 cva
 rfO
-nQK
+eQG
 cva
 cva
 cva
@@ -88217,7 +88237,7 @@ cva
 dIq
 ngQ
 cva
-qqG
+got
 dmc
 ggh
 wNr
@@ -90536,7 +90556,7 @@ bgV
 bim
 bjG
 aZV
-bmB
+vYo
 bnZ
 bpl
 bqH
@@ -90771,7 +90791,7 @@ aDG
 aFd
 auk
 uFJ
-aJg
+eXK
 aKo
 aLO
 edR
@@ -91342,10 +91362,10 @@ cbA
 gno
 olz
 hut
-mKO
+fkg
 hyU
 rol
-nQk
+bsv
 cbA
 bQt
 bLQ
@@ -91568,7 +91588,7 @@ wfP
 ybk
 wfP
 cwL
-xOg
+drI
 kIb
 buZ
 buZ
@@ -91821,9 +91841,9 @@ aZV
 aZV
 aZV
 aZV
-bmx
-bmx
-bmx
+aZV
+aZV
+aZV
 bqH
 bqH
 hjI
@@ -92302,7 +92322,7 @@ arf
 ask
 atm
 arf
-avl
+spd
 awq
 axO
 aza
@@ -93102,9 +93122,9 @@ ddj
 wzp
 ddj
 bfF
-nQI
+nvL
 jNM
-bgF
+gwG
 blf
 bmF
 bob
@@ -94658,7 +94678,7 @@ bvh
 bwC
 bxN
 bze
-bAp
+aVf
 bvh
 bCG
 bBd
@@ -96976,7 +96996,7 @@ bvj
 bCN
 bEa
 pHl
-bFA
+nHL
 bIm
 bJD
 bib
@@ -97257,7 +97277,7 @@ ccF
 dhI
 ceE
 cfl
-cfZ
+jIF
 cki
 cld
 alo
@@ -98274,7 +98294,7 @@ bNd
 bfJ
 bUb
 bVa
-bWf
+kaa
 bWX
 bOP
 bNd
@@ -98514,7 +98534,7 @@ bsN
 bvo
 bzl
 bua
-bzd
+kvF
 bhh
 btT
 bCU
@@ -98747,7 +98767,7 @@ aJI
 aRH
 aVz
 aVz
-aVH
+pMC
 fRC
 aYN
 aJI
@@ -98996,7 +99016,7 @@ cVb
 hxM
 aIk
 aIp
-aKW
+lAm
 aMG
 aIp
 aIp
@@ -104142,7 +104162,7 @@ aFw
 aPg
 aQr
 aFu
-aTb
+nAU
 vtb
 aVR
 aYW
@@ -104672,7 +104692,7 @@ biP
 bko
 blE
 udD
-bov
+mhl
 bpU
 brq
 bsW
@@ -104685,7 +104705,7 @@ bAH
 bCb
 bDc
 bEo
-bDf
+gBQ
 oju
 bGY
 bGY
@@ -105161,7 +105181,7 @@ asB
 aCK
 dua
 aFw
-aHg
+pAs
 aIA
 aJT
 aLc
@@ -105218,7 +105238,7 @@ dIJ
 oHa
 uek
 dYq
-inM
+xnN
 wDR
 oVW
 bvv
@@ -105475,7 +105495,7 @@ cSu
 lAR
 eBv
 nEH
-tdo
+lQi
 suU
 wSV
 cIo
@@ -105689,7 +105709,7 @@ aUH
 aTf
 aRS
 aZf
-baA
+aRS
 bbF
 aYV
 aXq
@@ -106717,7 +106737,7 @@ aUK
 aVU
 aWg
 aZf
-baA
+aRS
 bbF
 aYV
 bdv
@@ -106760,7 +106780,7 @@ oNT
 tQL
 ngb
 dYq
-nZF
+siM
 wDR
 hnc
 qdO
@@ -106950,7 +106970,7 @@ aaa
 aaa
 asB
 ije
-mBY
+cAM
 avO
 awU
 ayj
@@ -108546,7 +108566,7 @@ rbk
 sgc
 myK
 iRS
-jwv
+qXO
 iVm
 hKU
 cNW

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1382,9 +1382,6 @@
 /obj/structure/closet/secure_closet/lieutenant,
 /turf/open/floor/carpet/royalblue,
 /area/vacant_room/office)
-"afr" = (
-/turf/closed/wall,
-/area/space)
 "afs" = (
 /obj/machinery/teleport/station,
 /obj/machinery/firealarm{
@@ -2899,22 +2896,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"alf" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/door/airlock/solgov/glass{
-	name = "SolGov offices";
-	req_one_access_txt = "90"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "alh" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -18686,6 +18667,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"bvR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/solgov/glass{
+	name = "SolGov offices";
+	req_one_access_txt = "90"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/office)
 "bvT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33416,8 +33419,8 @@
 /area/science/test_area)
 "cDz" = (
 /turf/closed/indestructible/riveted{
-	name = "hyper-reinforced wall";
-	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease"
+	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
+	name = "hyper-reinforced wall"
 	},
 /area/science/test_area)
 "cDA" = (
@@ -37902,6 +37905,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"cYI" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "cYJ" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -43623,6 +43635,18 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
+"eEK" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "eEU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -44017,6 +44041,10 @@
 	dir = 1
 	},
 /area/engine/atmos)
+"eRe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "eRo" = (
 /obj/machinery/light{
 	dir = 8
@@ -52196,11 +52224,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"iyS" = (
-/obj/effect/spawner/structure/window/reinforced/shutters,
-/obj/structure/curtain/bounty,
-/turf/open/floor/wood,
-/area/vacant_room/office)
 "iyV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -52434,6 +52457,18 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"iFF" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "SolGov Maintenance";
+	req_access_txt = "90"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "iFH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
@@ -54812,6 +54847,13 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"jLy" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "jLL" = (
 /obj/structure/chair/office/light{
 	dir = 1;
@@ -57559,6 +57601,16 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard/aft)
+"kRb" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "kRz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -62845,13 +62897,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"nhJ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/vacant_room/office)
 "nib" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -62903,18 +62948,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"niv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "niC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63449,6 +63482,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
+"ntx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ntH" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/poddoor/preopen{
@@ -65659,6 +65701,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"oss" = (
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/obj/structure/curtain/bounty,
+/turf/open/floor/plating,
+/area/vacant_room/office)
 "osz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -65762,6 +65809,11 @@
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall,
 /area/hydroponics)
+"ouc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/vacant_room/office)
 "oum" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -69046,6 +69098,22 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/fore)
+"pLX" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/door/airlock/solgov/glass{
+	name = "SolGov offices";
+	req_one_access_txt = "90"
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/office)
 "pMd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -70144,6 +70212,13 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"qln" = (
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "qlW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -70781,6 +70856,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"qyC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/curtain/bounty,
+/obj/effect/spawner/structure/window/reinforced/shutters,
+/turf/open/floor/plating,
+/area/vacant_room/office)
 "qyH" = (
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/stripes/line{
@@ -73909,15 +73990,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"rOa" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/vacant_room/office)
 "rOk" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Antechamber";
@@ -76614,14 +76686,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"tdg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
-/turf/open/floor/wood,
-/area/vacant_room/office)
 "tdE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -76874,25 +76938,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"tkz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/solgov/glass{
-	name = "SolGov offices";
-	req_one_access_txt = "90"
-	},
-/turf/open/floor/plasteel,
-/area/vacant_room/office)
 "tkV" = (
 /obj/machinery/power/terminal,
 /obj/machinery/light/small{
@@ -78591,12 +78636,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /turf/open/floor/plating,
 /area/science/mixing)
-"tZt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/curtain/bounty,
-/obj/effect/spawner/structure/window/reinforced/shutters,
-/turf/open/floor/wood,
-/area/vacant_room/office)
 "tZI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -84524,11 +84563,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"wKL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/vacant_room/office)
 "wLe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -87834,17 +87868,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"yfk" = (
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
-/turf/open/floor/wood,
-/area/vacant_room/office)
 "yfz" = (
 /obj/effect/spawner/structure/window/reinforced/shutters,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -119984,13 +120007,13 @@ bzx
 bzx
 bzx
 bzx
-iyS
+oss
 bzx
 bzx
 aiJ
 aiJ
 ore
-tkz
+bvR
 aiJ
 aoJ
 aqa
@@ -120241,13 +120264,13 @@ bzx
 xAi
 rYU
 cgf
-tdg
+eRe
 kKC
-tZt
+qyC
 vlz
 gEU
 agU
-rOa
+eEK
 aiJ
 aoK
 aqa
@@ -120494,7 +120517,7 @@ aaa
 aaa
 aaa
 aaa
-iyS
+oss
 aey
 iim
 pxg
@@ -120504,8 +120527,8 @@ nGU
 nbY
 ieb
 reb
-eim
-agq
+jLy
+iFF
 kIF
 ajD
 arv
@@ -121269,14 +121292,14 @@ afp
 afq
 rYU
 cgf
-tdg
+eRe
 kKC
-tZt
+qyC
 upE
 epW
 aqv
 hll
-agq
+bzx
 hDJ
 ajD
 ajD
@@ -121522,7 +121545,7 @@ aaa
 aaa
 aaa
 aaa
-iyS
+oss
 aey
 iim
 pxg
@@ -121533,7 +121556,7 @@ ieb
 ieb
 reb
 eim
-agq
+bzx
 eow
 oSx
 oSx
@@ -121790,7 +121813,7 @@ vUQ
 aey
 vxT
 fuF
-agq
+bzx
 whe
 agq
 agq
@@ -122047,8 +122070,8 @@ sZv
 aey
 vxT
 fCe
-agq
-niv
+bzx
+ntx
 agq
 ary
 asR
@@ -122301,10 +122324,10 @@ jVr
 uFK
 ugJ
 qde
-qde
+kRb
 reb
 tvu
-agq
+bzx
 umu
 agq
 arz
@@ -122554,14 +122577,14 @@ bzx
 oeY
 ejY
 ejY
-yfk
+qln
 iqY
-wKL
+ouc
 sHy
-nhJ
+cYI
 aqv
 wnG
-acP
+bzx
 xYU
 agq
 arA
@@ -122808,17 +122831,17 @@ aai
 aaa
 aaa
 bzx
-afr
-acP
-acP
-acP
-acP
-acP
-acP
-acP
-alf
-acP
-acP
+bzx
+bzx
+bzx
+bzx
+bzx
+bzx
+bzx
+bzx
+pLX
+bzx
+bzx
 iEf
 acP
 arB

--- a/_maps/map_files/PackedStation/PackedStation.dmm
+++ b/_maps/map_files/PackedStation/PackedStation.dmm
@@ -1627,14 +1627,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
-"alU" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/relic,
-/obj/item/slime_extract,
-/turf/open/floor/plasteel/white,
-/area/science/explab)
 "alY" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
@@ -24899,6 +24891,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"oVQ" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/relic,
+/obj/item/slime_extract/grey,
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "oWN" = (
 /obj/structure/table,
 /obj/item/multitool,
@@ -79247,7 +79247,7 @@ haW
 upK
 aZs
 aTP
-alU
+oVQ
 arh
 aCC
 aZs

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -4086,22 +4086,6 @@
 "km" = (
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kn" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/control)
 "ko" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien20"
@@ -5880,27 +5864,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
-"op" = (
-/obj/structure/table/wood,
-/obj/item/clipboard,
-/obj/item/folder/blue,
-/obj/item/melee/chainofcommand,
-/obj/item/stamp/captain,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "oq" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
@@ -6334,21 +6297,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"pe" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel/grimy,
-/area/centcom/ferry)
-"pf" = (
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel/grimy,
-/area/centcom/ferry)
 "pg" = (
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
@@ -6726,40 +6674,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"pM" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/centcom/ferry)
-"pN" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/under/rank/civilian/curator/treasure_hunter,
-/obj/item/clothing/under/dress/skirt,
-/obj/item/clothing/under/shorts/black,
-/obj/item/clothing/under/pants/track,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/waistcoat,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/neck/stripedredscarf,
-/obj/item/clothing/neck/tie/red,
-/obj/item/clothing/head/helmet/space/beret,
-/obj/item/clothing/suit/curator,
-/obj/item/clothing/suit/space/officer,
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/eyepatch,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/grimy,
-/area/centcom/ferry)
 "pO" = (
 /obj/structure/destructible/cult/tome,
 /obj/item/book/codex_gigas,
@@ -6893,26 +6807,6 @@
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
-"qc" = (
-/obj/structure/table/wood,
-/obj/item/folder/red,
-/obj/item/lighter,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7556,25 +7450,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"rt" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "rv" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -7795,31 +7670,6 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/handcuffs,
 /obj/item/crowbar/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/control)
-"rR" = (
-/obj/item/storage/box/ids{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/silver_ids,
-/obj/structure/table/reinforced,
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -8498,28 +8348,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
-"tC" = (
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "tD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9110,34 +8938,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
-"uX" = (
-/obj/structure/table/wood,
-/obj/item/dice/d20{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/dice/d10{
-	pixel_x = -3
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "uY" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -9172,12 +8972,6 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
 /area/centcom/ferry)
-"vc" = (
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/turf/closed/indestructible/riveted,
-/area/centcom/control)
 "vd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -10672,37 +10466,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
-"yZ" = (
-/obj/structure/table/wood,
-/obj/item/phone{
-	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/cigarette/cigar/cohiba{
-	pixel_x = 6
-	},
-/obj/item/clothing/mask/cigarette/cigar/havana{
-	pixel_x = 2
-	},
-/obj/item/clothing/mask/cigarette/cigar{
-	pixel_x = 4.5
-	},
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "za" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light{
@@ -11559,22 +11322,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"BD" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "BE" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "XCCsec3";
@@ -11881,6 +11628,28 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"Ck" = (
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/item/folder/blue,
+/obj/item/melee/chainofcommand,
+/obj/item/stamp/captain,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Cm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -12248,25 +12017,6 @@
 "CP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
-"CR" = (
-/obj/machinery/computer/security{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -13640,6 +13390,23 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"FV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "FW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -14268,31 +14035,6 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/white,
-/area/tdome/tdomeobserve)
-"Ho" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -8
-	},
-/obj/item/kitchen/knife,
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/tdome/tdomeobserve)
 "Hp" = (
 /obj/machinery/light,
@@ -16882,6 +16624,52 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/one)
+"OR" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"OS" = (
+/obj/structure/table/wood,
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/cigarette/cigar/cohiba{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/cigarette/cigar/havana{
+	pixel_x = 2
+	},
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = 4.5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "OU" = (
 /obj/item/clothing/under/costume/jabroni,
 /obj/item/clothing/under/costume/geisha,
@@ -16890,6 +16678,34 @@
 /obj/item/clothing/under/costume/roman,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"OY" = (
+/obj/structure/table/wood,
+/obj/item/dice/d20{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/dice/d10{
+	pixel_x = -3
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Pa" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/white,
@@ -17287,6 +17103,30 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"Rr" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/item/clothing/under/rank/civilian/curator/treasure_hunter,
+/obj/item/clothing/under/dress/skirt,
+/obj/item/clothing/under/shorts/black,
+/obj/item/clothing/under/pants/track,
+/obj/item/clothing/accessory/armband/deputy,
+/obj/item/clothing/accessory/waistcoat,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/neck/stripedredscarf,
+/obj/item/clothing/neck/tie/red,
+/obj/item/clothing/head/helmet/space/beret,
+/obj/item/clothing/suit/curator,
+/obj/item/clothing/suit/space/officer,
+/obj/item/clothing/gloves/fingerless,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/eyepatch,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "Ru" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -17503,6 +17343,16 @@
 /obj/item/pen/fountain,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"SV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "SW" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/tile/green{
@@ -17557,6 +17407,23 @@
 /obj/structure/closet/chefcloset,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"Ts" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster/security_unit{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/control)
 "Tu" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -17577,6 +17444,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/three)
+"TA" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "TB" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/cafeteria,
@@ -17599,6 +17473,25 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"TS" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/lighter,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "TT" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
@@ -17690,11 +17583,15 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
 "UJ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/centcom/holding)
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "UM" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -17717,6 +17614,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"UR" = (
+/obj/item/storage/box/ids{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/silver_ids,
+/obj/structure/table/reinforced,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/control)
 "UT" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -17727,6 +17650,52 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"UY" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
+"Vj" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8
+	},
+/obj/item/kitchen/knife,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/tdome/tdomeobserve)
 "Vk" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -17915,6 +17884,29 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"Wo" = (
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Ws" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -18232,6 +18224,13 @@
 /obj/item/melee/transforming/energy/ctf,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"XW" = (
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "Ya" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -18320,6 +18319,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
+"YI" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
 "YJ" = (
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -45823,7 +45842,7 @@ CT
 CT
 HH
 Nd
-UJ
+TA
 Ud
 Ud
 NT
@@ -55307,7 +55326,7 @@ WQ
 xh
 WQ
 mD
-yZ
+OS
 pg
 pg
 pg
@@ -55552,7 +55571,7 @@ og
 oB
 oY
 oB
-qc
+TS
 mD
 mD
 mD
@@ -55811,7 +55830,7 @@ oZ
 oB
 qd
 nU
-rt
+UY
 sx
 tx
 up
@@ -57349,15 +57368,15 @@ aa
 nU
 on
 oI
-pe
-pM
+UJ
+SV
 qi
 mD
 ry
 Or
-tC
+Wo
 oB
-uX
+OY
 mD
 su
 ws
@@ -57863,8 +57882,8 @@ iF
 mD
 oo
 oI
-pf
-pN
+XW
+Rr
 qj
 nU
 YG
@@ -58118,7 +58137,7 @@ mG
 nl
 nD
 mD
-op
+Ck
 oK
 pg
 pg
@@ -59182,7 +59201,7 @@ Ge
 Ep
 GF
 GM
-Ho
+Vj
 HB
 HJ
 HU
@@ -59423,7 +59442,7 @@ zj
 pR
 xF
 ZS
-BD
+FV
 pR
 CG
 mD
@@ -64810,8 +64829,8 @@ rM
 sK
 mX
 nw
-vc
-mO
+io
+OR
 nq
 nq
 nq
@@ -66091,7 +66110,7 @@ iu
 io
 io
 io
-rR
+UR
 iC
 mm
 uy
@@ -69448,7 +69467,7 @@ At
 AZ
 qx
 Ch
-CR
+YI
 Dh
 DB
 Yn
@@ -70958,7 +70977,7 @@ aa
 aa
 io
 kh
-kn
+Ts
 kJ
 in
 lA


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just some map maintenance. 

Considering the Box Security PR is losing in votes, putting said wall mount fixes for box in here, as well as reinforcing the Captain's maintenance escape from some previous comments. Also fixed a few I saw on centcom. Fixes the slime extract on Packed. Also fixes the Solgov office on Meta, and the disposal track that was missing under it, as well as added a maintenance door. Whoever added the Solgov office used server room vents instead of normal ones, so they had 0 pressure check...


## Changelog
:cl:
fix: Boxstation: Wallmount fixes, Captain's escape maintenance's external wall is now also R-Wall to address some previous concerns.
fix: Packedstation: Slime Extract is now an actual grey extract for making your own Xenobio
fix: Centcom: Wallmount fixes
fix: Metastation: Solgov office fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
