### PR TITLE
Hugging a mothperson now puts dust on you

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -106,6 +106,10 @@
 	if(isliving(A))
 		check_heat(A)
 
+	if(iscarbon(A))
+		var/mob/living/carbon/C = A
+		C.mothdust -= 10;
+
 /obj/machinery/shower/process()
 	if(on)
 		wash_atom(loc)

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -106,7 +106,7 @@
 	if(isliving(A))
 		check_heat(A)
 
-	if(iscarbon(A))
+	if(iscarbon(A)) //WS edit - moth dust from hugging
 		var/mob/living/carbon/C = A
 		C.mothdust -= 10;
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -270,13 +270,25 @@
 						null, "<span class='hear'>You hear the rustling of clothes.</span>", DEFAULT_MESSAGE_RANGE, list(M, src))
 		to_chat(M, "<span class='notice'>You shake [src] trying to pick [p_them()] up!</span>")
 		to_chat(src, "<span class='notice'>[M] shakes you to get you up!</span>")
+		if(istype(M.dna.species, /datum/species/moth)) //Wasp edit - moth dust from hugging
+			mothdust += 10;
+		if(istype(dna.species, /datum/species/moth))
+			M.mothdust += 10; // End wasp edit
 	else if(check_zone(M.zone_selected) == BODY_ZONE_HEAD) //Headpats!
 		M.visible_message("<span class='notice'>[M] gives [src] a pat on the head to make [p_them()] feel better!</span>", \
 					"<span class='notice'>You give [src] a pat on the head to make [p_them()] feel better!</span>")
+		if(istype(M.dna.species, /datum/species/moth)) //Wasp edit - moth dust from hugging
+			mothdust += 5;
+		if(istype(dna.species, /datum/species/moth))
+			M.mothdust += 5; // End Wasp edit
 
 	else if(M.zone_selected == BODY_ZONE_CHEST || M.zone_selected == BODY_ZONE_PRECISE_GROIN)			// Wasp Edit - Adds more help emotes
 		M.visible_message("<span class='notice'>[M] hugs [src] to make [p_them()] feel better!</span>", \
 					"<span class='notice'>You hug [src] to make [p_them()] feel better!</span>")
+		if(istype(M.dna.species, /datum/species/moth)) //Wasp edit - moth dust from hugging
+			mothdust += 15; 
+		if(istype(dna.species, /datum/species/moth))
+			M.mothdust += 15; // End Wasp edit
 
 		// Warm them up with hugs
 		share_bodytemperature(M)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -270,25 +270,25 @@
 						null, "<span class='hear'>You hear the rustling of clothes.</span>", DEFAULT_MESSAGE_RANGE, list(M, src))
 		to_chat(M, "<span class='notice'>You shake [src] trying to pick [p_them()] up!</span>")
 		to_chat(src, "<span class='notice'>[M] shakes you to get you up!</span>")
-		if(istype(M.dna.species, /datum/species/moth)) //Wasp edit - moth dust from hugging
+		if(istype(M.dna.species, /datum/species/moth)) //WS edit - moth dust from hugging
 			mothdust += 10;
 		if(istype(dna.species, /datum/species/moth))
-			M.mothdust += 10; // End wasp edit
+			M.mothdust += 10; // End WS edit
 	else if(check_zone(M.zone_selected) == BODY_ZONE_HEAD) //Headpats!
 		M.visible_message("<span class='notice'>[M] gives [src] a pat on the head to make [p_them()] feel better!</span>", \
 					"<span class='notice'>You give [src] a pat on the head to make [p_them()] feel better!</span>")
-		if(istype(M.dna.species, /datum/species/moth)) //Wasp edit - moth dust from hugging
+		if(istype(M.dna.species, /datum/species/moth)) //WS edit - moth dust from hugging
 			mothdust += 5;
 		if(istype(dna.species, /datum/species/moth))
-			M.mothdust += 5; // End Wasp edit
+			M.mothdust += 5; // End WS edit
 
 	else if(M.zone_selected == BODY_ZONE_CHEST || M.zone_selected == BODY_ZONE_PRECISE_GROIN)			// Wasp Edit - Adds more help emotes
 		M.visible_message("<span class='notice'>[M] hugs [src] to make [p_them()] feel better!</span>", \
 					"<span class='notice'>You hug [src] to make [p_them()] feel better!</span>")
-		if(istype(M.dna.species, /datum/species/moth)) //Wasp edit - moth dust from hugging
+		if(istype(M.dna.species, /datum/species/moth)) //WS edit - moth dust from hugging
 			mothdust += 15; 
 		if(istype(dna.species, /datum/species/moth))
-			M.mothdust += 15; // End Wasp edit
+			M.mothdust += 15; // End WS edit
 
 		// Warm them up with hugs
 		share_bodytemperature(M)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -82,3 +82,6 @@
 
 	/// Timer id of any transformation
 	var/transformation_timer
+
+	/// Wasp edit - moth dust when hugging
+	var/mothdust

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -83,5 +83,5 @@
 	/// Timer id of any transformation
 	var/transformation_timer
 
-	/// Wasp edit - moth dust when hugging
+	/// WS edit - moth dust when hugging
 	var/mothdust

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -85,4 +85,3 @@
 
 	/// Wasp edit - moth dust when hugging
 	var/mothdust
-	

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -85,3 +85,4 @@
 
 	/// Wasp edit - moth dust when hugging
 	var/mothdust
+	

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -132,13 +132,13 @@
 			if(MOOD_LEVEL_HAPPY4 to INFINITY)
 				. += "[t_He] look[p_s()] ecstatic."
 
-	switch(mothdust) //Wasp edit - moth dust from hugging
+	switch(mothdust) //WS edit - moth dust from hugging
 		if(1 to 50)
 			. += "[t_He] [t_is] a little dusty."
 		if(51 to 150)
 			. += "[t_He] [t_has] a layer of shimmering dust on them."
 		if(151 to INFINITY)
-			. += "[t_He] [t_is] covered in glistening dust!" // End Wasp edit
+			. += "[t_He] [t_is] covered in glistening dust!" //WS Wasp edit
 
 	. += "*---------*</span>"
 

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -131,6 +131,15 @@
 				. += "[t_He] look[p_s()] very happy."
 			if(MOOD_LEVEL_HAPPY4 to INFINITY)
 				. += "[t_He] look[p_s()] ecstatic."
+
+	switch(mothdust) //Wasp edit - moth dust from hugging
+		if(1 to 50)
+			. += "[t_He] [t_is] a little dusty."
+		if(51 to 150)
+			. += "[t_He] [t_has] a layer of shimmering dust on them."
+		if(151 to INFINITY)
+			. += "[t_He] [t_is] covered in glistening dust!" // End Wasp edit
+
 	. += "*---------*</span>"
 
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -138,7 +138,7 @@
 		if(51 to 150)
 			. += "[t_He] [t_has] a layer of shimmering dust on them."
 		if(151 to INFINITY)
-			. += "[t_He] [t_is] covered in glistening dust!" //WS Wasp edit
+			. += "[t_He] [t_is] covered in glistening dust!" //End WS edit
 
 	. += "*---------*</span>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -318,6 +318,14 @@
 	if (length(msg))
 		. += "<span class='warning'>[msg.Join("")]</span>"
 
+	switch(mothdust) //Wasp edit - moth dust from hugging
+		if(1 to 50)
+			. += "[t_He] [t_is] a little dusty."
+		if(51 to 150)
+			. += "[t_He] [t_has] a layer of shimmering dust on [t_him]."
+		if(151 to INFINITY)
+			. += "<b>[t_He] [t_is] covered in glistening dust!</b>" // End Wasp edit
+
 	var/trait_exam = common_trait_examine()
 	if (!isnull(trait_exam))
 		. += trait_exam

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -318,13 +318,13 @@
 	if (length(msg))
 		. += "<span class='warning'>[msg.Join("")]</span>"
 
-	switch(mothdust) //Wasp edit - moth dust from hugging
+	switch(mothdust) //WS edit - moth dust from hugging
 		if(1 to 50)
 			. += "[t_He] [t_is] a little dusty."
 		if(51 to 150)
 			. += "[t_He] [t_has] a layer of shimmering dust on [t_him]."
 		if(151 to INFINITY)
-			. += "<b>[t_He] [t_is] covered in glistening dust!</b>" // End Wasp edit
+			. += "<b>[t_He] [t_is] covered in glistening dust!</b>" //WS Wasp edit
 
 	var/trait_exam = common_trait_examine()
 	if (!isnull(trait_exam))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -324,7 +324,7 @@
 		if(51 to 150)
 			. += "[t_He] [t_has] a layer of shimmering dust on [t_him]."
 		if(151 to INFINITY)
-			. += "<b>[t_He] [t_is] covered in glistening dust!</b>" //WS Wasp edit
+			. += "<b>[t_He] [t_is] covered in glistening dust!</b>" //End WS edit
 
 	var/trait_exam = common_trait_examine()
 	if (!isnull(trait_exam))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -34,7 +34,7 @@
 		if(stat != DEAD)
 			handle_brain_damage()
 
-		mothdust = max(0, mothdust - 1); //Wasp edit - moth dust when hugging
+		mothdust = max(0, mothdust - 1); //WS edit - moth dust when hugging
 	else
 		. = ..()
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -34,6 +34,7 @@
 		if(stat != DEAD)
 			handle_brain_damage()
 
+		mothdust = max(0, mothdust - 1); //Wasp edit - moth dust when hugging
 	else
 		. = ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When you hug, shake, or pat a mothperson, you will get a little bit of "moth dust" on you. 15 for hugging, 10 for shaking, and 5 for headpatting. This goes down at the rate of 1 per life-tick, about every 2 seconds.

Depending on how dusty you are, it will be visible when someone examines you.

When you are under a shower, you will rapidly lose moth dust.

## Why It's Good For The Game

momf

## Changelog
:cl:
add: Hugging, petting, or shaking a mothperson will now get moth dust on you, visible on examine. It goes away after a while, or if you shower.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
