### PR TITLE
Make failsafe more descriptive

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1399,7 +1399,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/failsafe
 	name = "Failsafe Uplink Code"
-	desc = "When entered the uplink will self-destruct immediately, taking whoever punches the code in with it in an explosion."
+	desc = "When entered the uplink will self-destruct immediately, taking whoever punches the code in with it in an explosion." //WS edit - more descriptive failsafe
 	item = /obj/effect/gibspawner/generic
 	cost = 1
 	surplus = 0

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1399,7 +1399,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/failsafe
 	name = "Failsafe Uplink Code"
-	desc = "When entered the uplink will self-destruct immediately."
+	desc = "When entered the uplink will self-destruct immediately, taking whoever punches the code in with it in an explosion."
 	item = /obj/effect/gibspawner/generic
 	cost = 1
 	surplus = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the failsafe actually tell you that it gibs you in an explosion instead of implying that only your PDA/uplink would be destroyed.

## Why It's Good For The Game

No, I'm not upset. No, I'm not grudgecoding. No, I didn't fall victim to this last round. What are you talking about?

## Changelog
:cl:
tweak: The Syndicate Uplink's failsafe option now properly tells you that it will explode you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
