### PR TITLE
Increase flavor text cutoff

### DIFF
--- a/waspstation/code/modules/mob/say_vr.dm
+++ b/waspstation/code/modules/mob/say_vr.dm
@@ -24,10 +24,10 @@
 /mob/proc/print_flavor_text()
 	if(flavor_text && flavor_text != "")
 		var/msg = replacetext(flavor_text, "\n", " ")
-		if(length(msg) <= 40)
+		if(length(msg) <= 100)
 			return "<span class='notice'>[msg]</span>"
 		else
-			return "<span class='notice'>[copytext(msg, 1, 37)]... <a href=\"byond://?src=\ref[src];flavor_more=1\">More...</span></a>"
+			return "<span class='notice'>[copytext(msg, 1, 97)]... <a href=\"byond://?src=\ref[src];flavor_more=1\">More...</span></a>"
 
 
 /mob/proc/get_top_level_mob()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increase the cutoff for flavor text characters from 40 to 100 characters before it truncates it.

## Why It's Good For The Game

This should hopefully allow people with only a couple of sentences of flavor text to not have the sentence cut off halfway through, and then it's just a few extra words when expanded.

## Changelog
:cl:
tweak: More of a character's flavor text will be shown before it is truncated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
