### PR TITLE
Pre-roundend "New round" discord notification

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -322,7 +322,8 @@
 				mode = SHUTTLE_DOCKED
 				setTimer(SSshuttle.emergencyDockTime)
 				send2tgs("Server", "The Emergency Shuttle has docked with the station.")
-				SSredbot.send_discord_message("admin","The escape shuttle has docked with the station.","round ending event")
+				SSredbot.send_discord_message("admin", "The escape shuttle has docked with the station.","round ending event")
+				SSredbot.send_discord_message("newround", "The escape shuttle has docked with the station. New round imminent!")
 				priority_announce("[SSshuttle.emergency] has docked with the station. You have [timeLeft(600)] minutes to board the Emergency Shuttle.", null, 'sound/ai/shuttledock.ogg', "Priority")
 				ShuttleDBStuff()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what the title says

## Why It's Good For The Game
People are complaining about not having enough time to join the game before roundstart after being pinged

## Changelog
:cl:
add: New discord notification for when the emergency shuttle has docked with the station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
