### PR TITLE
L4Z is useful now, botany vendor prices slashed

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -32,6 +32,7 @@
 	var/self_sufficiency_req = 20 //Required total dose to make a self-sufficient hydro tray. 1:1 with earthsblood.
 	var/self_sufficiency_progress = 0
 	var/self_sustaining = FALSE //If the tray generates nutrients and water on its own
+	var/mutate_yield = 0 // WS spritercode edit: makes L4Z worth a damn
 
 
 /obj/machinery/hydroponics/constructable
@@ -511,16 +512,19 @@
 	if(S.has_reagent(/datum/reagent/plantnutriment/eznutriment, 1))
 		yieldmod = 1
 		mutmod = 1
+		mutate_yield = 0
 		adjustNutri(round(S.get_reagent_amount(/datum/reagent/plantnutriment/eznutriment) * 1))
 
 	if(S.has_reagent(/datum/reagent/plantnutriment/left4zednutriment, 1))
 		yieldmod = 0
 		mutmod = 2
+		mutate_yield = 1 //ws edit: L4Z is worth a damn now
 		adjustNutri(round(S.get_reagent_amount(/datum/reagent/plantnutriment/left4zednutriment) * 1))
 
 	if(S.has_reagent(/datum/reagent/plantnutriment/robustharvestnutriment, 1))
 		yieldmod = 1.3
 		mutmod = 0
+		mutate_yield = 0
 		adjustNutri(round(S.get_reagent_amount(/datum/reagent/plantnutriment/robustharvestnutriment) *1 ))
 
 	// Ambrosia Gaia produces earthsblood.

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -165,7 +165,26 @@
 	var/output_loc = parent.Adjacent(user) ? user.loc : parent.loc //needed for TK
 	var/product_name
 	while(t_amount < getYield())
-		var/obj/item/reagent_containers/food/snacks/grown/t_prod = new product(output_loc, src)
+		var/obj/item/reagent_containers/food/snacks/grown/t_prod
+		if(parent.mutate_yield == 1 && LAZYLEN(mutatelist) && prob(20))
+			var/obj/item/seeds/new_prod = pick(mutatelist)
+			t_prod = initial(new_prod.product)
+			if(!t_prod)
+				continue
+			t_prod = new t_prod(output_loc, src)
+			t_prod.seed = new new_prod
+			t_prod.seed.name = initial(new_prod.name)
+			t_prod.seed.desc = initial(new_prod.desc)
+			t_prod.seed.plantname = initial(new_prod.plantname)
+			for(var/datum/plant_gene/trait/trait in parent.myseed.genes)
+				if(trait.can_add(t_prod.seed))
+					t_prod.seed.genes += trait
+			t_prod.transform = initial(t_prod.transform)
+			t_prod.transform *= TRANSFORM_USING_VARIABLE(t_prod.seed.potency, 100) + 0.5
+			t_amount++
+			continue
+		else
+			t_prod = new product(output_loc, src)
 		if(parent.myseed.plantname != initial(parent.myseed.plantname))
 			t_prod.name = lowertext(parent.myseed.plantname)
 		if(productdesc)

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -54,8 +54,8 @@
 					/obj/item/seeds/random = 2)
 	premium = list(/obj/item/reagent_containers/spray/waterflower = 1)
 	refill_canister = /obj/item/vending_refill/hydroseeds
-	default_price = 100
-	extra_price = 350
+	default_price = 50
+	extra_price = 150
 	payment_department = ACCOUNT_SRV
 
 /obj/item/vending_refill/hydroseeds

--- a/code/modules/vending/nutrimax.dm
+++ b/code/modules/vending/nutrimax.dm
@@ -18,8 +18,8 @@
 	contraband = list(/obj/item/reagent_containers/glass/bottle/ammonia = 10,
 					  /obj/item/reagent_containers/glass/bottle/diethylamine = 5)
 	refill_canister = /obj/item/vending_refill/hydronutrients
-	default_price = 100
-	extra_price = 250
+	default_price = 50
+	extra_price = 150
 	payment_department = ACCOUNT_SRV
 
 /obj/item/vending_refill/hydronutrients


### PR DESCRIPTION
most of the code for the L4Z mutant produce stuff was indirectly ripped from https://github.com/tgstation/tgstation/pull/52366.

## About The Pull Request

L4Z gives a 20% chance for a plant to produce a mutant produce instead of regular produce when you harvest from it now (ex: harvest grass dosed with L4Z, 20% chance for it to produce fairygrass or carpet instead)

stuff from the botany vendors cost 50 cr instead of 100, and the contraband selections cost 150 cr instead of 350/250.

## Why It's Good For The Game

botany no longer gets The Botany Experience when they try to buy cannabis seeds or ammonia bottles and L4Z is now a viable mutagen. What's not to love?

## Changelog
:cl:
add: L4Z now has a chance to make your plants produce mutated... produce.
tweak: botany vendor prices have dropped
/:cl: