### PR TITLE
Fix lockbox sprite

### DIFF
--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -10,8 +10,8 @@
 	req_access = list(ACCESS_ARMORY)
 	var/broken = FALSE
 	var/open = FALSE
-	var/icon_locked = "lockbox+l"
-	var/icon_closed = "lockbox"
+	var/icon_locked = "lockbox"
+	var/icon_closed = "lockbox+l"
 	var/icon_broken = "lockbox+b"
 
 /obj/item/storage/lockbox/ComponentInitialize()

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -10,8 +10,8 @@
 	req_access = list(ACCESS_ARMORY)
 	var/broken = FALSE
 	var/open = FALSE
-	var/icon_locked = "lockbox"
-	var/icon_closed = "lockbox+l"
+	var/icon_locked = "lockbox" //Waspstation edit - fix lockbox sprites
+	var/icon_closed = "lockbox+l" //Waspstation edit - fix lockbox sprites
 	var/icon_broken = "lockbox+b"
 
 /obj/item/storage/lockbox/ComponentInitialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the implant lockbox sprite to be green when unlocked and red when locked.

## Why It's Good For The Game

Makes it in-line with other electronic locks, like lockers.

## Changelog
:cl:
fix: Implant lockboxes are now green when unlocked and red when locked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
