### PR TITLE
Drunk driving

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/drunk_driving.dmm
+++ b/_maps/RandomRuins/SpaceRuins/drunk_driving.dmm
@@ -2,6 +2,12 @@
 "ak" = (
 /turf/closed/wall/mineral/titanium,
 /area/ruin/space/has_grav/drunk_driving)
+"aq" = (
+/obj/machinery/atmospherics/components/unary/tank/toxins{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
 "ax" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -27,10 +33,30 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
+"bx" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/obj/item/stack/sheet/mineral/titanium,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/turf_decal/stripes/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
 "bA" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"dE" = (
+/obj/machinery/atmospherics/pipe/manifold/general/hidden,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/turf_decal/stripes/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/ruin/space/has_grav/drunk_driving)
 "ef" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -55,6 +81,19 @@
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"gS" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/stripes/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
 "hx" = (
 /obj/machinery/door/airlock/external,
@@ -88,6 +127,17 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
+"kp" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/turf_decal/stripes/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
 "kr" = (
 /obj/item/pickaxe/drill,
 /obj/structure/rack,
@@ -95,22 +145,19 @@
 /obj/item/storage/bag/ore,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/drunk_driving)
+"kM" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/turf_decal/stripes/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
 "lL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/airless,
-/area/ruin/space/has_grav/drunk_driving)
-"ma" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/red{
-	dir = 1
-	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
 "mk" = (
@@ -162,18 +209,18 @@
 	icon_state = "floorscorched2"
 	},
 /area/ruin/space/has_grav/drunk_driving)
+"sw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/red,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
 "sD" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/closed/mineral/random,
-/area/ruin/space/has_grav/drunk_driving)
-"tK" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/hidden,
-/obj/effect/turf_decal/stripes/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/airless{
-	icon_state = "floorscorched2"
-	},
 /area/ruin/space/has_grav/drunk_driving)
 "uc" = (
 /obj/structure/table,
@@ -204,6 +251,21 @@
 /obj/item/multitool,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
+"vC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/turf_decal/stripes/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
 "ws" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 8
@@ -226,15 +288,6 @@
 /obj/structure/table,
 /turf/closed/mineral/random,
 /area/ruin/space/has_grav/drunk_driving)
-"zV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump,
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/stripes/red,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/drunk_driving)
 "Af" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 8
@@ -248,15 +301,6 @@
 /area/ruin/space/has_grav/drunk_driving)
 "Bj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8
-	},
-/turf/open/floor/plasteel/airless,
-/area/ruin/space/has_grav/drunk_driving)
-"Bx" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red{
 	dir = 8
 	},
 /turf/open/floor/plasteel/airless,
@@ -289,6 +333,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/drunk_driving)
+"DB" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/gibspawner/human,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
 "DG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -300,23 +354,17 @@
 /obj/effect/decal/cleanable/plasma,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/drunk_driving)
-"El" = (
-/obj/item/chair,
-/turf/open/floor/plasteel/airless,
-/area/ruin/space/has_grav/drunk_driving)
-"Em" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1
-	},
+"Ek" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/effect/decal/cleanable/plasma,
 /obj/effect/turf_decal/stripes/red{
-	dir = 1
+	dir = 8
 	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"El" = (
+/obj/item/chair,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
 "EW" = (
@@ -337,10 +385,6 @@
 /turf/open/floor/plasteel/airless{
 	icon_state = "floorscorched2"
 	},
-/area/ruin/space/has_grav/drunk_driving)
-"GG" = (
-/obj/machinery/atmospherics/components/unary/tank/toxins,
-/turf/open/floor/plasteel,
 /area/ruin/space/has_grav/drunk_driving)
 "GX" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -383,12 +427,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
-"Kq" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/effect/decal/cleanable/vomit/old,
-/obj/effect/turf_decal/stripes/red,
-/turf/open/floor/plasteel/airless,
-/area/ruin/space/has_grav/drunk_driving)
 "KL" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 8
@@ -397,6 +435,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/wirecutters,
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"Lc" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general/hidden,
+/obj/effect/turf_decal/stripes/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless{
+	icon_state = "floorscorched2"
+	},
 /area/ruin/space/has_grav/drunk_driving)
 "Lr" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -423,17 +470,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/drunk_driving)
-"Ni" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/effect/turf_decal/stripes/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/drunk_driving)
 "NR" = (
 /obj/item/stack/sheet/mineral/bananium,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -447,16 +483,6 @@
 /obj/machinery/light/broken{
 	dir = 1
 	},
-/turf/open/floor/plasteel/airless,
-/area/ruin/space/has_grav/drunk_driving)
-"OP" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/vomit/old,
-/obj/effect/gibspawner/human,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
 "OU" = (
@@ -478,19 +504,17 @@
 "Si" = (
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
-"TK" = (
-/obj/machinery/atmospherics/pipe/manifold/general/hidden,
-/obj/effect/decal/cleanable/vomit/old,
-/obj/effect/turf_decal/stripes/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/drunk_driving)
 "Ur" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"UA" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/turf_decal/stripes/red,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
 "UI" = (
@@ -499,16 +523,6 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/cable_coil/cut,
-/turf/open/floor/plasteel/airless,
-/area/ruin/space/has_grav/drunk_driving)
-"UR" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/vomit/old,
-/obj/effect/turf_decal/stripes/red{
-	dir = 8
-	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
 "UU" = (
@@ -528,18 +542,6 @@
 /obj/item/shard,
 /obj/machinery/light/broken{
 	dir = 8
-	},
-/turf/open/floor/plasteel/airless,
-/area/ruin/space/has_grav/drunk_driving)
-"XU" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/obj/item/stack/sheet/mineral/titanium,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/effect/turf_decal/stripes/red{
-	dir = 4
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
@@ -681,7 +683,7 @@ ak
 ak
 hN
 ak
-Bx
+Ek
 ak
 hN
 hN
@@ -697,7 +699,7 @@ hN
 ak
 ze
 pO
-TK
+dE
 NR
 fi
 ak
@@ -719,7 +721,7 @@ hN
 ak
 CI
 CJ
-Ni
+kp
 pL
 kr
 ak
@@ -757,19 +759,19 @@ hN
 hN
 hN
 ak
-zV
+sw
 RG
 Pm
 RG
-ma
+gS
 wA
-tK
+Lc
 ov
-Kq
+UA
 RG
 IL
 Eb
-Em
+vC
 ak
 hN
 hN
@@ -823,7 +825,7 @@ hN
 hN
 hN
 ak
-GG
+aq
 ak
 hN
 ak
@@ -873,7 +875,7 @@ hN
 ak
 ax
 El
-XU
+bx
 IP
 El
 LN
@@ -917,7 +919,7 @@ hN
 ak
 vb
 Gm
-UR
+kM
 Xp
 zv
 LN
@@ -938,7 +940,7 @@ hN
 hN
 et
 OU
-OP
+DB
 Bj
 hB
 ei

--- a/_maps/RandomRuins/SpaceRuins/drunk_driving.dmm
+++ b/_maps/RandomRuins/SpaceRuins/drunk_driving.dmm
@@ -1,0 +1,1191 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ak" = (
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/has_grav/drunk_driving)
+"ax" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"aS" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/drunk_driving)
+"bb" = (
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"bg" = (
+/obj/machinery/light/broken,
+/obj/item/storage/belt,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"bA" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"ef" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"ei" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 1
+	},
+/turf/closed/mineral/random,
+/area/ruin/space/has_grav/drunk_driving)
+"et" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/drunk_driving)
+"fi" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"hq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"hx" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/drunk_driving)
+"hB" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/item/stack/sheet/mineral/titanium,
+/obj/item/wrench,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"hN" = (
+/turf/open/space/basic,
+/area/space)
+"iq" = (
+/obj/machinery/atmospherics/pipe/manifold/general/hidden,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"kc" = (
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"kn" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"kr" = (
+/obj/item/pickaxe/drill,
+/obj/structure/rack,
+/obj/item/mining_scanner,
+/obj/item/storage/bag/ore,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"lL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"mk" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"mX" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/airless{
+	icon_state = "floorscorched2"
+	},
+/area/ruin/space/has_grav/drunk_driving)
+"ov" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"oF" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/screwdriver,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"pL" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/item/stack/sheet/mineral/gold/five,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"pO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/crowbar,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"rC" = (
+/obj/item/stack/sheet/mineral/titanium,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/airless{
+	icon_state = "floorscorched2"
+	},
+/area/ruin/space/has_grav/drunk_driving)
+"sD" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/closed/mineral/random,
+/area/ruin/space/has_grav/drunk_driving)
+"uc" = (
+/obj/structure/table,
+/obj/item/weldingtool/largetank,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"uo" = (
+/turf/open/floor/plasteel/airless{
+	icon_state = "floorscorched2"
+	},
+/area/ruin/space/has_grav/drunk_driving)
+"up" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"uq" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/eastright,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/drunk_driving)
+"vb" = (
+/obj/structure/table,
+/obj/item/multitool,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"ws" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"wA" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"ze" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"zv" = (
+/obj/structure/table,
+/turf/closed/mineral/random,
+/area/ruin/space/has_grav/drunk_driving)
+"zB" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"Af" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"An" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"AY" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/obj/item/stack/sheet/mineral/titanium,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"Bj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"Cm" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/drunk_driving)
+"Cw" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 1
+	},
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"CC" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"CI" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"CJ" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/item/stack/sheet/mineral/plasma/five,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"DG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"Eb" = (
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"El" = (
+/obj/item/chair,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"En" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"EW" = (
+/obj/machinery/atmospherics/pipe/manifold/general/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"Gm" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"Gn" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/airless{
+	icon_state = "floorscorched2"
+	},
+/area/ruin/space/has_grav/drunk_driving)
+"GG" = (
+/obj/machinery/atmospherics/components/unary/tank/toxins,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"GX" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/airless{
+	icon_state = "floorscorched2"
+	},
+/area/ruin/space/has_grav/drunk_driving)
+"Ix" = (
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/obj/item/shard,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"IL" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"IP" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/stack/sheet/mineral/titanium,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"IV" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/drunk_driving)
+"IY" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"KL" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/wirecutters,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"Lr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"LA" = (
+/obj/machinery/door/airlock/external,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/drunk_driving)
+"LN" = (
+/turf/closed/mineral/random,
+/area/ruin/space/has_grav/drunk_driving)
+"Mq" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"MN" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"Nb" = (
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"NR" = (
+/obj/item/stack/sheet/mineral/bananium,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"NX" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general/hidden,
+/turf/open/floor/plasteel/airless{
+	icon_state = "floorscorched2"
+	},
+/area/ruin/space/has_grav/drunk_driving)
+"Oa" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"OD" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"OU" = (
+/obj/structure/frame/computer{
+	anchored = 1
+	},
+/obj/item/shard,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"Pm" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"PQ" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"RG" = (
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"Si" = (
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"Ur" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"UI" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"UU" = (
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/drunk_driving)
+"WE" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/drunk_driving)
+"Xp" = (
+/obj/item/shard,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"Xu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
+"Yd" = (
+/obj/item/stack/sheet/mineral/titanium,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"Yv" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/turf/closed/mineral/random,
+/area/ruin/space/has_grav/drunk_driving)
+"ZD" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+
+(1,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+"}
+(2,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+"}
+(3,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+"}
+(4,1,1) = {"
+hN
+hN
+ak
+aS
+ak
+hN
+hN
+hN
+ak
+LA
+ak
+hN
+hN
+hN
+ak
+aS
+ak
+hN
+hN
+hN
+"}
+(5,1,1) = {"
+hN
+hN
+ak
+uq
+ak
+hN
+hN
+ak
+ak
+UU
+ak
+ak
+hN
+hN
+ak
+uq
+ak
+hN
+hN
+hN
+"}
+(6,1,1) = {"
+hN
+hN
+ak
+Af
+ak
+hN
+ak
+ak
+ak
+hx
+ak
+ak
+ak
+hN
+ak
+ZD
+ak
+hN
+hN
+hN
+"}
+(7,1,1) = {"
+hN
+hN
+ak
+Af
+ak
+hN
+ak
+ze
+pO
+iq
+NR
+fi
+ak
+hN
+ak
+Ur
+ak
+hN
+hN
+hN
+"}
+(8,1,1) = {"
+hN
+hN
+ak
+Af
+ak
+hN
+ak
+CI
+CJ
+MN
+pL
+kr
+ak
+hN
+ak
+oF
+ak
+hN
+hN
+hN
+"}
+(9,1,1) = {"
+hN
+hN
+ak
+up
+ak
+IV
+ak
+ak
+ak
+Nb
+ak
+ak
+ak
+IV
+ak
+ef
+ak
+hN
+hN
+hN
+"}
+(10,1,1) = {"
+hN
+hN
+ak
+Xu
+RG
+Pm
+RG
+En
+wA
+NX
+ov
+PQ
+RG
+IL
+Eb
+hq
+ak
+hN
+hN
+hN
+"}
+(11,1,1) = {"
+hN
+hN
+ak
+KL
+ak
+IV
+ak
+OD
+Mq
+ws
+Lr
+bg
+ak
+IV
+ak
+GX
+WE
+hN
+hN
+hN
+"}
+(12,1,1) = {"
+hN
+hN
+ak
+mk
+ak
+hN
+ak
+kc
+DG
+bb
+Cw
+An
+ak
+hN
+Cm
+mX
+Cm
+hN
+hN
+hN
+"}
+(13,1,1) = {"
+hN
+hN
+ak
+GG
+ak
+hN
+ak
+uc
+Si
+UI
+Gn
+rC
+WE
+hN
+Cm
+uo
+ak
+hN
+hN
+hN
+"}
+(14,1,1) = {"
+hN
+hN
+ak
+ak
+ak
+hN
+ak
+CC
+lL
+EW
+bA
+Yd
+ak
+hN
+WE
+ak
+WE
+hN
+hN
+hN
+"}
+(15,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+hN
+ak
+ax
+El
+AY
+IP
+El
+LN
+LN
+hN
+hN
+hN
+hN
+hN
+hN
+"}
+(16,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+hN
+ak
+ak
+ak
+Ix
+ak
+LN
+LN
+LN
+LN
+hN
+LN
+hN
+hN
+hN
+"}
+(17,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+hN
+ak
+vb
+Gm
+zB
+Xp
+zv
+LN
+LN
+LN
+LN
+LN
+LN
+hN
+hN
+"}
+(18,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+hN
+et
+OU
+Oa
+Bj
+hB
+ei
+sD
+LN
+LN
+LN
+LN
+LN
+hN
+hN
+"}
+(19,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+LN
+sD
+IV
+kn
+IY
+Yv
+sD
+sD
+LN
+LN
+LN
+LN
+LN
+hN
+hN
+"}
+(20,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+LN
+LN
+IV
+IV
+IV
+sD
+sD
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+hN
+"}
+(21,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+hN
+"}
+(22,1,1) = {"
+hN
+hN
+hN
+hN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+hN
+"}
+(23,1,1) = {"
+hN
+hN
+hN
+hN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+hN
+"}
+(24,1,1) = {"
+hN
+hN
+hN
+hN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+hN
+"}
+(25,1,1) = {"
+hN
+hN
+hN
+hN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+hN
+"}
+(26,1,1) = {"
+hN
+hN
+hN
+hN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+hN
+hN
+"}
+(27,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+hN
+hN
+"}
+(28,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+LN
+LN
+LN
+hN
+LN
+LN
+LN
+LN
+hN
+hN
+hN
+hN
+hN
+"}
+(29,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+LN
+LN
+LN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+"}
+(30,1,1) = {"
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+hN
+"}

--- a/_maps/RandomRuins/SpaceRuins/drunk_driving.dmm
+++ b/_maps/RandomRuins/SpaceRuins/drunk_driving.dmm
@@ -56,18 +56,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/drunk_driving)
-"hq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/effect/decal/cleanable/plasma,
-/turf/open/floor/plasteel/airless,
-/area/ruin/space/has_grav/drunk_driving)
 "hx" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -87,11 +75,6 @@
 "hN" = (
 /turf/open/space/basic,
 /area/space)
-"iq" = (
-/obj/machinery/atmospherics/pipe/manifold/general/hidden,
-/obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/drunk_driving)
 "kc" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plasteel/airless,
@@ -115,6 +98,19 @@
 "lL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"ma" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/stripes/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
 "mk" = (
@@ -170,6 +166,15 @@
 /obj/effect/spawner/structure/window/shuttle,
 /turf/closed/mineral/random,
 /area/ruin/space/has_grav/drunk_driving)
+"tK" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general/hidden,
+/obj/effect/turf_decal/stripes/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless{
+	icon_state = "floorscorched2"
+	},
+/area/ruin/space/has_grav/drunk_driving)
 "uc" = (
 /obj/structure/table,
 /obj/item/weldingtool/largetank,
@@ -221,12 +226,14 @@
 /obj/structure/table,
 /turf/closed/mineral/random,
 /area/ruin/space/has_grav/drunk_driving)
-"zB" = (
+"zV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/plasteel/airless,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/red,
+/turf/open/floor/plasteel,
 /area/ruin/space/has_grav/drunk_driving)
 "Af" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -239,17 +246,17 @@
 /obj/effect/decal/cleanable/plasma,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
-"AY" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/obj/item/stack/sheet/mineral/titanium,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/airless,
-/area/ruin/space/has_grav/drunk_driving)
 "Bj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"Bx" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red{
 	dir = 8
 	},
 /turf/open/floor/plasteel/airless,
@@ -297,13 +304,18 @@
 /obj/item/chair,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
-"En" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/structure/cable{
-	icon_state = "0-4"
+"Em" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/turf_decal/stripes/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
@@ -371,6 +383,12 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
+"Kq" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/turf_decal/stripes/red,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
 "KL" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 8
@@ -398,14 +416,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
-"MN" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/drunk_driving)
 "Nb" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -413,26 +423,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/drunk_driving)
+"Ni" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/turf_decal/stripes/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/drunk_driving)
 "NR" = (
 /obj/item/stack/sheet/mineral/bananium,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/drunk_driving)
-"NX" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/hidden,
-/turf/open/floor/plasteel/airless{
-	icon_state = "floorscorched2"
-	},
-/area/ruin/space/has_grav/drunk_driving)
-"Oa" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/vomit/old,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
 "OD" = (
 /obj/machinery/power/smes,
@@ -442,6 +447,16 @@
 /obj/machinery/light/broken{
 	dir = 1
 	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"OP" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/gibspawner/human,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
 "OU" = (
@@ -455,11 +470,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/drunk_driving)
-"PQ" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/plasteel/airless,
-/area/ruin/space/has_grav/drunk_driving)
 "RG" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
@@ -467,6 +477,14 @@
 /area/ruin/space/has_grav/drunk_driving)
 "Si" = (
 /turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"TK" = (
+/obj/machinery/atmospherics/pipe/manifold/general/hidden,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/turf_decal/stripes/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/ruin/space/has_grav/drunk_driving)
 "Ur" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -481,6 +499,16 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/cable_coil/cut,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/drunk_driving)
+"UR" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/turf_decal/stripes/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
 "UU" = (
@@ -503,13 +531,17 @@
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
-"Xu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump,
+"XU" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 8
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
+/obj/item/stack/sheet/mineral/titanium,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/turf_decal/stripes/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
 "Yd" = (
 /obj/item/stack/sheet/mineral/titanium,
@@ -521,12 +553,6 @@
 	dir = 8
 	},
 /turf/closed/mineral/random,
-/area/ruin/space/has_grav/drunk_driving)
-"ZD" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/drunk_driving)
 
 (1,1,1) = {"
@@ -655,7 +681,7 @@ ak
 ak
 hN
 ak
-ZD
+Bx
 ak
 hN
 hN
@@ -671,7 +697,7 @@ hN
 ak
 ze
 pO
-iq
+TK
 NR
 fi
 ak
@@ -693,7 +719,7 @@ hN
 ak
 CI
 CJ
-MN
+Ni
 pL
 kr
 ak
@@ -731,19 +757,19 @@ hN
 hN
 hN
 ak
-Xu
+zV
 RG
 Pm
 RG
-En
+ma
 wA
-NX
+tK
 ov
-PQ
+Kq
 RG
 IL
 Eb
-hq
+Em
 ak
 hN
 hN
@@ -847,7 +873,7 @@ hN
 ak
 ax
 El
-AY
+XU
 IP
 El
 LN
@@ -891,7 +917,7 @@ hN
 ak
 vb
 Gm
-zB
+UR
 Xp
 zv
 LN
@@ -912,7 +938,7 @@ hN
 hN
 et
 OU
-Oa
+OP
 Bj
 hB
 ei

--- a/waspstation/code/datums/ruins/space.dm
+++ b/waspstation/code/datums/ruins/space.dm
@@ -22,3 +22,9 @@
 	suffix = "spacegym.dmm"
 	name = "Space Gym"
 	description = "A gym, lost in space, where many grunts and moaning could be heard."
+
+/datum/map_template/ruin/space/drunk_driving
+	id = "drunk_driving"
+	suffix = "drunkdriving.dmm"
+	name = "drink driving"
+	description = "A man drank strong alkohol while driving his shuttle. now he is dead and his shuttle crashed into an asteroid."

--- a/waspstation/code/game/area/areas/ruins/space.dm
+++ b/waspstation/code/game/area/areas/ruins/space.dm
@@ -63,3 +63,9 @@
 /area/ruin/space/has_grav/spacegym
 	name = "Space Gym"
 	icon_state = "firingrange"
+
+//Drunk driving
+
+/area/ruin/space/has_grav/drunk_driving
+	name = "crashed shuttle"
+	icon_state = "green"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A new space ruins containing a ship that has crashed into an asterid. it contains 1 plasma can and a full ish toolbelt spread out over the shuttle
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
more stuff in space
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Solgov whants to remind everyone not to drink and drive. days since last acsident has now been reset in this sector (new space ruin)

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
